### PR TITLE
Add `ListItem` to code examples

### DIFF
--- a/api/extensions.md
+++ b/api/extensions.md
@@ -165,7 +165,7 @@ This extensions is intended to be used with the `ListItem` extension.
 
 <script>
 import { Editor, EditorContent, EditorMenuBar } from 'tiptap'
-import { BulletList } from 'tiptap-extensions'
+import { ListItem, BulletList } from 'tiptap-extensions'
 
 export default {
   components: {
@@ -177,6 +177,7 @@ export default {
       editor: new Editor({
         extensions: [
           new BulletList(),
+          new ListItem()
         ],
         content: `
           <ul>
@@ -565,7 +566,7 @@ This extensions is intended to be used with the `ListItem` extension.
 
 <script>
 import { Editor, EditorContent, EditorMenuBar } from 'tiptap'
-import { OrderedList } from 'tiptap-extensions'
+import { ListItem, OrderedList } from 'tiptap-extensions'
 
 export default {
   components: {
@@ -576,6 +577,7 @@ export default {
     return {
       editor: new Editor({
         extensions: [
+          new ListItem(),
           new OrderedList(),
         ],
         content: `


### PR DESCRIPTION
BulletList and OrderedList requires ListItem to work, as you notify users about very well in the documentation. 
But I still think it should be part of the code examples as well. Examples that break aren't really good examples :)