### PR TITLE
fix: typo on `insertContentAt` command code examples

### DIFF
--- a/.changeset/breezy-otters-sip.md
+++ b/.changeset/breezy-otters-sip.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Fixed a typo on `insertContentAt` command code examples

--- a/src/content/editor/api/commands/content/insert-content-at.mdx
+++ b/src/content/editor/api/commands/content/insert-content-at.mdx
@@ -27,13 +27,13 @@ The content to be inserted. Can be plain text, an HTML string or JSON node(s).
 
 ```js
 // Plain text
-editor.commands.insertContent(12, 'Example Text')
+editor.commands.insertContentAt(12, 'Example Text')
 
 // Plain text, replacing a range
-editor.commands.insertContent({ from: 12, to: 16 }, 'Example Text')
+editor.commands.insertContentAt({ from: 12, to: 16 }, 'Example Text')
 
 // HTML
-editor.commands.insertContent(12, '<h1>Example Text</h1>')
+editor.commands.insertContentAt(12, '<h1>Example Text</h1>')
 
 // HTML with trim white space
 editor.commands.insertContentAt(12, '<p>Hello world</p>', {
@@ -58,7 +58,7 @@ editor.commands.insertContentAt(12, {
 })
 
 // Multiple nodes at once
-editor.commands.insertContent(12, [
+editor.commands.insertContentAt(12, [
   {
     type: 'paragraph',
     content: [


### PR DESCRIPTION
fix typo on `insertContentAt` command code examples