### PR TITLE
Add new FloatingUI based API for BubbleMenu and FloatingMenu

### DIFF
--- a/.changeset/neat-donuts-notice.md
+++ b/.changeset/neat-donuts-notice.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': major
+---
+
+Add new API for FloatingUI based BubbleMenu and FloatingMenu extensions

--- a/src/content/editor/extensions/functionality/bubble-menu.mdx
+++ b/src/content/editor/extensions/functionality/bubble-menu.mdx
@@ -54,13 +54,34 @@ Type: `Number`
 
 Default: `undefined`
 
-### tippyOptions
+### resizeDelay
 
-Under the hood, the `BubbleMenu` uses [tippy.js](https://atomiks.github.io/tippyjs/v6/all-props/). You can directly pass options to it.
+The `BubbleMenu` debounces the resize calculation for the bubble menu to allow the bubble menu to not be updated on every resize event. This can be controlled in milliseconds.
+
+Type: `Number`
+
+Default: `100`
+
+### options
+
+Under the hood, the `BubbleMenu` [Floating UI](https://floating-ui.com). You can control the middleware and positioning of the floating menu with these options.
 
 Type: `Object`
 
-Default: `{}`
+Default: `{ strategy: 'absolute', placement: 'right' }`
+
+| Option          | Type                                | Description                                                                                                                                                  |
+| --------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `strategy`      | `string`                            | The positioning strategy. See [here](https://floating-ui.com/docs/computePosition#strategy)                                                                  |
+| `placement`     | `string`                            | The placement of the menu. See [here](https://floating-ui.com/docs/computePosition#placement)                                                                |
+| `offset`        | `OffsetOptions` or `boolean`        | The [offset middleware options](https://floating-ui.com/docs/offset#options). If `true` use default options, if `false` disable the middleware               |
+| `flip`          | `FlipOptions` or `boolean`          | The [flip middleware options](https://floating-ui.com/docs/flip#options). If `true` use default options, if `false` disable the middleware                   |
+| `shift`         | `ShiftOptions` or `boolean`         | The [shift middleware options](https://floating-ui.com/docs/shift#options). If `true` use default options, if `false` disable the middleware                 |
+| `arrow`         | `ArrowOptions` or `false`           | The [arrow middleware options](https://floating-ui.com/docs/arrow#options). If `false` disable the middleware                                                |
+| `size`          | `SizeOptions` or `boolean`          | The [size middleware options](https://floating-ui.com/docs/size#options). If `true` use default options, if `false` disable the middleware                   |
+| `autoPlacement` | `AutoPlacementOptions` or `boolean` | The [autoPlacement middleware options](https://floating-ui.com/docs/autoPlacement#options). If `true` use default options, if `false` disable the middleware |
+| `hide`          | `HideOptions` or `boolean`          | The [hide middleware options](https://floating-ui.com/docs/hide#options). If `true` use default options, if `false` disable the middleware                   |
+| `inline`        | `InlineOptions` or `boolean`        | The [inline middleware options](https://floating-ui.com/docs/inline#options). If `true` use default options, if `false` disable the middleware               |
 
 ### pluginKey
 

--- a/src/content/editor/extensions/functionality/floatingmenu.mdx
+++ b/src/content/editor/extensions/functionality/floatingmenu.mdx
@@ -30,7 +30,8 @@ Use the Floating Menu extension in Tiptap to make a menu appear on an empty line
 ## Install the extension
 
 ```bash
-npm install @tiptap/extension-floating-menu
+# install the extension & Floating UI
+npm install @tiptap/extension-floating-menu @floating-ui/dom@^1.6.0
 ```
 
 ## Settings
@@ -43,13 +44,26 @@ Type: `HTMLElement`
 
 Default: `null`
 
-### tippyOptions
+### options
 
-Under the hood, the `FloatingMenu` uses [tippy.js](https://atomiks.github.io/tippyjs/v6/all-props/). You can directly pass options to it.
+Under the hood, the `FloatingMenu` uses [Floating UI](https://floating-ui.com). You can control the middleware and positioning of the floating menu with these options.
 
 Type: `Object`
 
-Default: `{}`
+Default: `{ strategy: 'absolute', placement: 'right' }`
+
+| Option          | Type                                | Description                                                                                                                                                  |
+| --------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `strategy`      | `string`                            | The positioning strategy. See [here](https://floating-ui.com/docs/computePosition#strategy)                                                                  |
+| `placement`     | `string`                            | The placement of the menu. See [here](https://floating-ui.com/docs/computePosition#placement)                                                                |
+| `offset`        | `OffsetOptions` or `boolean`        | The [offset middleware options](https://floating-ui.com/docs/offset#options). If `true` use default options, if `false` disable the middleware               |
+| `flip`          | `FlipOptions` or `boolean`          | The [flip middleware options](https://floating-ui.com/docs/flip#options). If `true` use default options, if `false` disable the middleware                   |
+| `shift`         | `ShiftOptions` or `boolean`         | The [shift middleware options](https://floating-ui.com/docs/shift#options). If `true` use default options, if `false` disable the middleware                 |
+| `arrow`         | `ArrowOptions` or `false`           | The [arrow middleware options](https://floating-ui.com/docs/arrow#options). If `false` disable the middleware                                                |
+| `size`          | `SizeOptions` or `boolean`          | The [size middleware options](https://floating-ui.com/docs/size#options). If `true` use default options, if `false` disable the middleware                   |
+| `autoPlacement` | `AutoPlacementOptions` or `boolean` | The [autoPlacement middleware options](https://floating-ui.com/docs/autoPlacement#options). If `true` use default options, if `false` disable the middleware |
+| `hide`          | `HideOptions` or `boolean`          | The [hide middleware options](https://floating-ui.com/docs/hide#options). If `true` use default options, if `false` disable the middleware                   |
+| `inline`        | `InlineOptions` or `boolean`        | The [inline middleware options](https://floating-ui.com/docs/inline#options). If `true` use default options, if `false` disable the middleware               |
 
 ### pluginKey
 


### PR DESCRIPTION
Because of [this](https://github.com/ueberdosis/tiptap/pull/5398) change in Tiptap we will need new API documentation for both extensions.

