### PR TITLE
docs: fix typo in code example

### DIFF
--- a/src/content/editor/extensions/functionality/export.mdx
+++ b/src/content/editor/extensions/functionality/export.mdx
@@ -95,7 +95,7 @@ const editor = new Editor({
   // ...
   extensions: [
     // ...
-    Export.Configure({
+    Export.configure({
       // The Convert App-ID from the convert settings page: https://cloud.tiptap.dev/convert-settings
       appId: 'your-app-id',
 


### PR DESCRIPTION
Fixed typo in code example for Export extension