### PR TITLE
fix: update tiptap-vue package

### DIFF
--- a/src/content/editor/getting-started/install/nuxt.mdx
+++ b/src/content/editor/getting-started/install/nuxt.mdx
@@ -31,10 +31,10 @@ cd my-tiptap-project
 
 ### Install the dependencies
 
-Okay, enough of the boring boilerplate work. Let’s finally install Tiptap! For the following example you’ll need the `@tiptap/vue-2` package with a few components, the `@tiptap/pm` package, and `@tiptap/starter-kit` which has the most common extensions to get started quickly.
+Okay, enough of the boring boilerplate work. Let’s finally install Tiptap! For the following example you’ll need the `@tiptap/vue-3` package with a few components, the `@tiptap/pm` package, and `@tiptap/starter-kit` which has the most common extensions to get started quickly.
 
 ```bash
-npm install @tiptap/vue-2 @tiptap/pm @tiptap/starter-kit
+npm install @tiptap/vue-3 @tiptap/pm @tiptap/starter-kit
 ```
 
 If you followed step 1 and 2, you can now start your project with `npm run dev`, and open [http://localhost:8080/](http://localhost:8080/) in your favorite browser. This might be different, if you’re working with an existing project.
@@ -51,7 +51,7 @@ This is the fastest way to get Tiptap up and running with Vue. It will give you 
 </template>
 
 <script>
-  import { Editor, EditorContent } from '@tiptap/vue-2'
+  import { Editor, EditorContent } from '@tiptap/vue-3'
   import StarterKit from '@tiptap/starter-kit'
 
   export default {
@@ -117,7 +117,7 @@ You’re probably used to bind your data with `v-model` in forms, that’s also 
 </template>
 
 <script>
-  import { Editor, EditorContent } from '@tiptap/vue-2'
+  import { Editor, EditorContent } from '@tiptap/vue-3'
   import StarterKit from '@tiptap/starter-kit'
 
   export default {


### PR DESCRIPTION
When creating a new nuxt project using the command provided, it will use vue3, which does not work with tiptap-vue2.  Update code provided, so if users copy/paste, it will work as expected.