### PR TITLE
Remove callout to align with existing features

### DIFF
--- a/src/content/collaboration/operations/configure.mdx
+++ b/src/content/collaboration/operations/configure.mdx
@@ -12,11 +12,6 @@ Configure runtime settings in Tiptap Collaboration to manage your collaboration 
 
 Use these settings to modify secrets, webhook URLs, and more, particularly when needing to adapt to changes in your project requirements or security protocols without restarting your application.
 
-<Callout title="Cloud interface" variant="hint">
-  If you integrated a Collaboration cloud application you can manage all of these settings in your
-  [cloud account](https://cloud.tiptap.dev/apps/settings).
-</Callout>
-
 ## Collaboration Settings Overview
 
 Several `key` settings can be adjusted dynamically:


### PR DESCRIPTION
The cloud interface isn’t displaying all configuration options available. Removing the hint callout until the feature is expanded.