### PR TITLE
Add missing pro tag on the table of contents extension

### DIFF
--- a/.changeset/twenty-pets-boil.md
+++ b/.changeset/twenty-pets-boil.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Add missing pro tag for the table of content extension in both sidebar and the Extensions overview page. Also remove a unused variable in the ExtensionGrid component.

--- a/src/components/ExtensionGrid.tsx
+++ b/src/components/ExtensionGrid.tsx
@@ -2,7 +2,7 @@
 'use client'
 
 import { SearchIcon } from 'lucide-react'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import { CloseIcon } from '@codesandbox/sandpack-react'
 import { Tag } from './ui/Tag'
 import { Card } from './ui/Card'

--- a/src/content/editor/extensions/functionality/table-of-contents.mdx
+++ b/src/content/editor/extensions/functionality/table-of-contents.mdx
@@ -11,6 +11,7 @@ extension:
   description: Add a table of contents of all your anchors or headlines.
   type: extension
   icon: List
+  isPro: true
 ---
 
 import { CodeDemo } from '@/components/CodeDemo'

--- a/src/content/editor/sidebar.ts
+++ b/src/content/editor/sidebar.ts
@@ -350,6 +350,7 @@ export const sidebarConfig: SidebarConfig = {
             {
               href: '/editor/extensions/functionality/table-of-contents',
               title: 'Table of contents',
+              tags: ['Pro'],
             },
             {
               href: '/editor/extensions/functionality/textalign',


### PR DESCRIPTION
### The pro tag was missing in the sidebar and and the extensions overview page. Added the same.

Preview from the official docs
![image](https://github.com/user-attachments/assets/86ac60ba-d207-4d82-8402-76d93d3d28e7)

Preview after changes from localhost
![image](https://github.com/user-attachments/assets/ad27455a-ab21-4d8b-a996-1c7f20b1bc53)
