### PR TITLE
Update Nuxt code snippets to use beforeUnmount hook instead of before…

### DIFF
--- a/src/content/editor/getting-started/install/nuxt.mdx
+++ b/src/content/editor/getting-started/install/nuxt.mdx
@@ -72,7 +72,7 @@ This is the fastest way to get Tiptap up and running with Vue. It will give you 
       })
     },
 
-    beforeDestroy() {
+    beforeUnmount() {
       this.editor.destroy()
     },
   }
@@ -168,7 +168,7 @@ You’re probably used to bind your data with `v-model` in forms, that’s also 
       })
     },
 
-    beforeDestroy() {
+    beforeUnmount() {
       this.editor.destroy()
     },
   }


### PR DESCRIPTION
Since beforeDestroy() hook is removed in Vue3, and this guide is not compatible with the latest versions of Nuxt