### PR TITLE
docs(styling): add open-source wysiwyg editor component built with ta…

### DIFF
--- a/src/content/editor/getting-started/style-editor/index.mdx
+++ b/src/content/editor/getting-started/style-editor/index.mdx
@@ -148,3 +148,7 @@ If you're using [TailwindCSS Intellisense](https://marketplace.visualstudio.com/
   "class:\\s*?[\"'`]([^\"'`]*).*?,"
 ]
 ```
+
+### WYSIWYG editor component
+
+Additionally, you can also check out the open-source [WYSIWYG editor](https://flowbite.com/docs/plugins/wysiwyg/) component examples from Flowbite built with the utility classes from Tailwind CSS.


### PR DESCRIPTION
Hey peeps from Tip Tap,

First of all, congrats on the awesome library and docs - we decided to use it for our WYSYWIG component from Flowbite.

I think that at the "styling section with Tailwind CSS" it would be very valuable for users to get some WYSIWYG text editor demos and components built with Tailwind CSS. We've built quite a few covering almost all open-source examples from Tip Tap based on the API and we open-sourced it under the MIT license.

Here it is:

https://flowbite.com/docs/plugins/wysiwyg/

Would be awesome to have it featured there, I've been strolling through your docs for 2-3 weeks time which is the time it took me to styles, think out and code the wysiwyg examples based on Tip Tap.

Cheers,
Zoltan