### PR TITLE
fix(docs): Add missing dep from Next.js quickstart

### DIFF
--- a/src/content/editor/getting-started/install/nextjs.mdx
+++ b/src/content/editor/getting-started/install/nextjs.mdx
@@ -32,7 +32,7 @@ cd my-tiptap-project
 Now that we have a standard boilerplate set up we can get started on getting Tiptap up and running! For this we will need to install three packages: `@tiptap/react`, `@tiptap/pm` and `@tiptap/starter-kit` which includes all the extensions you need to get started quickly.
 
 ```bash
-npm install @tiptap/react @tiptap/pm @tiptap/starter-kit
+npm install @tiptap/react @tiptap/pm @tiptap/starter-kit @tiptap/extension-text-style
 ```
 
 If you followed step 1 and 2, you can now start your project with `npm run dev`, and open [http://localhost:3000/](http://localhost:3000/) in your favorite browser. This might be different, if you’re working with an existing project.


### PR DESCRIPTION
When setting this up in my Next.js project, I encountered this error after installing the current stated required deps:
```bash
Import trace for requested module:
./node_modules/@tiptap/starter-kit/dist/index.js
./src/components/TipTap.tsx
 ⨯ ./node_modules/@tiptap/extension-bullet-list/dist/index.js:3:1
Module not found: Can't resolve '@tiptap/extension-text-style'
```

Installing the dep listed in the error above resolved this issue.