### PR TITLE
Fix typo in the export extension page

### DIFF
--- a/.changeset/two-mirrors-sparkle.md
+++ b/.changeset/two-mirrors-sparkle.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+fix typo in the export extension page

--- a/src/content/editor/extensions/functionality/export.mdx
+++ b/src/content/editor/extensions/functionality/export.mdx
@@ -89,7 +89,7 @@ npm i @tiptap-pro/extension-export
 
 ```js
 // Start with importing the extension
-import { Export } from '@tiptap/extension-export'
+import { Export } from '@tiptap-pro/extension-export'
 
 const editor = new Editor({
   // ...


### PR DESCRIPTION
fix package import typo from `import { Export } from '@tiptap/extension-export'` to `import { Export } from '@tiptap-pro/extension-export'`