### PR TITLE
Update custom LLM docs

### DIFF
--- a/.changeset/fluffy-students-grin.md
+++ b/.changeset/fluffy-students-grin.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Update custom LLM docs. Update the resolver return types. Specify that the LLM should respond with HTML to allow the editor to parse the response as rich-text.

--- a/src/content/content-ai/custom-llms/integrate.mdx
+++ b/src/content/content-ai/custom-llms/integrate.mdx
@@ -42,11 +42,17 @@ If you want to rely on our cloud in some cases, make sure that you [setup your t
 
 You can define custom resolver functions on the extension options. Be aware that they expect the following return types.
 
-| Type       | Method name            | Return Type        |
-| ---------- | ---------------------- | ------------------ |
-| completion | `aiCompletionResolver` | `Promise`          |
-| streaming  | `aiStreamResolver`     | `Promise  \| null` |
-| image      | `aiImageResolver`      | `Promise`          |
+| Type       | Method name            | Return Type                                   |
+| ---------- | ---------------------- | --------------------------------------------- |
+| completion | `aiCompletionResolver` | `Promise<string \| null>`                     |
+| streaming  | `aiStreamResolver`     | `Promise<ReadableStream<Uint8Array> \| null>` |
+| image      | `aiImageResolver`      | `Promise<string \| null>`                     |
+
+Use `aiCompletionResolver` to add text to the editor in a non-streaming manner.
+
+Use the `aiStreamResolver` to stream content directly into the editor. This gives the editor typewritter effect.
+
+Make sure that the stream returns HTML to allow Tiptap to render the content directly as rich text. This approach removes the need for a Markdown parser and keeps the frontend lightweight.
 
 ## Examples
 
@@ -64,8 +70,12 @@ Ai.configure({
   appId: 'APP_ID_HERE',
   token: 'TOKEN_HERE',
   // ...
+  onError(error, context) {
+    // handle error
+  },
   // Define the resolver function for completions (attention: streaming and image have to be defined separately!)
   aiCompletionResolver: async ({
+    editor,
     action,
     text,
     textOptions,
@@ -87,10 +97,12 @@ Ai.configure({
 
     // Everything else is routed to the Tiptap AI service
     return defaultResolver({
+      editor,
       action,
       text,
       textOptions,
       extensionOptions,
+      defaultResolver,
     })
   },
 })
@@ -137,12 +149,16 @@ const editor = useEditor({
     /* … add other extension */
     AiExtended.configure({
       /* … add configuration here (appId, token etc.) */
+      onError(error, context) {
+        // handle error
+      },
       aiCompletionResolver: async ({
         action,
         text,
         textOptions,
         extensionOptions,
         defaultResolver,
+        editor,
       }) => {
         if (action === 'customCommand') {
           const response = await fetch('https://dummyjson.com/quotes/random')
@@ -156,10 +172,12 @@ const editor = useEditor({
         }
 
         return defaultResolver({
+          editor,
           action,
           text,
           textOptions,
           extensionOptions,
+          defaultResolver,
         })
       },
     }),
@@ -177,7 +195,7 @@ We’re entirely relying on a custom backend in this example.
 
 Make sure that the function `aiStreamResolver` returns a `ReadableStream<Uint8Array>`.
 
-And remember: If you want to use both streaming and the traditional completion mode, you’ll need to define a `aiCompletionResolver`, too!
+And remember: If you want to use both streaming and the traditional completion mode (non-streaming way), you’ll need to define a `aiCompletionResolver`, too!
 
 ```js
 // ...
@@ -188,6 +206,9 @@ Ai.configure({
   appId: 'APP_ID_HERE',
   token: 'TOKEN_HERE',
   // ...
+  onError(error, context) {
+    // handle error
+  },
   // Define the resolver function for streams
   aiStreamResolver: async ({ action, text, textOptions }) => {
     const fetchOptions = {


### PR DESCRIPTION
### Update custom LLM docs. 

Resolves #35
- Update the resolver return types. 
- Specify that the LLM should respond with HTML to allow the editor to parse the response as rich-text.
- Add `onError` callback in each example to help users debug more effectively when implementing the feature.