### PR TITLE
Fix incorrect yarn modern (v2+) example causing 404

### DIFF
--- a/src/content/guides/pro-extensions.mdx
+++ b/src/content/guides/pro-extensions.mdx
@@ -39,7 +39,7 @@ If you are using **Yarn Modern** (Yarn 2+), add the registry to `.yarnrc.yml`.
 
 ```
 npmScopes:
- "@tiptap-pro":
+ tiptap-pro:
    npmAlwaysAuth: true
    npmRegistryServer: "https://registry.tiptap.dev/"
    npmAuthToken: ${TIPTAP_PRO_TOKEN}


### PR DESCRIPTION
Previous example always gives 404 error. 