### PR TITLE
fix: corrected 'bubble menu' to 'floating menu' in floatingmenu.mdx

### DIFF
--- a/.changeset/angry-pets-approve.md
+++ b/.changeset/angry-pets-approve.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+The term 'bubble menu' was mistakenly used instead of 'floating menu' due to copy-paste from another document.

--- a/src/content/editor/extensions/functionality/floatingmenu.mdx
+++ b/src/content/editor/extensions/functionality/floatingmenu.mdx
@@ -86,7 +86,7 @@ new Editor({
 
 ### Other frameworks
 
-Check out the demo at the [top of this page](#) to see how to integrate the bubble menu extension with React or Vue.
+Check out the demo at the [top of this page](#) to see how to integrate the floating menu extension with React or Vue.
 
 ### Custom logic
 


### PR DESCRIPTION
The term 'bubble menu' was mistakenly used instead of 'floating menu' due to copy-paste from another document.