### PR TITLE
Added documentation for `defaultLanguage` setting in the `CodeBlock` extension

### DIFF
--- a/.changeset/modern-ladybugs-crash.md
+++ b/.changeset/modern-ladybugs-crash.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Added documentation for `defaultLanguage` setting in the `CodeBlock` extension.

--- a/src/content/editor/extensions/nodes/code-block.mdx
+++ b/src/content/editor/extensions/nodes/code-block.mdx
@@ -68,6 +68,18 @@ CodeBlock.configure({
 })
 ```
 
+### defaultLanguage
+
+Define a default language instead of the automatic detection of lowlight.
+
+Default: `null`
+
+```js
+CodeBlock.configure({
+  defaultLanguage: 'plaintext',
+})
+```
+
 ### exitOnArrowDown
 
 Define whether the node should be exited on arrow down if there is no node after it.


### PR DESCRIPTION
- https://github.com/ueberdosis/tiptap/pull/5406 introduced the `defaultLanguage` setting for the `CodeBlock` extension as a bug fix. The objective of this PR is to add documentation this change.

---

The following code snippet demonstrates how to specify the `defaultLanguage` setting.

```js
CodeBlock.configure({
  defaultLanguage: '<lang>',
})
```

When the `defaultLanguage` setting is specified, it will add a class of the format `language-<lang>` to the `<code>` tag. The prefix (`language-`) can be further customized using the [languageClassPrefix](https://tiptap.dev/docs/editor/extensions/nodes/code-block#languageclassprefix) setting.

I am attaching a CodeSandbox link where the same can be verified: https://codesandbox.io/p/sandbox/codeblock-tiptap-387xqm