### PR TITLE
docs(editor): document zero-width space for inline node selection

### DIFF
--- a/src/content/editor/core-concepts/schema.mdx
+++ b/src/content/editor/core-concepts/schema.mdx
@@ -167,6 +167,14 @@ Node.create({
 })
 ```
 
+Inline nodes can be tricky to select, especially at line edges. A quick fix: add a zero-width space right after the element using CSS:
+
+```css
+.customInlineNode::after {
+  content: "\200B";
+}
+```
+
 #### Atom
 
 Nodes with `atom: true` aren’t directly editable and should be treated as a single unit. It’s not so likely to use that in a editor context, but this is how it would look like:


### PR DESCRIPTION
Document how adding a zero-width space (\200B) after inline nodes with CSS makes it easier to position the cursor and select inline nodes.