### PR TITLE
docs: add validate and shouldAutoLink options to Link extension settings

### DIFF
--- a/src/content/editor/extensions/marks/link.mdx
+++ b/src/content/editor/extensions/marks/link.mdx
@@ -163,7 +163,7 @@ This function enables you to enforce rules on allowed protocols or domains when 
 ```js
 // Validate URLs to only accept specific protocols
 Link.configure({
-  validate: (url, ctx) => ctx.defaultValidate(url) && ctx.protocols.includes('https'),
+  validate: (url, ctx) => ctx.defaultValidate(url) && !url.startsWith('./'),
 })
 ```
 

--- a/src/content/editor/extensions/marks/link.mdx
+++ b/src/content/editor/extensions/marks/link.mdx
@@ -146,14 +146,43 @@ Link.configure({
 
 ### validate
 
-A function that validates every autolinked link. If it exists, it will be called with the link href as argument. If it returns `false`, the link will be removed.
+A function that allows customization of link validation, modifying the default verification logic. This function accepts the URL and a context object with additional properties.
 
-Can be used to set rules for example excluding or including certain domains, tlds, etc.
+**Parameters:**
+
+- `url`: The URL to validate.
+- `ctx`: An object containing:
+  - `defaultValidate`: A function that performs the default URL validation.
+  - `protocols`: An array of allowed protocols for the URL, e.g., `["http", "https"]`.
+  - `defaultProtocol`: The default protocol (e.g., `'http'`).
+
+**Returns:** `boolean` - `true` if the URL is valid, `false` otherwise.
+
+This function enables you to enforce rules on allowed protocols or domains when autolinking URLs.
 
 ```js
-// only autolink urls with a protocol
+// Validate URLs to only accept specific protocols
 Link.configure({
-  validate: (href) => /^https?:\/\//.test(href),
+  validate: (url, ctx) => ctx.defaultValidate(url) && ctx.protocols.includes('https'),
+})
+```
+
+### shouldAutoLink
+
+Defines whether a valid link should be automatically linked within the editor content.
+
+**Parameters:**
+
+- `url`: The URL that has already passed validation.
+
+**Returns:** `boolean` - `true` if the link should be auto-linked, `false` if it should not.
+
+Use this function to control autolinking behavior based on the URL.
+
+```js
+// Example: Auto-link only if the URL is secure
+Link.configure({
+  shouldAutoLink: (url) => url.startsWith('https://'),
 })
 ```
 


### PR DESCRIPTION
**Description:**
Update the documentation for the Link extension by adding details on the new validate and shouldAutoLink options.

**Related PR:**
References [5808](https://github.com/ueberdosis/tiptap/pull/5808) for context.