### PR TITLE
Add documentation for useLegacyWrapping option in comments extension

### DIFF
--- a/.changeset/stupid-ads-perform.md
+++ b/.changeset/stupid-ads-perform.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Added new information about the useLegacyWrapping option for the comments extension.

--- a/src/content/comments/core-concepts/configure.mdx
+++ b/src/content/comments/core-concepts/configure.mdx
@@ -6,6 +6,8 @@ meta:
   category: Comments
 ---
 
+import { Callout } from '@/components/ui/Callout'
+
 Comments are embedded within documents in the Collaboration Cloud. To enable comments, integrate the TiptapCollabProvider and configure your setup to support comment functionality.
 
 ## provider
@@ -66,5 +68,28 @@ Default: `undefined`
 Comments.Configure({
   // id can be a string or null
   onClickThread: (id) => console.log('Thread clicked', id),
+})
+```
+
+## useLegacyWrapping
+
+<Callout title="Warning" variant="warning">
+  The new wrapping mechanism is using a different schema for block thread nodes, which is not
+  compatible with the legacy wrapping mechanism. If you are using the new wrapping mechanism, you
+  need to set this option to `false`. If this is set to `false` without mapping existing thread
+  nodes to the new schema, the threads content will be stripped from the document.
+</Callout>
+
+A boolean option that controls whether to use the legacy wrapping mechanism for multi-line comments. This is required to support backwards compatibility with existing comments and will
+be removed in the future. The default value is `true`.
+
+The new wrapping mechanism is more flexible, allowing to wrap content more precise and supports mixed wrapping of inline and block nodes.
+
+Default: `true`
+
+```js
+Comments.configure({
+  // enable new flexible block wrapping
+  useLegacyWrapping: false,
 })
 ```

--- a/src/content/comments/core-concepts/configure.mdx
+++ b/src/content/comments/core-concepts/configure.mdx
@@ -74,18 +74,17 @@ Comments.Configure({
 ## useLegacyWrapping
 
 <Callout title="Warning" variant="warning">
-  The new wrapping mechanism is using a different schema for block thread nodes, which is not
-  compatible with the legacy wrapping mechanism. If you are using the new wrapping mechanism, you
-  need to set this option to `false`. If this is set to `false` without mapping existing thread
-  nodes to the new schema, the threads content will be stripped from the document.
+  The new wrapping mechanism uses a different schema for threads on block nodes, which is not
+  compatible with the previous wrapping behavior. If this is set to `false` without mapping existing
+  thread nodes to the new schema, the threads content will be stripped from the document.
 </Callout>
 
-A boolean option that controls whether to use the legacy wrapping mechanism for multi-line comments. This is required to support backwards compatibility with existing comments and will
-be removed in the future. The default value is `true`.
+A boolean option that controls whether to use the legacy wrapping mechanism for multi-line comments. We suggest for new implementations to set this to `false`, and existing integrations can stay on the previous behavior. This is only required for backwards compatibility with existing comments, and it will
+be removed in the future.
 
 The new wrapping mechanism is more flexible, allowing to wrap content more precise and supports mixed wrapping of inline and block nodes.
 
-Default: `true`
+**Default:** `true`
 
 ```js
 Comments.configure({

--- a/src/content/comments/getting-started/install.mdx
+++ b/src/content/comments/getting-started/install.mdx
@@ -50,12 +50,18 @@ const editor = new Editor({
     ...,
     CommentsKit.configure({
       provider: collabProvider,
+      useLegacyWrapping: false, // optional, will be the default in the future
     }),
   ]
 })
 ```
 
 Your editor is now ready to support threads.
+
+<Callout title="Important" variant="warning">
+  The new `useLegacyWrapping` option can be set to false to use a new block wrapping mechanism for
+  multi-line comments. This **will become the default** in the future.
+</Callout>
 
 <hr />
 


### PR DESCRIPTION
Introduce documentation for the new `useLegacyWrapping` option, explaining its purpose for backward compatibility and the transition to a more flexible wrapping mechanism for multi-line comments. Include usage examples and warnings regarding its future default value.