### PR TITLE
fix: remove localhost reference in docs

### DIFF
--- a/src/content/collaboration/provider/integration.mdx
+++ b/src/content/collaboration/provider/integration.mdx
@@ -46,7 +46,7 @@ useEffect(() => {
 
 ## Configure the collaboration provider
 
-The Tiptap Collaboration provider offers several settings for custom configurations. Review the tables below for all parameters, practical use cases, and key concepts like "[awareness](http://localhost:3000/collaboration/core-concepts/awareness)".
+The Tiptap Collaboration provider offers several settings for custom configurations. Review the tables below for all parameters, practical use cases, and key concepts like "[awareness](/collaboration/core-concepts/awareness)".
 
 | Setting            | Default Value     | Description                                                                                                                |
 | ------------------ | ----------------- | -------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Fixed a link that had a localhost reference