### PR TITLE
chore: update font family extension docs

### DIFF
--- a/src/content/editor/extensions/functionality/fontfamily.mdx
+++ b/src/content/editor/extensions/functionality/fontfamily.mdx
@@ -29,7 +29,7 @@ This extension enables you to set the font family in the editor. It uses the [`T
 <CodeDemo path="/Extensions/FontFamily" />
 
 <Callout title="Heads-up!" variant="hint">
-  Be aware that `editor.isActive('textStyle', { fontFamily: 'Font Family' })` will return the font family as set by the [browser's CSS rules](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family) and not as you would have expected when setting the font family.
+  Be aware that `editor.isActive('textStyle', { fontFamily: 'Font Family' })` will return the font family as set by the [browser's CSS rules](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#family-name) and not as you would have expected when setting the font family.
 </Callout>
 
 ## Install

--- a/src/content/editor/extensions/functionality/fontfamily.mdx
+++ b/src/content/editor/extensions/functionality/fontfamily.mdx
@@ -22,10 +22,15 @@ extension:
 ---
 
 import { CodeDemo } from '@/components/CodeDemo'
+import { Callout } from '@/components/ui/Callout'
 
 This extension enables you to set the font family in the editor. It uses the [`TextStyle`](/editor/extensions/marks/text-style) mark, which renders a `<span>` tag. The font family is applied as inline style, for example `<span style="font-family: Arial">`.
 
 <CodeDemo path="/Extensions/FontFamily" />
+
+<Callout title="Heads-up!" variant="hint">
+  Be aware that `editor.isActive('textStyle', { fontFamily: 'Font Family' })` will return the font family as set by the [browser's CSS rules](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family) and not as you would have expected when setting the font family.
+</Callout>
 
 ## Install
 


### PR DESCRIPTION
This PR updates the font family extension docs to include an information that could be useful for everyone that uses the `FontFamily` extension and might be having troubles with the `editor.isActive('textStyle')` call