### PR TITLE
The header row is added by default

### DIFF
--- a/src/content/editor/extensions/nodes/table.mdx
+++ b/src/content/editor/extensions/nodes/table.mdx
@@ -79,11 +79,11 @@ Default: `false`
 
 ### insertTable()
 
-Creates a new table, with the specified number of rows and columns, and with a header row.
+Creates a new three-by-three table by default, including a header row. You can specify custom rows, columns, and header preferences:
 
 ```js
 editor.commands.insertTable()
-editor.commands.insertTable({ rows: 3, cols: 3, withHeaderRow: true })
+editor.commands.insertTable({ rows: 3, cols: 3, withHeaderRow: false })
 ```
 
 ### addColumnBefore()

--- a/src/content/editor/extensions/nodes/table.mdx
+++ b/src/content/editor/extensions/nodes/table.mdx
@@ -79,7 +79,7 @@ Default: `false`
 
 ### insertTable()
 
-Creates a new table, with the specified number of rows and columns, and with a header row (if you tell it to).
+Creates a new table, with the specified number of rows and columns, and with a header row.
 
 ```js
 editor.commands.insertTable()


### PR DESCRIPTION
I was confused that `insertTable` added a header row. The documentation seems to imply that the header row is only added when you explicitly ask for it, but the default is to add it.

https://github.com/ueberdosis/tiptap/blob/a0d2f2803652851bbe2f06f124a70bc01cfb0dab/packages/extension-table/src/table.ts#L301

Thanks!