### PR TITLE
Update vue3.mdx - escaped quotation marks in code strings that causes…

### DIFF
--- a/src/content/editor/getting-started/install/vue3.mdx
+++ b/src/content/editor/getting-started/install/vue3.mdx
@@ -68,7 +68,7 @@ This is the fastest way to get Tiptap up and running with Vue. It will give you 
 
     mounted() {
       this.editor = new Editor({
-        content: '<p>I'm running Tiptap with Vue.js. 🎉</p>',
+        content: '<p>I'\m running Tiptap with Vue.js. 🎉</p>',
         extensions: [StarterKit],
       })
     },
@@ -98,7 +98,7 @@ Alternatively, you can use the Composition API with the `useEditor` method.
 
     setup() {
       const editor = useEditor({
-        content: '<p>I'm running Tiptap with Vue.js. 🎉</p>',
+        content: '<p>I\'m running Tiptap with Vue.js. 🎉</p>',
         extensions: [StarterKit],
       })
 
@@ -120,7 +120,7 @@ Or feel free to use the new [`<script setup>` syntax](https://v3.vuejs.org/api/s
   import StarterKit from '@tiptap/starter-kit'
 
   const editor = useEditor({
-    content: '<p>I'm running Tiptap with Vue.js. 🎉</p>',
+    content: '<p>I\'m running Tiptap with Vue.js. 🎉</p>',
     extensions: [StarterKit],
   })
 </script>


### PR DESCRIPTION
… error when copied

From this:
content: '<p>I'm running Tiptap with Vue.js. 🎉</p>' To this:
content: '<p>I'\m running Tiptap with Vue.js. 🎉</p>'