### PR TITLE
docs: fix `'` usage

### DIFF
--- a/src/content/editor/getting-started/install/vue3.mdx
+++ b/src/content/editor/getting-started/install/vue3.mdx
@@ -68,7 +68,7 @@ This is the fastest way to get Tiptap up and running with Vue. It will give you 
 
     mounted() {
       this.editor = new Editor({
-        content: '<p>I'm running Tiptap with Vue.js. 🎉</p>',
+        content: "<p>I'm running Tiptap with Vue.js. 🎉</p>",
         extensions: [StarterKit],
       })
     },
@@ -98,7 +98,7 @@ Alternatively, you can use the Composition API with the `useEditor` method.
 
     setup() {
       const editor = useEditor({
-        content: '<p>I'm running Tiptap with Vue.js. 🎉</p>',
+        content: "<p>I'm running Tiptap with Vue.js. 🎉</p>",
         extensions: [StarterKit],
       })
 

--- a/src/content/editor/getting-started/install/vue3.mdx
+++ b/src/content/editor/getting-started/install/vue3.mdx
@@ -120,7 +120,7 @@ Or feel free to use the new [`<script setup>` syntax](https://v3.vuejs.org/api/s
   import StarterKit from '@tiptap/starter-kit'
 
   const editor = useEditor({
-    content: '<p>I'm running Tiptap with Vue.js. 🎉</p>',
+    content: "<p>I'm running Tiptap with Vue.js. 🎉</p>",
     extensions: [StarterKit],
   })
 </script>


### PR DESCRIPTION
There's another `'` on the same line that breaks the string