### PR TITLE
Update configure.mdx

### DIFF
--- a/src/content/editor/getting-started/configure.mdx
+++ b/src/content/editor/getting-started/configure.mdx
@@ -103,11 +103,13 @@ You can configure all extensions included in the [StarterKit](/editor/extensions
 import StarterKit from '@tiptap/starter-kit'
 
 new Editor({
-  extensions: StarterKit.configure({
-    heading: {
-      levels: [1, 2, 3],
-    },
-  }),
+  extensions: [
+    StarterKit.configure({
+      heading: {
+        levels: [1, 2, 3],
+      },
+    }),
+  ],
 })
 ```
 


### PR DESCRIPTION
Typo previously in the example. StarterKit should be in an array. 

Previous example returns an error (Uncaught TypeError: this.options.extensions is not iterable).

```
  extensions: [
    StarterKit.configure({
      heading: {
        levels: [1, 2, 3],
      },
    }),
  ],
```