### PR TITLE
Change from single to double quotes

### DIFF
--- a/src/content/editor/getting-started/install/vue2.mdx
+++ b/src/content/editor/getting-started/install/vue2.mdx
@@ -66,7 +66,7 @@ This is the fastest way to get Tiptap up and running with Vue. It will give you 
 
     mounted() {
       this.editor = new Editor({
-        content: '<p>I'm running Tiptap with Vue.js. 🎉</p>',
+        content: "<p>I'm running Tiptap with Vue.js. 🎉</p>",
         extensions: [StarterKit],
       })
     },


### PR DESCRIPTION
Continue changing content examples to use double quotes to prevent breaking strings.