### PR TITLE
Extension Focus: Document mistake

### DIFF
--- a/src/content/editor/extensions/functionality/focus.mdx
+++ b/src/content/editor/extensions/functionality/focus.mdx
@@ -44,7 +44,7 @@ The class that is applied to the focused element.
 Default: `'has-focus'`
 
 ```js
-Focus.configure({
+FocusClasses.configure({
   className: 'focus',
 })
 ```
@@ -56,7 +56,7 @@ Apply the class to `'all'`, the `'shallowest'` or the `'deepest'` node.
 Default: `'all'`
 
 ```js
-Focus.configure({
+FocusClasses.configure({
   mode: 'deepest',
 })
 ```


### PR DESCRIPTION
There is an error in the documentation. The current component that needs to be imported is FocusClasses, not Focus.

It would also be preferable to update the example in CodeDemo.