### PR TITLE
Use pro package in Import Extension configuration example

### DIFF
--- a/.changeset/gentle-berries-remember.md
+++ b/.changeset/gentle-berries-remember.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Corrected the example configuration code in the `Configure the Extension` section of the Import extension. The previous version was referencing a non-pro version of the package and initializing it with a `.Configure` call rather than a `.configure`.

--- a/src/content/editor/extensions/functionality/import.mdx
+++ b/src/content/editor/extensions/functionality/import.mdx
@@ -98,13 +98,13 @@ npm i @tiptap-pro/extension-import
 
 ```js
 // Start with importing the extension
-import { Import } from '@tiptap/extension-import'
+import { Import } from '@tiptap-pro/extension-import'
 
 const editor = new Editor({
   // ...
   extensions: [
     // ...
-    Import.Configure({
+    Import.configure({
       // The Convert App-ID from the Convert settings page: https://cloud.tiptap.dev/convert-settings
       appId: 'your-app-id',
 


### PR DESCRIPTION
**Issue**: The Import Extension docs had code that referenced the wrong package.

**Fix**: Switched the [Configure the Extension](https://tiptap.dev/docs/editor/extensions/functionality/import#configure-the-extension) section of the Import Extension docs to use the `@tiptap-pro/extension-import` package.