### PR TITLE
Added y-tiptap to the documentation

### DIFF
--- a/src/content/collaboration/getting-started/install.mdx
+++ b/src/content/collaboration/getting-started/install.mdx
@@ -33,7 +33,7 @@ Afterwards we will connect Y.Doc to the TiptapCollabProvider to synchronize user
 Add the Editor Collaboration extension and Yjs library to your frontend:
 
 ```bash
-npm install @tiptap/extension-collaboration yjs y-prosemirror y-protocols
+npm install @tiptap/extension-collaboration @tiptap/y-tiptap yjs y-protocols
 ```
 
 Then, update your index.jsx to include these new imports:

--- a/src/content/editor/extensions/functionality/collaboration.mdx
+++ b/src/content/editor/extensions/functionality/collaboration.mdx
@@ -33,12 +33,15 @@ This small guide quickly shows how to integrate basic collaboration functionalit
 <CodeDemo path="/Demos/CollaborationSplitPane" />
 
 ## Install
+
 <Callout title="More details" variant="hint">
-    For more detailed information on how to integrate, install, and configure the Collaboration extension with the Tiptap Collaboration product, please visit our [feature page](/collaboration/getting-started/overview).
+  For more detailed information on how to integrate, install, and configure the Collaboration
+  extension with the Tiptap Collaboration product, please visit our [feature
+  page](/collaboration/getting-started/overview).
 </Callout>
 
 ```bash
-npm install @tiptap/extension-collaboration yjs y-websocket y-prosemirror
+npm install @tiptap/extension-collaboration @tiptap/y-tiptap yjs y-websocket
 ```
 
 ## Settings

--- a/src/content/editor/extensions/functionality/drag-handle-react.mdx
+++ b/src/content/editor/extensions/functionality/drag-handle-react.mdx
@@ -33,7 +33,7 @@ It essentially wraps the [DragHandle](/editor/extensions/functionality/drag-hand
 </Callout>
 
 ```bash
-npm install @tiptap-pro/extension-drag-handle-react @tiptap-pro/extension-drag-handle @tiptap-pro/extension-node-range @tiptap/extension-collaboration y-prosemirror yjs y-protocols
+npm install @tiptap-pro/extension-drag-handle-react @tiptap-pro/extension-drag-handle @tiptap-pro/extension-node-range @tiptap/extension-collaboration @tiptap/y-tiptap yjs y-protocols
 ```
 
 ## Props

--- a/src/content/editor/extensions/functionality/drag-handle-vue.mdx
+++ b/src/content/editor/extensions/functionality/drag-handle-vue.mdx
@@ -33,7 +33,7 @@ It essentially wraps the [DragHandle](/editor/extensions/functionality/drag-hand
 </Callout>
 
 ```bash
-npm install @tiptap-pro/extension-drag-handle-vue-3 @tiptap-pro/extension-drag-handle @tiptap-pro/extension-node-range @tiptap/extension-collaboration y-prosemirror yjs y-protocols
+npm install @tiptap-pro/extension-drag-handle-vue-3 @tiptap-pro/extension-drag-handle @tiptap-pro/extension-node-range @tiptap/extension-collaboration @tiptap/y-tiptap yjs y-protocols
 ```
 
 <Callout title="Vue 2 vs. Vue 3" variant="info">


### PR DESCRIPTION
This pull request includes updates to the installation commands in various documentation files to ensure consistency and correct usage of the `@tiptap/y-tiptap` package. The most important changes involve updating the npm install commands across different files.

Documentation updates:

* [`src/content/collaboration/getting-started/install.mdx`](diffhunk://#diff-e5b38a36b24a500bd080968f6d70a843fb9b25050691d9059b0259ee65d8e196L36-R36): Changed the npm install command to include `@tiptap/y-tiptap` instead of `y-prosemirror`.
* [`src/content/editor/extensions/functionality/collaboration.mdx`](diffhunk://#diff-ff0a3e74a890a059add87bff398a99818ed4158d2f6f5da98dbd693c37ed00bdR36-R44): Updated the npm install command to include `@tiptap/y-tiptap` instead of `y-prosemirror`.
* [`src/content/editor/extensions/functionality/drag-handle-react.mdx`](diffhunk://#diff-280a291ebaea9c598496cf09377069a66cdc1b808849328f7b95e4e01fb2c156L36-R36): Modified the npm install command to include `@tiptap/y-tiptap` instead of `y-prosemirror`.
* [`src/content/editor/extensions/functionality/drag-handle-vue.mdx`](diffhunk://#diff-3bd8138d4fb1698d58156b5fcf81a80613438aa68d410def33498beff3054152L36-R36): Updated the npm install command to include `@tiptap/y-tiptap` instead of `y-prosemirror`.