### PR TITLE
fix: remove not available events from CustomExtension

### DIFF
--- a/src/content/editor/api/events.mdx
+++ b/src/content/editor/api/events.mdx
@@ -170,12 +170,6 @@ const CustomExtension = Extension.create({
   onDestroy() {
     // The editor is being destroyed.
   },
-  onPaste(event: ClipboardEvent, slice: Slice) {
-    // The editor is being pasted into.
-  },
-  onDrop(event: DragEvent, slice: Slice, moved: boolean) {
-    // The editor is being pasted into.
-  },
   onContentError({ editor, error, disableCollaboration }) {
     // The editor content does not match the schema.
   },


### PR DESCRIPTION
The `onPaste()` and `onDrop()` events are not available on a custom extension. 