### PR TITLE
Adapt Next.js "Getting Started" guide to Next.js App Router folder structure

### DIFF
--- a/.changeset/beige-cheetahs-flash.md
+++ b/.changeset/beige-cheetahs-flash.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': minor
+---
+
+Adapt the Next.js "Getting Started" guide to the Next.js App Router folder structure

--- a/.changeset/beige-cheetahs-flash.md
+++ b/.changeset/beige-cheetahs-flash.md
@@ -1,5 +1,0 @@
----
-'tiptap-docs': minor
----
-
-Adapt the Next.js "Getting Started" guide to the Next.js App Router folder structure

--- a/src/content/editor/getting-started/install/nextjs.mdx
+++ b/src/content/editor/getting-started/install/nextjs.mdx
@@ -61,7 +61,7 @@ export default Tiptap
 
 ### Add it to your app
 
-Now, let's replace the content of `pages/index.js` with the following example code to use the `Tiptap` component in our app.
+Now, let's replace the content of `app/page.js` (or `pages/index.js`, if you are using the Pages router) with the following example code to use the `Tiptap` component in our app.
 
 ```jsx
 import Tiptap from '../components/Tiptap'


### PR DESCRIPTION
The App Router folder structure is the default option when creating a new Next.js project nowadays. However, the Tiptap Next.js "Getting Started" guide only mentions the Pages Router folder structure.

I suggest the "Getting Started" guide mention the App Router folder structure by default, and the Pages Router folder structure as an alternative option.

## Changes Overview
Mention both the App router folder structure (default option) and the Pages Router folder structure (alternative option) in the Next.js "Getting Started" guide.

## Implementation Approach
Modify the markdown file.

## Testing Done
- Run `npm run lint`. No issues found.
- Open local dev server (`npm run dev`). Visit the site: http://localhost:3000/editor/getting-started/install/nextjs . Check the changed content.

## Verification Steps
1. Open local dev server (`npm run dev`)
2. Visit the site: http://localhost:3000/editor/getting-started/install/nextjs
3. Check the changed content.

## Additional Notes
None

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
None
