### PR TITLE
Remove unnecessary dependencies from install command of `@tiptap-pro/extension-drag-handle-react`

### DIFF
--- a/.changeset/sharp-walls-fix.md
+++ b/.changeset/sharp-walls-fix.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Update the installation extensions required for drag handle react

--- a/src/content/editor/extensions/functionality/drag-handle-react.mdx
+++ b/src/content/editor/extensions/functionality/drag-handle-react.mdx
@@ -33,7 +33,7 @@ It essentially wraps the [DragHandle](/editor/extensions/functionality/drag-hand
 </Callout>
 
 ```bash
-npm install @tiptap-pro/extension-drag-handle-react @tiptap-pro/extension-drag-handle @tiptap-pro/extension-node-range @tiptap/extension-collaboration y-prosemirror yjs y-protocols
+npm install @tiptap-pro/extension-drag-handle-react
 ```
 
 ## Props


### PR DESCRIPTION
These were added in #36 but according to my tests they're not peer dependencies anymore. I'm able to use the extension only by installing it's own dependency.

For more context see #23.