### PR TITLE
Rename CollaboationCursor docs to Caret

### DIFF
--- a/.changeset/happy-shoes-sip.md
+++ b/.changeset/happy-shoes-sip.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': major
+---
+
+Updated docs to reflect package name changes for collaboration cursor

--- a/src/content/collaboration/core-concepts/awareness.mdx
+++ b/src/content/collaboration/core-concepts/awareness.mdx
@@ -71,6 +71,6 @@ document.addEventListener('mousemove', (event) => {
 
 Check your browser's console to see the stream of events as users move their mice.
 
-## Add cursors and carets
+## Add carets and selections
 
-With basic Awareness in place, consider adding the [Collaboration Cursor](/editor/extensions/functionality/collaboration-cursor) extension to your editor. This extension adds cursor positions, text selections, and personalized details (such as names and colors) of all participating users to your editor.
+With basic Awareness in place, consider adding the [Collaboration Caret](/editor/extensions/functionality/collaboration-caret) extension to your editor. This extension adds caret positions, text selections, and personalized details (such as names and colors) of all participating users to your editor.

--- a/src/content/editor/extensions/functionality/collaboration-caret.mdx
+++ b/src/content/editor/extensions/functionality/collaboration-caret.mdx
@@ -1,22 +1,22 @@
 ---
-title: CollaborationCursor extension
+title: CollaborationCaret extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-collaboration-cursor.svg?label=version
-    url: https://www.npmjs.com/package/@tiptap/extension-collaboration-cursor
+    src: https://img.shields.io/npm/v/@tiptap/extension-collaboration-caret.svg?label=version
+    url: https://www.npmjs.com/package/@tiptap/extension-collaboration-caret
     label: Version
   - type: image
-    src: https://img.shields.io/npm/dm/@tiptap/extension-collaboration-cursor.svg
-    url: https://npmcharts.com/compare/@tiptap/extension-collaboration-cursor?minimal=true
+    src: https://img.shields.io/npm/dm/@tiptap/extension-collaboration-caret.svg
+    url: https://npmcharts.com/compare/@tiptap/extension-collaboration-caret?minimal=true
     label: Downloads
 meta:
-  title: CollaborationCursor extension | Tiptap Editor Docs
-  description: Use the Collaboration Cursor extension in Tiptap to show other user’s cursors and their names while they type. More in the docs!
+  title: CollaborationCaret extension | Tiptap Editor Docs
+  description: Use the Collaboration Cursor extension in Tiptap to show other user’s carets and their names while they type. More in the docs!
   category: Editor
 extension:
-  name: Collaboration Cursor
-  link: https://github.com/ueberdosis/tiptap/tree/main/packages/extension-collaboration-cursor
-  description: 'See other users’ cursors and names while they type.'
+  name: Collaboration Caret
+  link: https://github.com/ueberdosis/tiptap/tree/main/packages/extension-collaboration-caret
+  description: 'See other user’s carets and names while they type.'
   type: extension
   icon: MousePointer2
 ---
@@ -28,7 +28,7 @@ import { Button } from '@/components/ui/Button'
 import { CodeDemo } from '@/components/CodeDemo'
 import { Callout } from '@/components/ui/Callout'
 
-This extension adds information about all connected users (like their name and a specified color), their current cursor position and their text selection (if there’s one).
+This extension adds information about all connected users (like their name and a specified color), their current caret position and their text selection (if there’s one).
 
 It requires a collaborative Editor, so make sure to check out the [Tiptap Collaboration Docs](/collaboration/getting-started/overview) for a fully hosted or on-premises collaboration server solution.
 
@@ -36,15 +36,15 @@ It requires a collaborative Editor, so make sure to check out the [Tiptap Collab
   The content of this editor is shared with other users.
 </Callout>
 
-<CodeDemo path="/Extensions/CollaborationCursor?hideSource" />
-<CodeDemo path="/Extensions/CollaborationCursor" />
+<CodeDemo path="/Extensions/CollaborationCaret?hideSource" />
+<CodeDemo path="/Extensions/CollaborationCaret" />
 
 Open this page in multiple browser windows to test it.
 
 ## Install
 
 ```bash
-npm install @tiptap/extension-collaboration-cursor
+npm install @tiptap/extension-collaboration-caret
 ```
 
 This extension requires the [`Collaboration`](/collaboration/getting-started/overview) extension.
@@ -65,11 +65,11 @@ Default: `{ user: null, color: null }`
 
 ### render
 
-A render function for the cursor, look at [the extension source code](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-collaboration-cursor/) for an example.
+A render function for the caret, look at [the extension source code](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-collaboration-caret/) for an example.
 
 ### selectionRender
 
-A render function for the selection, look at [the extension source code](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-collaboration-cursor/) for an example.
+A render function for the selection, look at [the extension source code](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-collaboration-caret/) for an example.
 
 ## Commands
 
@@ -87,7 +87,7 @@ editor.commands.updateUser({
 
 ## Source code
 
-[packages/extension-collaboration-cursor/](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-collaboration-cursor/)
+[packages/extension-collaboration-caret/](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-collaboration-caret/)
 
 <CtaBox.Wrapper>
   <CtaBox.Title>Collaboration</CtaBox.Title>

--- a/src/content/editor/sidebar.ts
+++ b/src/content/editor/sidebar.ts
@@ -258,8 +258,8 @@ export const sidebarConfig: SidebarConfig = {
               title: 'Collaboration',
             },
             {
-              href: '/editor/extensions/functionality/collaboration-cursor',
-              title: 'Collaboration Cursor',
+              href: '/editor/extensions/functionality/collaboration-caret',
+              title: 'Collaboration Caret',
             },
             {
               href: '/editor/extensions/functionality/background-color',

--- a/src/utils/sandpackConfiguration.ts
+++ b/src/utils/sandpackConfiguration.ts
@@ -93,7 +93,7 @@ export const dependencies = {
   '@tiptap/extension-code-block-lowlight': 'next',
   '@tiptap/extension-code-block': 'next',
   '@tiptap/extension-code': 'next',
-  '@tiptap/extension-collaboration-cursor': 'next',
+  '@tiptap/extension-collaboration-caret': 'next',
   '@tiptap/extension-collaboration': 'next',
   '@tiptap/extension-color': 'next',
   '@tiptap/extension-document': 'next',


### PR DESCRIPTION
This pull request includes significant changes to the Tiptap documentation and codebase to reflect the renaming of the `CollaborationCursor` extension to `CollaborationCaret`. The most important changes include updating the documentation, renaming files, and modifying references to the extension.

Documentation updates:
* Updated the documentation to reflect the package name changes from `CollaborationCursor` to `CollaborationCaret` in `.changeset/happy-shoes-sip.md`.
* Changed section titles and content in `src/content/collaboration/core-concepts/awareness.mdx` to use "carets" instead of "cursors".

File renaming:
* Renamed `src/content/editor/extensions/functionality/collaboration-cursor.mdx` to `src/content/editor/extensions/functionality/collaboration-caret.mdx` and updated the content to reflect the new extension name [[1]](diffhunk://#diff-b5b4cf40f19fbdf5fc7dbced3258da763658cc8e1a8bc5301a9fbf8ecfc0ac6bL2-R19) [[2]](diffhunk://#diff-b5b4cf40f19fbdf5fc7dbced3258da763658cc8e1a8bc5301a9fbf8ecfc0ac6bL31-R47) [[3]](diffhunk://#diff-b5b4cf40f19fbdf5fc7dbced3258da763658cc8e1a8bc5301a9fbf8ecfc0ac6bL68-R72) [[4]](diffhunk://#diff-b5b4cf40f19fbdf5fc7dbced3258da763658cc8e1a8bc5301a9fbf8ecfc0ac6bL90-R90).

Reference updates:
* Updated the sidebar configuration in `src/content/editor/sidebar.ts` to point to the new `CollaborationCaret` extension.
* Modified the dependencies in `src/utils/sandpackConfiguration.ts` to use the new `CollaborationCaret` package.