### PR TITLE
Update the TextAlign doc to have the correct default value of defaultAlignment

### DIFF
--- a/src/content/editor/extensions/functionality/textalign.mdx
+++ b/src/content/editor/extensions/functionality/textalign.mdx
@@ -70,7 +70,7 @@ TextAlign.configure({
 
 The default text align.
 
-Default: `'left'`
+Default: `null`
 
 ```js
 TextAlign.configure({


### PR DESCRIPTION
From the code I see the defaultAlignment value is set to `null` by default, so updating the document.