### PR TITLE
fix: update types of event handlers

### DIFF
--- a/src/content/editor/api/events.mdx
+++ b/src/content/editor/api/events.mdx
@@ -12,7 +12,6 @@ The editor fires a few different events that you can hook into. Let’s have a l
 
 | Event Name        | Description                                                                                                   |
 | ----------------- | ------------------------------------------------------------------------------------------------------------- |
-
 | `beforeCreate`    | Before the editor view is created.                                                                            |
 | `create`          | When the editor is fully initialized and ready.                                                               |
 | `update`          | When there is a change in the content.                                                                        |

--- a/src/content/editor/api/events.mdx
+++ b/src/content/editor/api/events.mdx
@@ -12,6 +12,7 @@ The editor fires a few different events that you can hook into. Let’s have a l
 
 | Event Name        | Description                                                                                                   |
 | ----------------- | ------------------------------------------------------------------------------------------------------------- |
+
 | `beforeCreate`    | Before the editor view is created.                                                                            |
 | `create`          | When the editor is fully initialized and ready.                                                               |
 | `update`          | When there is a change in the content.                                                                        |
@@ -109,11 +110,11 @@ editor.on('destroy', () => {
   // The editor is being destroyed.
 })
 
-editor.on('paste', (event: ClipboardEvent, slice: Slice) => {
+editor.on('paste', ({ event, slice, editor }) => {
   // The editor is being pasted into.
 })
 
-editor.on('drop', (event: DragEvent, slice: Slice, moved: boolean) => {
+editor.on('drop', ({ editor, event, slice, moved }) => {
   // The editor is being destroyed.
 })
 


### PR DESCRIPTION
This PR completes the work started by this contributor on PR https://github.com/ueberdosis/tiptap-docs/pull/72 , which was a useful contribution but had merge conflicts.

I checked that the changes introduced reflect the actual types of the code.