### PR TITLE
feat: add metadata property

### DIFF
--- a/src/content/content-ai/capabilities/suggestion/api-reference.mdx
+++ b/src/content/content-ai/capabilities/suggestion/api-reference.mdx
@@ -259,6 +259,13 @@ export interface AiSuggestionRule {
    * when the suggestion is selected.
    */
   backgroundColor: string
+  /**
+   * Extra metadata for the rule, that can be used to store additional
+   * information about it (e.g. its source or its category). It is not used
+   * internally by the extension but it may help developers customize how a
+   * rule is displayed in the UI.
+   */
+  metadata?: any
 }
 ```
 
@@ -324,6 +331,13 @@ export interface Suggestion {
    * Whether the suggestion was rejected by the user.
    */
   isRejected: boolean
+  /**
+   * Extra metadata for the suggestion, that can be used to store additional
+   * information about it (e.g. its source or its category). It is not used
+   * internally by the extension but it may help developers customize how a
+   * suggestion is displayed in the UI.
+   */
+  metadata?: any
 }
 ```
 


### PR DESCRIPTION
Some customers want to customize how suggestions are displayed. It would be easier for them to do so if suggestions have a metadata object where developers can store their custom properties (like category, type, source...) and perform different business logic based on it.

Link to Slack conversation: https://ueberdosis.slack.com/archives/C06K4FUHLP3/p1743079883725909