### PR TITLE
docs: update `mount` and `unmount` docs

### DIFF
--- a/src/content/editor/api/editor.mdx
+++ b/src/content/editor/api/editor.mdx
@@ -336,6 +336,22 @@ editor.isActive('heading', { level: 2 })
 editor.isActive({ textAlign: 'justify' })
 ```
 
+### mount()
+
+Mount the editor to an element. This is useful when you want to mount the editor to an element that is not yet available in the DOM.
+
+```js
+editor.mount(document.querySelector('.element'))
+```
+
+### unmount()
+
+Unmount the editor from an element. This is useful when you want to unmount the editor from an element, but later want to re-mount it to another element.
+
+```js
+editor.unmount()
+```
+
 ### registerPlugin()
 
 Register a ProseMirror plugin.


### PR DESCRIPTION
This updates the documentation to include the new `unmount` method introduced by this PR: https://github.com/ueberdosis/tiptap/pull/6182
