### PR TITLE
Remove param from AI Suggestion commands

### DIFF
--- a/src/content/content-ai/capabilities/suggestion/api-reference.mdx
+++ b/src/content/content-ai/capabilities/suggestion/api-reference.mdx
@@ -90,19 +90,13 @@ declare module '@tiptap/core' {
     aiSuggestion: {
       /**
        * Load AI suggestions immediately.
-       *
-       * @param rules Custom rules to use for the suggestions. If not provided,
-       * the rules defined in the extension options will be used.
        */
-      loadAiSuggestions: (rules?: AiSuggestionRule[]) => ReturnType
+      loadAiSuggestions: () => ReturnType
       /**
        * Load AI suggestions after a debounce timeout defined in the
        * extension options.
-       *
-       * @param rules Custom rules to use for the suggestions. If not provided,
-       * the rules defined in the extension options will be used.
        */
-      loadAiSuggestionsDebounced: (rules?: AiSuggestionRule[]) => ReturnType
+      loadAiSuggestionsDebounced: () => ReturnType
       /**
        * Set the AI suggestions to be displayed.
        *
@@ -229,7 +223,7 @@ export interface AiSuggestionStorage {
   /** Error that occurred during the last load attempt, if any */
   error: unknown | null
   /** Debounced function for loading suggestions */
-  debouncedFunction: DebouncedFunction<(rules?: AiSuggestionRule[]) => void>
+  debouncedFunction: DebouncedFunction<() => void>
   /** Controller to abort loading suggestions */
   abortController: AbortController
   /**


### PR DESCRIPTION
Remove `rules` param from some commands. To adapt the docs to the changes in [this PR](https://github.com/ueberdosis/tiptap-pro/pull/221)