### PR TITLE
AI Suggestion performance: chunking editor content and caching suggestions

### DIFF
--- a/.changeset/loud-ligers-call.md
+++ b/.changeset/loud-ligers-call.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': minor
+---
+
+Add docs about AI Suggestion performance optimizations like chunking editor content and caching suggestions

--- a/src/content/content-ai/capabilities/suggestion/api-reference.mdx
+++ b/src/content/content-ai/capabilities/suggestion/api-reference.mdx
@@ -79,6 +79,33 @@ export interface AiSuggestionOptions {
    * for generating suggestions.
    */
   context: string | null
+  /**
+   * Whether to chunk the editor content and cache the suggestions
+   * for each chunk. This allows the extension to reuse the cached suggestions
+   * for each chunk when the content is reloaded. This is useful for large
+   * documents to improve performance and reduce costs.
+   *
+   * @default true
+   */
+  enableCache: boolean
+  /**
+   * The size of the chunks to split the document into, measured in the amount
+   * of top-level child nodes of the editor's content.
+   *
+   * @default 2
+   */
+  chunkSize: number
+  /**
+   * A function that splits the HTML content of the editor into chunks. By
+   * default, it splits the HTML into smaller pieces based on the configured
+   * chunk size and returns an array of HTML chunks. You can override this
+   * behavior by providing your own function.
+   *
+   * @param options - The options for chunking the HTML.
+   * @returns An array of chunks
+   * @default `defaultChunkHtmlFunction`
+   */
+  chunkHtmlFunction: (options: ChunkHtmlOptions) => HtmlChunk[]
 }
 ```
 
@@ -231,6 +258,10 @@ export interface AiSuggestionStorage {
    * for generating suggestions.
    */
   context: string | null
+  /**
+   * The cache used to store the suggestions of each chunk of the document.
+   */
+  cache: AiSuggestionCache
 }
 
 /**

--- a/src/content/content-ai/capabilities/suggestion/configure.mdx
+++ b/src/content/content-ai/capabilities/suggestion/configure.mdx
@@ -190,3 +190,33 @@ AiSuggestion.configure({
 ```
 
 You can learn more about providing context in [this guide](/content-ai/capabilities/suggestion/features/provide-llm-context).
+
+## Configure Content Caching
+
+To avoid unnecessary API calls, the AI Suggestion splits the editor content into chunks and caches the suggestions that have been generated for each chunk. When the suggestions are reloaded, it only re-fetches the suggestions for the chunks that have changed. This is done automatically, but you can configure how the content is split and cached.
+
+You can disable the cache by setting `enableCache` to `false`. This will make the AI Suggestion extension call the API for all chunks when the editor content changes.
+
+```ts
+AiSuggestion.configure({
+  // Disable caching
+  enableCache: false,
+})
+```
+
+You can also configure the chunk size with the `chunkSize` option. This option controls how many top-level nodes of the document are included in each chunk. The default value is `2`, meaning that, for a document with 10 paragraphs, the AI Suggestion will create 5 chunks of 2 paragraphs each.
+
+```ts
+AiSuggestion.configure({
+  // Each chunk will contain 3 top-level HTML nodes
+  chunkSize: 3,
+})
+```
+
+You can customize chunk generation by overriding the `chunkHtml` function. This function receives the editor content and should return an array of HTML strings, each representing a chunk. This gives you fine-grained control over how the content is split into chunks.
+
+```ts
+AiSuggestion.configure({
+  chunkHtml: customChunkHtmlFunction,
+})
+```

--- a/src/content/content-ai/capabilities/suggestion/configure.mdx
+++ b/src/content/content-ai/capabilities/suggestion/configure.mdx
@@ -70,7 +70,7 @@ To learn more about the data that a suggestion object should contain, check the 
 
 ## Custom Suggestion Styles
 
-The `getCustomSuggestionDecoration` function allows you to control the appearance of suggestions and provide visual cues to the user. You can add custom CSS classes to the suggestions, and add custom elements before and after them. This is useful for adding popovers, tooltips, icons, or other elements to the suggestions.
+The `getCustomSuggestionDecoration` function allows you to control the appearance of suggestions and provide visual cues to the user. You can add custom CSS classes to the suggestions, and add custom elements before and after them. Useful for adding popovers, tooltips, or icons to suggestions.
 
 The custom styles and elements are implemented with the [Prosemirror Decorations API](https://prosemirror.net/docs/ref/#view.Decorations).
 

--- a/src/content/content-ai/capabilities/suggestion/configure.mdx
+++ b/src/content/content-ai/capabilities/suggestion/configure.mdx
@@ -191,9 +191,9 @@ AiSuggestion.configure({
 
 You can learn more about providing context in [this guide](/content-ai/capabilities/suggestion/features/provide-llm-context).
 
-## Configure Content Caching
+## Configure Caching
 
-To avoid unnecessary API calls, the AI Suggestion splits the editor content into chunks and caches the suggestions that have been generated for each chunk. When the suggestions are reloaded, it only re-fetches the suggestions for the chunks that have changed. This is done automatically, but you can configure how the content is split and cached.
+The AI Suggestion extension caches suggestions to minimize API calls. It splits the editor content into chunks and stores the generated suggestions for each chunk. When reloading suggestions, only modified chunks are re-fetched. This behavior is enabled by default, but you can customize it.
 
 You can disable the cache by setting `enableCache` to `false`. This will make the AI Suggestion extension call the API for all chunks when the editor content changes.
 
@@ -204,7 +204,7 @@ AiSuggestion.configure({
 })
 ```
 
-You can also configure the chunk size with the `chunkSize` option. This option controls how many top-level nodes of the document are included in each chunk. The default value is `2`, meaning that, for a document with 10 paragraphs, the AI Suggestion will create 5 chunks of 2 paragraphs each.
+You can configure the chunk size with the `chunkSize` option. This option controls how many top-level nodes of the document are included in each chunk. The default value is `2`, meaning that, for a document with 10 paragraphs, the AI Suggestion will create 5 chunks of 2 paragraphs each.
 
 ```ts
 AiSuggestion.configure({

--- a/src/content/content-ai/capabilities/suggestion/custom-llms.mdx
+++ b/src/content/content-ai/capabilities/suggestion/custom-llms.mdx
@@ -54,7 +54,7 @@ To provide maximum flexibility, the `apiResolver` accepts the response in two fo
 
 ### `replacements` Format (recommended)
 
-The response is an array of replacements that will be applied to the editor's content. It is useful when the suggestions modify specific parts of the document. It is the format used internally Tiptap Content AI Cloud, which has given us the best results so far.
+The response is an array of replacements that will be applied to the editor's content. It is useful when the suggestions modify specific parts of the document. It is the format used internally in our Tiptap Content AI Cloud, which has given us the best results so far.
 It contains the following properties:
 
 - `items`: A list of suggestions. Each suggestion has the following properties:

--- a/src/content/content-ai/capabilities/suggestion/custom-llms.mdx
+++ b/src/content/content-ai/capabilities/suggestion/custom-llms.mdx
@@ -52,81 +52,100 @@ AiSuggestion.configure({
 
 To provide maximum flexibility, the `apiResolver` accepts the response in two formats:
 
-- `replacements`: The response is an array of replacements that will be applied to the editor's content. It also includes a list of chunks associated with each replacement, so that the replacements can be cached. This is useful when you want to replace specific parts of the content with the suggestions. This is the format used internally Tiptap Content AI Cloud, which has given us the best results so far.
+### `replacements` Format (recommended)
 
-  Here is an example response in the `replacements` format.
+The response is an array of replacements that will be applied to the editor's content. It is useful when the suggestions modify specific parts of the document. It is the format used internally Tiptap Content AI Cloud, which has given us the best results so far.
+It contains the following properties:
 
-  ```json
-  {
-    "format": "replacements",
-    "content": {
-      "htmlChunks": [
-        {
-          "id": "1",
-          "html": "<p>Hello, welcome to our awesome app! We hope you guys will love it. Our aplication offers unique features that enhance your cooking experience. You can explore various cuisines and share your food momentts.</p><p>Hola, estamos emocionados de tenerte aquí. Our app is not just about recipes but also about building a community. We believe this will transform how you cook.</p>",
-          "generateSuggestions": true
-        },
-        {
-          "id": "2",
-          "html": "<p>Please check out our cool fetures and enjoy cooking with us. Si tienes dudas, no dudes en preguntar.</p>",
-          "generateSuggestions": true
-        }
-      ],
-      "items": [
-        {
-          "ruleId": "1",
-          "deleteHtml": "Hola, estamos <bold>emocionados</bold> de tenerte aquí.",
-          "insertHtml": "Hello, we are <bold>excited</bold> to have you here.",
-          "chunkId": "1"
-        },
-        {
-          "ruleId": "2",
-          "deleteHtml": "aplication",
-          "insertHtml": "application",
-          "chunkId": "1"
-        },
-        {
-          "ruleId": "2",
-          "deleteHtml": "momentts",
-          "insertHtml": "moments",
-          "chunkId": "1"
-        },
-        {
-          "ruleId": "1",
-          "deleteHtml": "Si tienes dudas, no dudes en preguntar.",
-          "insertHtml": "If you have any questions, feel free to ask.",
-          "chunkId": "2"
-        },
-        {
-          "ruleId": "2",
-          "deleteHtml": "fetures",
-          "insertHtml": "features",
-          "chunkId": "2"
-        }
-      ]
-    }
+- `items`: A list of suggestions. Each suggestion has the following properties:
+  - `ruleId`: The ID of the rule that generated the suggestion.
+  - `deleteHtml`: The HTML content to be deleted from the editor.
+  - `insertHtml`: The HTML content to be inserted into the editor.
+  - `chunkId`: The ID of the chunk where the suggestion should be applied.
+- `htmlChunks`: A list of all the chunks of HTML code in the editor content. Each chunk has these properties:
+  - `id`: A unique identifier for the chunk.
+  - `html`: The HTML content of the chunk.
+  - `generateSuggestions`: Whether the AI model did generate suggestions for this chunk. Otherwise, if set to `false`, the suggestions will be fetched from the extension's internal cache.
+
+Make sure the `htmlChunks` property contains all the chunks of HTML code in the editor content, otherwise the caching mechanism will not work properly.
+
+You can easily get the value of the `htmlChunks` property by reading the `htmlChunks` argument of the `apiResolver` function.
+
+Here is an example response in the `replacements` format.
+
+```json
+{
+  "format": "replacements",
+  "content": {
+    "htmlChunks": [
+      {
+        "id": "1",
+        "html": "<p>Hello, welcome to our awesome app! We hope you guys will love it. Our aplication offers unique features that enhance your cooking experience. You can explore various cuisines and share your food momentts.</p><p>Hola, estamos emocionados de tenerte aquí. Our app is not just about recipes but also about building a community. We believe this will transform how you cook.</p>",
+        "generateSuggestions": true
+      },
+      {
+        "id": "2",
+        "html": "<p>Please check out our cool fetures and enjoy cooking with us. Si tienes dudas, no dudes en preguntar.</p>",
+        "generateSuggestions": true
+      }
+    ],
+    "items": [
+      {
+        "ruleId": "1",
+        "deleteHtml": "Hola, estamos <bold>emocionados</bold> de tenerte aquí.",
+        "insertHtml": "Hello, we are <bold>excited</bold> to have you here.",
+        "chunkId": "1"
+      },
+      {
+        "ruleId": "2",
+        "deleteHtml": "aplication",
+        "insertHtml": "application",
+        "chunkId": "1"
+      },
+      {
+        "ruleId": "2",
+        "deleteHtml": "momentts",
+        "insertHtml": "moments",
+        "chunkId": "1"
+      },
+      {
+        "ruleId": "1",
+        "deleteHtml": "Si tienes dudas, no dudes en preguntar.",
+        "insertHtml": "If you have any questions, feel free to ask.",
+        "chunkId": "2"
+      },
+      {
+        "ruleId": "2",
+        "deleteHtml": "fetures",
+        "insertHtml": "features",
+        "chunkId": "2"
+      }
+    ]
   }
-  ```
+}
+```
 
-- `fullHtml`: The response is a full HTML string that will replace the editor's content. This is useful when you want to replace the entire content with the suggestions. We've found this format to perform very well when there is only one rule to apply, but less so when there are multiple rules. This format does not support chunking and caching.
+### `fullHtml` Format
 
-  ```json
-  {
-    "format": "fullHtml",
-    "content": {
-      "items": [
-        {
-          "ruleId": "1",
-          "fullHtml": "<p>Hello, welcome to our awesome app! We hope you guys will love it. Our aplication offers unique features that enhance your cooking experience. You can explore various cuisines and share your food momentts.</p><p>Hello, we are excited to have you here. Our app is not just about recipes but also about building a community. We believe this will transform how you cook.</p><p>Please check out our cool fetures and enjoy cooking with us. If you have doubts, do not hesitate to ask.</p>"
-        },
-        {
-          "ruleId": "2",
-          "fullHtml": "<p>Hello, welcome to our awesome app! We hope you guys will love it. Our application offers unique features that enhance your cooking experience. You can explore various cuisines and share your food moments.</p><p>Hola, estamos emocionados de tenerte aquí. Our app is not just about recipes but also about building a community. We believe this will transform how you cook.</p><p>Please check out our cool features and enjoy cooking with us. Si tienes dudas, no dudes en preguntar.</p>"
-        }
-      ]
-    }
+The response is a full HTML string that will replace the editor's content. This is useful when you want to replace the entire content with the suggestions. We've found this format to perform very well when there is only one rule to apply, but less so when there are multiple rules. This format does not support chunking and caching.
+
+```json
+{
+  "format": "fullHtml",
+  "content": {
+    "items": [
+      {
+        "ruleId": "1",
+        "fullHtml": "<p>Hello, welcome to our awesome app! We hope you guys will love it. Our aplication offers unique features that enhance your cooking experience. You can explore various cuisines and share your food momentts.</p><p>Hello, we are excited to have you here. Our app is not just about recipes but also about building a community. We believe this will transform how you cook.</p><p>Please check out our cool fetures and enjoy cooking with us. If you have doubts, do not hesitate to ask.</p>"
+      },
+      {
+        "ruleId": "2",
+        "fullHtml": "<p>Hello, welcome to our awesome app! We hope you guys will love it. Our application offers unique features that enhance your cooking experience. You can explore various cuisines and share your food moments.</p><p>Hola, estamos emocionados de tenerte aquí. Our app is not just about recipes but also about building a community. We believe this will transform how you cook.</p><p>Please check out our cool features and enjoy cooking with us. Si tienes dudas, no dudes en preguntar.</p>"
+      }
+    ]
   }
-  ```
+}
+```
 
 ### Improving Accuracy
 
@@ -180,7 +199,7 @@ To enhance the performance of your API and custom LLM models when generating sug
 - Choose a model that balances accuracy with speed and low latency. Use leaderboards like [Artificial Analysis](https://artificialanalysis.ai/#intelligence-vs-output-speed) to compare models across different metrics.
 - Before implementing performance improvements, measure your API's response times. If your pipeline includes multiple steps or model calls, analyze each step to identify bottlenecks. Use an evaluation framework like [Evalite](https://www.evalite.dev/) to iterate on prompts and compare their effectiveness.
 - Leverage [OpenAI predicted outputs](https://platform.openai.com/docs/guides/predicted-outputs) (or the equivalent feature in other LLM providers) to improve latency and processing speed.
-- Chunk editor content into sub-sections and process them in parallel to reduce overall processing time, especially for large documents. Take advantage of the built-in cache mechanism of our AI Suggestion extension and only reload the suggestions of the chunks that have changed.
+- Chunk editor content into sub-sections and process them in parallel to reduce overall processing time, especially for large documents. Take advantage of the built-in chunking and caching mechanism of the extension, and only reload the suggestions of the chunks that have changed.
 - Structure your prompt to take advantage of full or [partial caching](https://platform.openai.com/docs/guides/prompt-caching). Note that different LLM providers offer varying caching implementations, and some may not support it. If necessary, implement your own caching mechanism to reuse LLM responses for identical or similar prompts.
 - Streaming responses can improve the perceived performance of your API, particularly for large documents, by allowing suggestions to be displayed before the entire response is generated. While our AI Suggestion extension currently does not support streaming, we are considering adding this feature in future versions. If you believe your application would benefit from it, reach out to us at humans@tiptap.dev.
 

--- a/src/content/content-ai/capabilities/suggestion/custom-llms.mdx
+++ b/src/content/content-ai/capabilities/suggestion/custom-llms.mdx
@@ -11,12 +11,12 @@ By default, the AI Suggestion extension uses the Tiptap Content AI Cloud to gene
 The AI Suggestion extension supports different degrees of customization. You can:
 
 1. Use the Tiptap Content AI Cloud, but customize the OpenAI model.
-2. Replace the API endpoint to get the suggestions data with your own LLM and backend, but let the extension handle how suggestions are displayed and applied. **This is the recommended approach** for most use cases, as we handle most of the complexity for you: comparing the old and new editor content, displaying the diff in a pleasant way, and handling conflicts.
+2. Replace the API endpoint to get the suggestions data with your own LLM and backend, but let the extension handle how suggestions are displayed and applied. This is the recommended approach for most use cases, as we handle most of the complexity for you: comparing the old and new editor content, displaying the diff in a pleasant way, and handling conflicts.
 3. Implement your own resolver function entirely. This gives you total flexibility to decide how suggestions are displayed in the editor. It is only recommended in advanced scenarios.
 
 ## Customize the OpenAI Model in Tiptap Cloud
 
-You can configure the OpenAI model to use for generating suggestions with the `model` option. The default model is `gpt-4o-mini`. We recommend it for most use cases, as it provides a good balance between speed, cost and accuracy.
+You can configure the OpenAI model to use for generating suggestions with the `model` option. The default model is `gpt-4o-mini`. It provides a good balance between speed, cost and accuracy.
 
 If you want to improve the suggestions' quality, you can use a larger model like `gpt-4o`. Bear in mind that larger models tend to be more expensive, slower, and have a higher latency.
 
@@ -151,7 +151,7 @@ The response is a full HTML string that will replace the editor's content. This 
 
 LLMs can make mistakes, making it difficult to ensure that their responses follow the desired format. To improve the accuracy of your custom models, we recommend following these best practices and prompt engineering techniques.
 
-- Before implementing improvements, evaluate your custom endpoint's responses and measure their performance and accuracy. Use an evaluation framework like [Evalite](https://www.evalite.dev/). This will help you iterate on your prompt, improve it over time, and compare alternative prompts to determine which performs better.
+- Before implementing improvements, evaluate your custom endpoint's responses and measure their performance and accuracy. Use an evaluation framework like [Evalite](https://www.evalite.dev/). This helps you refine and compare prompts for better performance.
 - If you use the `replacements` format, take advantage of [OpenAI structured outputs](https://platform.openai.com/docs/guides/structured-outputs) (or the equivalent feature in other LLM providers) to ensure that responses are JSON objects that comply with a specific schema.
 - If you use the `fullHtml` format, leverage [OpenAI predicted outputs](https://platform.openai.com/docs/guides/predicted-outputs) (or the equivalent feature in other LLM providers) to ensure that responses do not deviate excessively from the original editor content.
 - Adjust the `temperature` or `top_p` [parameters](https://platform.openai.com/docs/api-reference/completions/create) to control the randomness of the model's output.
@@ -232,7 +232,7 @@ AiSuggestion.configure({
     // Split the rules into two groups
     const { rulesForDefaultSuggestions, rulesForCustomSuggestions } = splitRules(rules)
 
-    // Get suggestions from Tiptap Cloud API
+    // Get suggestions from Tiptap Content AI Cloud
     const defaultSuggestions = await defaultResolver({
       ...options,
       rules: rulesForDefaultSuggestions,

--- a/src/content/content-ai/capabilities/suggestion/custom-llms.mdx
+++ b/src/content/content-ai/capabilities/suggestion/custom-llms.mdx
@@ -36,9 +36,9 @@ AiSuggestion.configure({
   async resolver({ defaultResolver, ...options }) {
     const suggestions = defaultResolver({
       ...options,
-      apiResolver: async ({ html, rules }) => {
+      apiResolver: async ({ html, htmlChunks, rules }) => {
         // Generate the response by calling your custom backend and LLMs
-        const response = await claudeSonnetApi({ html, rules })
+        const response = await claudeSonnetApi({ html, htmlChunks, rules })
 
         // Return the response in the correct format (see details below)
         return { format: 'fullHtml', content: response }
@@ -52,7 +52,7 @@ AiSuggestion.configure({
 
 To provide maximum flexibility, the `apiResolver` accepts the response in two formats:
 
-- `replacements`: The response is an array of replacements that will be applied to the editor's content. This is useful when you want to replace specific parts of the content with the suggestions. This is the format that we use with the Tiptap Content AI Cloud, which has given us the best results so far.
+- `replacements`: The response is an array of replacements that will be applied to the editor's content. It also includes a list of chunks associated with each replacement, so that the replacements can be cached. This is useful when you want to replace specific parts of the content with the suggestions. This is the format used internally Tiptap Content AI Cloud, which has given us the best results so far.
 
   Here is an example response in the `replacements` format.
 
@@ -60,37 +60,55 @@ To provide maximum flexibility, the `apiResolver` accepts the response in two fo
   {
     "format": "replacements",
     "content": {
+      "htmlChunks": [
+        {
+          "id": "1",
+          "html": "<p>Hello, welcome to our awesome app! We hope you guys will love it. Our aplication offers unique features that enhance your cooking experience. You can explore various cuisines and share your food momentts.</p><p>Hola, estamos emocionados de tenerte aquí. Our app is not just about recipes but also about building a community. We believe this will transform how you cook.</p>",
+          "generateSuggestions": true
+        },
+        {
+          "id": "2",
+          "html": "<p>Please check out our cool fetures and enjoy cooking with us. Si tienes dudas, no dudes en preguntar.</p>",
+          "generateSuggestions": true
+        }
+      ],
       "items": [
         {
-          "paragraph": 1,
-          "ruleId": "2",
-          "deleteHtml": "aplication",
-          "insertHtml": "application"
-        },
-        {
-          "paragraph": 2,
           "ruleId": "1",
           "deleteHtml": "Hola, estamos <bold>emocionados</bold> de tenerte aquí.",
-          "insertHtml": "Hello, we are <bold>excited</bold> to have you here."
+          "insertHtml": "Hello, we are <bold>excited</bold> to have you here.",
+          "chunkId": "1"
         },
         {
-          "paragraph": 3,
           "ruleId": "2",
-          "deleteHtml": "fetures",
-          "insertHtml": "features"
+          "deleteHtml": "aplication",
+          "insertHtml": "application",
+          "chunkId": "1"
         },
         {
-          "paragraph": 3,
+          "ruleId": "2",
+          "deleteHtml": "momentts",
+          "insertHtml": "moments",
+          "chunkId": "1"
+        },
+        {
           "ruleId": "1",
           "deleteHtml": "Si tienes dudas, no dudes en preguntar.",
-          "insertHtml": "If you have questions, do not hesitate to ask."
+          "insertHtml": "If you have any questions, feel free to ask.",
+          "chunkId": "2"
+        },
+        {
+          "ruleId": "2",
+          "deleteHtml": "fetures",
+          "insertHtml": "features",
+          "chunkId": "2"
         }
       ]
     }
   }
   ```
 
-- `fullHtml`: The response is a full HTML string that will replace the editor's content. This is useful when you want to replace the entire content with the suggestions. We've found this format to perform very well when there is only one rule to apply, but less so when there are multiple rules.
+- `fullHtml`: The response is a full HTML string that will replace the editor's content. This is useful when you want to replace the entire content with the suggestions. We've found this format to perform very well when there is only one rule to apply, but less so when there are multiple rules. This format does not support chunking and caching.
 
   ```json
   {
@@ -134,8 +152,8 @@ LLMs can make mistakes, making it difficult to ensure that their responses follo
       const suggestions1 = await defaultResolver({
         ...options,
         rules: rulesForFirstApiEndpoint
-        apiResolver: async ({ html, rules }) => {
-          const response = await firstApi({ html, rules });
+        apiResolver: async ({ html, htmlChunks, rules }) => {
+          const response = await firstApi({ html, htmlChunks, rules });
           return { format: "replacements", content: response };
         },
       });
@@ -144,8 +162,8 @@ LLMs can make mistakes, making it difficult to ensure that their responses follo
       const suggestions2 = await defaultResolver({
         ...options,
         rules: rulesForSecondApiEndpoint
-        apiResolver: async ({ html, rules }) => {
-          const response = await secondApi({ html, rules });
+        apiResolver: async ({ html, htmlChunks, rules }) => {
+          const response = await secondApi({ html, htmlChunks, rules });
           return { format: "fullHtml", content: response };
         },
       });
@@ -162,7 +180,7 @@ To enhance the performance of your API and custom LLM models when generating sug
 - Choose a model that balances accuracy with speed and low latency. Use leaderboards like [Artificial Analysis](https://artificialanalysis.ai/#intelligence-vs-output-speed) to compare models across different metrics.
 - Before implementing performance improvements, measure your API's response times. If your pipeline includes multiple steps or model calls, analyze each step to identify bottlenecks. Use an evaluation framework like [Evalite](https://www.evalite.dev/) to iterate on prompts and compare their effectiveness.
 - Leverage [OpenAI predicted outputs](https://platform.openai.com/docs/guides/predicted-outputs) (or the equivalent feature in other LLM providers) to improve latency and processing speed.
-- Chunk editor content into sub-sections and process them in parallel to reduce overall processing time, especially for large documents.
+- Chunk editor content into sub-sections and process them in parallel to reduce overall processing time, especially for large documents. Take advantage of the built-in cache mechanism of our AI Suggestion extension and only reload the suggestions of the chunks that have changed.
 - Structure your prompt to take advantage of full or [partial caching](https://platform.openai.com/docs/guides/prompt-caching). Note that different LLM providers offer varying caching implementations, and some may not support it. If necessary, implement your own caching mechanism to reuse LLM responses for identical or similar prompts.
 - Streaming responses can improve the perceived performance of your API, particularly for large documents, by allowing suggestions to be displayed before the entire response is generated. While our AI Suggestion extension currently does not support streaming, we are considering adding this feature in future versions. If you believe your application would benefit from it, reach out to us at humans@tiptap.dev.
 


### PR DESCRIPTION
Add documentation about the functionality of the AI Suggestion extension that chunks the editor content and caches it so that suggestions are reloaded only in the content that has changed.

Add guides on how to configure it and use it.

Relevant links

- [Notion task](https://www.notion.so/tiptap-suite/Chunk-editor-content-and-cache-suggestions-of-chunks-in-the-client-1cb01ffa3ebc80ffa64ffad9938df09b?pvs=4)
- [PR in tiptap-pro repository](https://github.com/ueberdosis/tiptap-pro/pull/222)

