### PR TITLE
Use correct beta tags for beta packages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "tailwindCSS.rootFontSize": 16,
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
   "[mdx]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": null,
+    "editor.formatOnSave": false
   }
 }

--- a/src/content/editor/api/utilities/html.mdx
+++ b/src/content/editor/api/utilities/html.mdx
@@ -6,11 +6,11 @@ meta:
   category: Editor
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/html.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/html/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/html
     label: Version
   - type: image
-    src: https://img.shields.io/npm/dm/@tiptap/html.svg?label=version
+    src: https://img.shields.io/npm/dm/@tiptap/html/beta?label=version
     url: https://npmcharts.com/compare/@tiptap/html
     label: Downloads
 ---

--- a/src/content/editor/api/utilities/static-renderer.mdx
+++ b/src/content/editor/api/utilities/static-renderer.mdx
@@ -6,11 +6,11 @@ meta:
   category: Editor
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/static-renderer.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/static-renderer/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/static-renderer
     label: Version
   - type: image
-    src: https://img.shields.io/npm/dm/@tiptap/static-renderer.svg?label=version
+    src: https://img.shields.io/npm/dm/@tiptap/static-renderer/beta?label=version
     url: https://npmcharts.com/compare/@tiptap/static-renderer
     label: Downloads
 ---

--- a/src/content/editor/api/utilities/suggestion.mdx
+++ b/src/content/editor/api/utilities/suggestion.mdx
@@ -6,11 +6,11 @@ meta:
   category: Editor
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/suggestion.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/suggestion/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/suggestion
     label: Version
   - type: image
-    src: https://img.shields.io/npm/dm/@tiptap/suggestion.svg?label=version
+    src: https://img.shields.io/npm/dm/@tiptap/suggestion/beta?label=version
     url: https://npmcharts.com/compare/@tiptap/suggestion
     label: Downloads
 ---

--- a/src/content/editor/extensions/functionality/background-color.mdx
+++ b/src/content/editor/extensions/functionality/background-color.mdx
@@ -2,7 +2,7 @@
 title: Background Color extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-text-style.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-text-style/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-text-style
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/bubble-menu.mdx
+++ b/src/content/editor/extensions/functionality/bubble-menu.mdx
@@ -2,7 +2,7 @@
 title: BubbleMenu extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-bubble-menu.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-bubble-menu/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-bubble-menu
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/character-count.mdx
+++ b/src/content/editor/extensions/functionality/character-count.mdx
@@ -2,7 +2,7 @@
 title: CharacterCount extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extensions.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extensions/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extensions
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/collaboration-caret.mdx
+++ b/src/content/editor/extensions/functionality/collaboration-caret.mdx
@@ -2,7 +2,7 @@
 title: CollaborationCaret extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-collaboration-caret.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-collaboration-caret/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-collaboration-caret
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/collaboration.mdx
+++ b/src/content/editor/extensions/functionality/collaboration.mdx
@@ -2,7 +2,7 @@
 title: Collaboration extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-collaboration.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-collaboration/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-collaboration
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/color.mdx
+++ b/src/content/editor/extensions/functionality/color.mdx
@@ -2,7 +2,7 @@
 title: Color extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-text-style.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-text-style/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-text-style
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/dropcursor.mdx
+++ b/src/content/editor/extensions/functionality/dropcursor.mdx
@@ -2,7 +2,7 @@
 title: Dropcursor extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extensions.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extensions/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extensions
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/floatingmenu.mdx
+++ b/src/content/editor/extensions/functionality/floatingmenu.mdx
@@ -2,7 +2,7 @@
 title: FloatingMenu extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-floating-menu.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-floating-menu/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-floating-menu
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/focus.mdx
+++ b/src/content/editor/extensions/functionality/focus.mdx
@@ -2,7 +2,7 @@
 title: Focus extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extensions.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extensions/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extensions
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/fontfamily.mdx
+++ b/src/content/editor/extensions/functionality/fontfamily.mdx
@@ -2,7 +2,7 @@
 title: FontFamily extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-font-family.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-font-family/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-font-family
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/fontsize.mdx
+++ b/src/content/editor/extensions/functionality/fontsize.mdx
@@ -2,7 +2,7 @@
 title: FontSize extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-text-style.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-text-style/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-text-style
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/gapcursor.mdx
+++ b/src/content/editor/extensions/functionality/gapcursor.mdx
@@ -2,7 +2,7 @@
 title: Gapcursor extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extensions.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extensions/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extensions
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/line-height.mdx
+++ b/src/content/editor/extensions/functionality/line-height.mdx
@@ -2,7 +2,7 @@
 title: Line Height extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-text-style.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-text-style/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-text-style
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/listkeymap.mdx
+++ b/src/content/editor/extensions/functionality/listkeymap.mdx
@@ -2,7 +2,7 @@
 title: List Keymap extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-list.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-list/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-list
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/placeholder.mdx
+++ b/src/content/editor/extensions/functionality/placeholder.mdx
@@ -2,7 +2,7 @@
 title: Placeholder extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extensions.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extensions/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extensions
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/selection.mdx
+++ b/src/content/editor/extensions/functionality/selection.mdx
@@ -2,7 +2,7 @@
 title: Selection extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extensions.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extensions/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extensions
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/starterkit.mdx
+++ b/src/content/editor/extensions/functionality/starterkit.mdx
@@ -2,7 +2,7 @@
 title: StarterKit extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/starter-kit.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/starter-kit/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/starter-kit
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/textalign.mdx
+++ b/src/content/editor/extensions/functionality/textalign.mdx
@@ -2,7 +2,7 @@
 title: TextAlign extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-text-align.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-text-align/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-text-align
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/trailing-node.mdx
+++ b/src/content/editor/extensions/functionality/trailing-node.mdx
@@ -2,7 +2,7 @@
 title: Trailing Node extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extensions.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extensions/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extensions
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/typography.mdx
+++ b/src/content/editor/extensions/functionality/typography.mdx
@@ -2,7 +2,7 @@
 title: Typography extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-typography.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-typography/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-typography
     label: Version
   - type: image

--- a/src/content/editor/extensions/functionality/undo-redo.mdx
+++ b/src/content/editor/extensions/functionality/undo-redo.mdx
@@ -2,7 +2,7 @@
 title: Undo/Redo extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extensions.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extensions/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extensions
     label: Version
   - type: image

--- a/src/content/editor/extensions/marks/bold.mdx
+++ b/src/content/editor/extensions/marks/bold.mdx
@@ -2,7 +2,7 @@
 title: Bold extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-bold.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-bold/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-bold
     label: Version
   - type: image

--- a/src/content/editor/extensions/marks/code.mdx
+++ b/src/content/editor/extensions/marks/code.mdx
@@ -2,7 +2,7 @@
 title: Code extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-code.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-code/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-code
     label: Version
   - type: image

--- a/src/content/editor/extensions/marks/highlight.mdx
+++ b/src/content/editor/extensions/marks/highlight.mdx
@@ -2,7 +2,7 @@
 title: Highlight extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-highlight.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-highlight/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-highlight
     label: Version
   - type: image

--- a/src/content/editor/extensions/marks/italic.mdx
+++ b/src/content/editor/extensions/marks/italic.mdx
@@ -2,7 +2,7 @@
 title: Italic extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-italic.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-italic/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-italic
     label: Version
   - type: image

--- a/src/content/editor/extensions/marks/link.mdx
+++ b/src/content/editor/extensions/marks/link.mdx
@@ -2,7 +2,7 @@
 title: Link extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-link.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-link/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-link
     label: Version
   - type: image

--- a/src/content/editor/extensions/marks/strike.mdx
+++ b/src/content/editor/extensions/marks/strike.mdx
@@ -2,7 +2,7 @@
 title: Strike extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-strike.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-strike/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-strike
     label: Version
   - type: image

--- a/src/content/editor/extensions/marks/subscript.mdx
+++ b/src/content/editor/extensions/marks/subscript.mdx
@@ -2,7 +2,7 @@
 title: Subscript extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-subscript.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-subscript/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-subscript
     label: Version
   - type: image

--- a/src/content/editor/extensions/marks/superscript.mdx
+++ b/src/content/editor/extensions/marks/superscript.mdx
@@ -2,7 +2,7 @@
 title: Superscript extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-superscript.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-superscript/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-superscript
     label: Version
   - type: image

--- a/src/content/editor/extensions/marks/text-style.mdx
+++ b/src/content/editor/extensions/marks/text-style.mdx
@@ -2,7 +2,7 @@
 title: TextStyle extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-text-style.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-text-style/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-text-style
     label: Version
   - type: image

--- a/src/content/editor/extensions/marks/underline.mdx
+++ b/src/content/editor/extensions/marks/underline.mdx
@@ -2,7 +2,7 @@
 title: Underline extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-underline.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-underline/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-underline
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/blockquote.mdx
+++ b/src/content/editor/extensions/nodes/blockquote.mdx
@@ -2,7 +2,7 @@
 title: Blockquote extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-blockquote.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-blockquote/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-blockquote
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/bullet-list.mdx
+++ b/src/content/editor/extensions/nodes/bullet-list.mdx
@@ -2,7 +2,7 @@
 title: BulletList extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-list.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-list/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-list
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/code-block-lowlight.mdx
+++ b/src/content/editor/extensions/nodes/code-block-lowlight.mdx
@@ -2,7 +2,7 @@
 title: CodeBlockLowlight extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-code-block-lowlight.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-code-block-lowlight/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-code-block-lowlight
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/code-block.mdx
+++ b/src/content/editor/extensions/nodes/code-block.mdx
@@ -2,7 +2,7 @@
 title: CodeBlock extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-code-block.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-code-block/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-code-block
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/document.mdx
+++ b/src/content/editor/extensions/nodes/document.mdx
@@ -2,7 +2,7 @@
 title: Document extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-document.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-document/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-document
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/hard-break.mdx
+++ b/src/content/editor/extensions/nodes/hard-break.mdx
@@ -2,7 +2,7 @@
 title: HardBreak extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-hard-break.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-hard-break/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-hard-break
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/heading.mdx
+++ b/src/content/editor/extensions/nodes/heading.mdx
@@ -2,7 +2,7 @@
 title: Heading extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-heading.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-heading/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-heading
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/horizontal-rule.mdx
+++ b/src/content/editor/extensions/nodes/horizontal-rule.mdx
@@ -2,7 +2,7 @@
 title: HorizontalRule extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-horizontal-rule.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-horizontal-rule/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-horizontal-rule
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/image.mdx
+++ b/src/content/editor/extensions/nodes/image.mdx
@@ -2,7 +2,7 @@
 title: Image extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-image.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-image/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-image
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/list-item.mdx
+++ b/src/content/editor/extensions/nodes/list-item.mdx
@@ -2,7 +2,7 @@
 title: ListItem extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-list.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-list/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-list
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/mention.mdx
+++ b/src/content/editor/extensions/nodes/mention.mdx
@@ -2,7 +2,7 @@
 title: Mention extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-mention.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-mention/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-mention
     label: Version
   - type: image
@@ -92,10 +92,12 @@ Mention.configure({
 ```
 
 ### deleteTriggerWithBackspace
+
 Toggle whether the suggestion character(s) should also be deleted on deletion of a mention node. Default is `false`.
+
 ```js
 Mention.configure({
-  deleteTriggerWithBackspace: true
+  deleteTriggerWithBackspace: true,
 })
 ```
 

--- a/src/content/editor/extensions/nodes/ordered-list.mdx
+++ b/src/content/editor/extensions/nodes/ordered-list.mdx
@@ -2,7 +2,7 @@
 title: OrderedList extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-list.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-list/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-list
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/paragraph.mdx
+++ b/src/content/editor/extensions/nodes/paragraph.mdx
@@ -2,7 +2,7 @@
 title: Paragraph extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-paragraph.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-paragraph/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-paragraph
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/table-cell.mdx
+++ b/src/content/editor/extensions/nodes/table-cell.mdx
@@ -2,7 +2,7 @@
 title: TableCell extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-table.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-table/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-table
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/table-header.mdx
+++ b/src/content/editor/extensions/nodes/table-header.mdx
@@ -2,7 +2,7 @@
 title: TableHeader extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-table.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-table/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-table
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/table-row.mdx
+++ b/src/content/editor/extensions/nodes/table-row.mdx
@@ -2,7 +2,7 @@
 title: TableRow extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-table.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-table/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-table
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/table.mdx
+++ b/src/content/editor/extensions/nodes/table.mdx
@@ -2,7 +2,7 @@
 title: Table extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-table.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-table/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-table
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/task-item.mdx
+++ b/src/content/editor/extensions/nodes/task-item.mdx
@@ -2,7 +2,7 @@
 title: TaskItem extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-list.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-list/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-list
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/task-list.mdx
+++ b/src/content/editor/extensions/nodes/task-list.mdx
@@ -2,7 +2,7 @@
 title: TaskList extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-list.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-list/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-list
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/text.mdx
+++ b/src/content/editor/extensions/nodes/text.mdx
@@ -2,7 +2,7 @@
 title: Text extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-text.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-text/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-text
     label: Version
   - type: image

--- a/src/content/editor/extensions/nodes/youtube.mdx
+++ b/src/content/editor/extensions/nodes/youtube.mdx
@@ -2,7 +2,7 @@
 title: Youtube extension
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/extension-youtube.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/extension-youtube/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/extension-youtube
     label: Version
   - type: image

--- a/src/content/editor/getting-started/overview.mdx
+++ b/src/content/editor/getting-started/overview.mdx
@@ -97,15 +97,11 @@ Additionally, developers can use the [Awesome Tiptap Repository](https://github.
 
 <CtaBox.Wrapper>
   <CtaBox.Title>Unlock the Editor's full potential</CtaBox.Title>
-  <CtaBox.Description>
-    Integrate advanced text editor features with the Tiptap Collaboration Server.
-  </CtaBox.Description>
+  <CtaBox.Description>Integrate advanced text editor features with the Tiptap Collaboration Server.</CtaBox.Description>
   <CtaBox.List>
     <CtaBox.ListItem>Add comments, document history, and more</CtaBox.ListItem>
     <CtaBox.ListItem>Enable real-time collaboration capabilities</CtaBox.ListItem>
-    <CtaBox.ListItem>
-      Host on your infrastructure or as a managed service hosted by Tiptap
-    </CtaBox.ListItem>
+    <CtaBox.ListItem>Host on your infrastructure or as a managed service hosted by Tiptap</CtaBox.ListItem>
   </CtaBox.List>
   <CtaBox.Actions className="-mx-3">
     <Button className="text-white/80 hover:text-white/100" variant="tertiary" asChild>
@@ -160,9 +156,7 @@ Additionally, developers can use the [Awesome Tiptap Repository](https://github.
       <Link href="/editor/getting-started/style-editor">
         <CardGrid.Subtitle size="sm">Styling</CardGrid.Subtitle>
         <div>
-          <CardGrid.ItemTitle>
-            How to apply styling to the headless Tiptap Editor
-          </CardGrid.ItemTitle>
+          <CardGrid.ItemTitle>How to apply styling to the headless Tiptap Editor</CardGrid.ItemTitle>
         </div>
         <CardGrid.ItemFooter>
           <Tag>Editor</Tag>

--- a/src/content/editor/getting-started/overview.mdx
+++ b/src/content/editor/getting-started/overview.mdx
@@ -2,7 +2,7 @@
 title: Integrate the Tiptap Editor
 tags:
   - type: image
-    src: https://img.shields.io/npm/v/@tiptap/core.svg?label=version
+    src: https://img.shields.io/npm/v/@tiptap/core/beta?label=version
     url: https://www.npmjs.com/package/@tiptap/core
     label: Version
   - type: image
@@ -40,33 +40,49 @@ Tiptap lets you create a fully customizable rich text editor using modular build
 Tiptap works across multiple frameworks, including React, Vue, Svelte, and more. Developers often use the vanilla JavaScript integration to adapt Tiptap to their preferred framework. [Learn how to integrate Tiptap with your framework](/editor/getting-started/install).
 
 <div className="grid gap-20">
-    <Section title="Getting started with a template"
-             description="By default, Tiptap doesn’t include a user interface, giving you complete freedom over its design and behavior. No need for class overwrites or !important. However, if you’d like a quicker start, you can simply integrate our pre-built templates and UI components.">
-        <CardGrid.Wrapper>
-            <CardGrid.Item asChild>
-                <Link href="/ui-components/templates/simple-editor">
-                    <CardGrid.ItemImage asNextImage src={cardCoverSimpleEditorTemplate.src} width={cardCoverSimpleEditorTemplate.width} height={cardCoverSimpleEditorTemplate.height} alt="Image" />
-                    <div>
-                        <CardGrid.ItemTitle>Templates</CardGrid.ItemTitle>
-                        <CardGrid.ItemParagraph>Get started fast with a prebuilt editor that includes commonly used features.</CardGrid.ItemParagraph>
-                    </div>
-                    <CardGrid.ItemFooter>
-                    </CardGrid.ItemFooter>
-                </Link>
-            </CardGrid.Item>
-            <CardGrid.Item asChild>
-                <Link href="/ui-components/components/overview">
-                    <CardGrid.ItemImage asNextImage src={cardCoverUIComponents.src} width={cardCoverUIComponents.width} height={cardCoverUIComponents.height} alt="Image" />
-                    <div>
-                        <CardGrid.ItemTitle>Components</CardGrid.ItemTitle>
-                        <CardGrid.ItemParagraph>Already using Tiptap? Drop in just the pieces you need.</CardGrid.ItemParagraph>
-                    </div>
-                    <CardGrid.ItemFooter>
-                    </CardGrid.ItemFooter>
-                </Link>
-            </CardGrid.Item>
-        </CardGrid.Wrapper>
-    </Section>
+  <Section
+    title="Getting started with a template"
+    description="By default, Tiptap doesn’t include a user interface, giving you complete freedom over its design and behavior. No need for class overwrites or !important. However, if you’d like a quicker start, you can simply integrate our pre-built templates and UI components."
+  >
+    <CardGrid.Wrapper>
+      <CardGrid.Item asChild>
+        <Link href="/ui-components/templates/simple-editor">
+          <CardGrid.ItemImage
+            asNextImage
+            src={cardCoverSimpleEditorTemplate.src}
+            width={cardCoverSimpleEditorTemplate.width}
+            height={cardCoverSimpleEditorTemplate.height}
+            alt="Image"
+          />
+          <div>
+            <CardGrid.ItemTitle>Templates</CardGrid.ItemTitle>
+            <CardGrid.ItemParagraph>
+              Get started fast with a prebuilt editor that includes commonly used features.
+            </CardGrid.ItemParagraph>
+          </div>
+          <CardGrid.ItemFooter></CardGrid.ItemFooter>
+        </Link>
+      </CardGrid.Item>
+      <CardGrid.Item asChild>
+        <Link href="/ui-components/components/overview">
+          <CardGrid.ItemImage
+            asNextImage
+            src={cardCoverUIComponents.src}
+            width={cardCoverUIComponents.width}
+            height={cardCoverUIComponents.height}
+            alt="Image"
+          />
+          <div>
+            <CardGrid.ItemTitle>Components</CardGrid.ItemTitle>
+            <CardGrid.ItemParagraph>
+              Already using Tiptap? Drop in just the pieces you need.
+            </CardGrid.ItemParagraph>
+          </div>
+          <CardGrid.ItemFooter></CardGrid.ItemFooter>
+        </Link>
+      </CardGrid.Item>
+    </CardGrid.Wrapper>
+  </Section>
 </div>
 
 ### Add extensions to your editor


### PR DESCRIPTION
This pull request includes updates to the `.vscode/settings.json` file and various markdown files in the `src/content/editor` directory to modify the default formatter settings and update image URLs to point to beta versions of packages.

These changes ensure that the documentation reflects the latest beta versions of the packages, and the editor settings are adjusted for `mdx` files.