### PR TITLE
adjust docsearch to exclude code

### DIFF
--- a/docsearch.config.json
+++ b/docsearch.config.json
@@ -17,13 +17,10 @@
       "lvl4": "h4",
       "lvl5": "h5",
       "lvl6": "h6",
-      "text": "p, li, pre, td",
-      "code": {
-        "selector": "pre > code",
-        "global": true
-      }
+      "text": "p, li, td"
     }
   },
+  "selectors_exclude": ["pre"],
   "strip_chars": " .,;:#",
   "custom_settings": {
     "separatorsToIndex": "_",


### PR DESCRIPTION
This pull request includes changes to the `docsearch.config.json` file to refine the indexing configuration. The most important changes include updating the text selectors and excluding certain elements from indexing.

Indexing configuration updates:

* [`docsearch.config.json`](diffhunk://#diff-132024eaa414911c7c5e5296e5ef9cfe30f2b3c93c78373adc6bd0d26ea6c8e1L20-R23): Removed the `code` selector and updated the `text` selector to exclude `pre` elements.
* [`docsearch.config.json`](diffhunk://#diff-132024eaa414911c7c5e5296e5ef9cfe30f2b3c93c78373adc6bd0d26ea6c8e1L20-R23): Added a new `selectors_exclude` entry to exclude `pre` elements from indexing.