### PR TITLE
adjust typo for simple editor name and clean up temp doc

### DIFF
--- a/src/content/ui-components/templates/simple-editor.mdx
+++ b/src/content/ui-components/templates/simple-editor.mdx
@@ -42,13 +42,8 @@ The Simple Editor Template is a fully working setup for the Tiptap editor. It in
 Add the Simple Editor Template to your project using the Tiptap CLI (for Vite or Next.js):
 
 ```bash
-npx @tiptap/cli add simple
+npx @tiptap/cli add simple-editor
 ```
-
-When you initialize the simple template, the CLI creates the template file in the app router folder: `src/app/simple/page.tsx`
-
-### Manual Integration
-For frameworks other than Vite or Next.js, add the template manually from the [open-source repository](https://github.com/ueberdosis/tiptap-ui-components/tree/main/apps/web/src/components/tiptap-templates/simple).
 
 ### Include Global Styles
 


### PR DESCRIPTION
> When you initialize the simple template, the CLI creates the template file in the app router folder: `src/app/simple/page.tsx`

This should not be mentioned, as it is specific to Next.js only.

> ### Manual Integration
> For frameworks other than Vite or Next.js, add the template manually from the [open-source repository](https://github.com/ueberdosis/tiptap-ui-components/tree/main/apps/web/src/components/tiptap-templates/simple).

No longer needed, as in the new CLI, all frameworks are now supported.