### PR TITLE
keep consistent markup of code-like content

### DIFF
--- a/src/content/ui-components/templates/simple-editor.mdx
+++ b/src/content/ui-components/templates/simple-editor.mdx
@@ -79,13 +79,13 @@ Ensure the following open source packages and extensions are present to make ful
 npm i @tiptap/react @tiptap/starter-kit @tiptap/extension-image @tiptap/extension-task-item @tiptap/extension-task-list @tiptap/extension-text-align @tiptap/extension-typography
 ```
 
-- @tiptap/react
-- @tiptap/starter-kit
-- @tiptap/extension-image
-- @tiptap/extension-task-item
-- @tiptap/extension-task-list
-- @tiptap/extension-text-align
-- @tiptap/extension-typography
+- `@tiptap/react`
+- `@tiptap/starter-kit`
+- `@tiptap/extension-image`
+- `@tiptap/extension-task-item`
+- `@tiptap/extension-task-list`
+- `@tiptap/extension-text-align`
+- `@tiptap/extension-typography`
 
 ## Features
 


### PR DESCRIPTION
To keep the markup consistent I marked the package names as code