### PR TITLE
Removed an unnecessary semicolon from `extension-list-keymap` docs

### DIFF
--- a/src/content/editor/extensions/functionality/listkeymap.mdx
+++ b/src/content/editor/extensions/functionality/listkeymap.mdx
@@ -42,7 +42,7 @@ A array of list items and their parent wrapper node types.
 Default:
 
 ```js
-;[
+[
   {
     itemName: 'listItem',
     wrapperNames: ['bulletList', 'orderedList'],


### PR DESCRIPTION
The following PR removes an unnecessary semicolon from `extension-list-keymap` documentation.