### PR TITLE
Added docs for resizable image nodes

### DIFF
--- a/src/content/editor/extensions/nodes/image.mdx
+++ b/src/content/editor/extensions/nodes/image.mdx
@@ -80,6 +80,29 @@ Image.configure({
 })
 ```
 
+### resize
+Adds resizing to image nodes. Resizeable directions and the minimum size of images can be configured.
+
+When set to `false`, the resize handles are removed.
+
+```js
+Image.configure({
+  resize: {
+    directions: ['left', 'right', 'bottom', 'top', 'top-left', 'top-right', 'bottom-left', 'bottom-right'],
+    minWidth: 150,
+    minHeight: 150,
+  }
+})
+
+// or
+
+Image.configure({
+  resize: false,
+})
+```
+
+Resize is disabled by default.
+
 ## Commands
 
 ### setImage()


### PR DESCRIPTION
Docs of https://github.com/ueberdosis/tiptap/pull/6285

This pull request adds a new feature to the `Image` node configuration in the `src/content/editor/extensions/nodes/image.mdx` file, enabling image resizing with customizable options.

### New Feature: Image Resizing

* Added a `resize` configuration option to the `Image` node, allowing users to enable resizing for images. This includes specifying resizeable directions (`['left', 'right', 'bottom', 'top', 'top-left', 'top-right', 'bottom-left', 'bottom-right']`) and setting minimum dimensions (`minWidth` and `minHeight`). The feature can also be disabled entirely by setting `resize` to `false`. Resize is disabled by default.