### PR TITLE
change back to @hocuspocus/provider, as v3 required Tiptap v3, which …

### DIFF
--- a/src/content/collaboration/getting-started/install.mdx
+++ b/src/content/collaboration/getting-started/install.mdx
@@ -96,21 +96,10 @@ Your editor is now almost prepared for collaborative editing!
 
 ### Connect to your Document server
 
-For collaborative functionality, install the `@tiptap-cloud/provider` package:
-
-<Callout title="Set up private registry" variant="hint">
-Note that you need to follow the instructions [here](https://cloud.tiptap.dev/pro-extensions) to set up access to the private registry.
-Additionally, you may need to add this line to your .npmrc:
-
-```
-@tiptap-cloud:registry=https://registry.tiptap.dev/
-```
-
-Note that `@tiptap-cloud/provider` requires Tiptap v3, which is currently in beta. If you want to use Tiptap v2, please use `@hocuspocus/provider^2.15.2` instead of `@tiptap-cloud/provider`.
-</Callout>
+For collaborative functionality, install the `@hocuspocus/provider` (make sure to stay on provider v2, as v3 required Tiptap v3, which is still in beta) package:
 
 ```bash
-npm install @tiptap-cloud/provider
+npm install @hocuspocus/provider@^2.15.2
 ```
 
 Next, configure the provider in your index.jsx file with your server details:

--- a/src/content/collaboration/provider/integration.mdx
+++ b/src/content/collaboration/provider/integration.mdx
@@ -16,21 +16,10 @@ The `TiptapCollabProvider` adds advanced features tailored for collaborative env
 
 ## Set up the provider
 
-First, install the provider package in your project using:
-
-<Callout title="Set up private registry" variant="hint">
-Note that you need to follow the instructions [here](https://cloud.tiptap.dev/pro-extensions) to set up access to the private registry.
-Additionally, you may need to add this line to your .npmrc:
-
-```
-@tiptap-cloud:registry=https://registry.tiptap.dev/
-```
-
-Note that `@tiptap-cloud/provider` requires Tiptap v3, which is currently in beta. If you want to use Tiptap v2, please use `@hocuspocus/provider^2.15.2` instead of `@tiptap-cloud/provider`.
-</Callout>
+First, install the provider package (make sure to stay on provider v2, as v3 required Tiptap v3, which is still in beta) in your project using:
 
 ```bash
-npm install @tiptap-cloud/provider
+npm install @hocuspocus/provider@^2.15.2
 ```
 
 For a basic setup, connect to the Collaboration backend by specifying the document's name, your app's ID (for cloud setups), or the base URL (for on-premises), along with your JWT.


### PR DESCRIPTION
…is still beta