### PR TITLE
Added upgrade guide for shouldRerenderOnTransaction option

### DIFF
--- a/src/content/guides/upgrade-tiptap-v2.mdx
+++ b/src/content/guides/upgrade-tiptap-v2.mdx
@@ -144,7 +144,7 @@ The `@tiptap/react` Editor configuration now includes `shouldRerenderOnTransacti
 
 Previously (pre-3.0.0), the Editor rerendered on every transaction-induced state update, facilitating continuous editor object tracking but potentially impacting rendering performance.
 
-Tiptap 3.0.0 enables `shouldRerenderOnTransaction` by default. Disable it by setting `shouldRerenderOnTransaction: false` in the editor configuration.
+`shouldRerenderOnTransaction` is disabled by default. Enable it by setting `shouldRerenderOnTransaction: true` in the editor configuration.
 
 Post-upgrade, UI elements relying on the Editor's state might become unresponsive. Solutions include disabling the option (potential performance implications) or implementing manual state tracking, as demonstrated:
 
@@ -162,6 +162,17 @@ function MyEditor() {
     },
   });
 }
+```
+
+You can also use `useEditorState` to extract either the whole state or select specific values to extract.
+
+```js
+const { currentSelection } = useEditorState({
+  editor,
+  selector: (snapshot) => {
+    return { currentSelection: snapshot.editor.state.selection }
+  },
+})
 ```
 
 This allows explicit state extraction and management for dependent UI logic.

--- a/src/content/guides/upgrade-tiptap-v2.mdx
+++ b/src/content/guides/upgrade-tiptap-v2.mdx
@@ -138,6 +138,34 @@ new Editor({
 })
 ```
 
+### Introducing `shouldRerenderOnTransaction`
+
+The `@tiptap/react` Editor configuration now includes `shouldRerenderOnTransaction`, controlling component rerendering.
+
+Previously (pre-3.0.0), the Editor rerendered on every transaction-induced state update, facilitating continuous editor object tracking but potentially impacting rendering performance.
+
+Tiptap 3.0.0 enables `shouldRerenderOnTransaction` by default. Disable it by setting `shouldRerenderOnTransaction: false` in the editor configuration.
+
+Post-upgrade, UI elements relying on the Editor's state might become unresponsive. Solutions include disabling the option (potential performance implications) or implementing manual state tracking, as demonstrated:
+
+```js
+function MyEditor() {
+  const [selection, setSelection] = useState({ from: 0, to: 0 });
+
+  const editor = useEditor({
+    // Editor configuration
+    onTransaction({ transaction }) {
+      setSelection({
+        from: transaction.selection.from,
+        to: transaction.selection.to,
+      });
+    },
+  });
+}
+```
+
+This allows explicit state extraction and management for dependent UI logic.
+
 ### Command Changes
 
 - `clearContent` and `setContent` now emit updates by default


### PR DESCRIPTION
This pull request updates the Tiptap upgrade guide to include information about a new configuration option introduced in Tiptap 3.0.0. It explains the purpose and usage of the `shouldRerenderOnTransaction` option and provides guidance for handling potential issues after upgrading.

### Documentation update:

* [`src/content/guides/upgrade-tiptap-v2.mdx`](diffhunk://#diff-38abf516880a1231a40c98f4b07771372af099ecf6e288a571d09f927960042fR141-R168): Added a new section introducing the `shouldRerenderOnTransaction` option in the Tiptap Editor configuration. The section explains how this option affects component rerendering, its default behavior in Tiptap 3.0.0, and solutions for managing UI responsiveness, including an example of manual state tracking.