### PR TITLE
Docs: Fix typo in DetailsSummary

### DIFF
--- a/src/content/editor/extensions/nodes/details-summary.mdx
+++ b/src/content/editor/extensions/nodes/details-summary.mdx
@@ -40,7 +40,7 @@ npm install @tiptap-pro/extension-details
 import { Details, DetailsSummary, DetailsContent } from '@tiptap-pro/extension-details'
 
 const editor = new Editor({
-  extensions: [Details, DetailSummary, DetailsContent],
+  extensions: [Details, DetailsSummary, DetailsContent],
 })
 ```
 


### PR DESCRIPTION
Small typo in the docs. Had to add an extra s for `DetailsSummary`