### PR TITLE
fix: [V3] command was changed from npm to pnpm

### DIFF
--- a/src/content/resources/contributing.mdx
+++ b/src/content/resources/contributing.mdx
@@ -25,28 +25,28 @@ Make sure to open an issue and outline your idea first. We’ll get back to you 
 
 ## Set up the development environment
 
-It’s not too hard to tinker around with the official repository. You’ll need [Git](https://github.com/git-guides/install-git), [Node and NPM](https://nodejs.org/en/download/) installed. Here is what you need to do then:
+It’s not too hard to tinker around with the official repository. You’ll need [Git](https://github.com/git-guides/install-git), [Node](https://nodejs.org/en/download/) and [pnpm](https://pnpm.io/installation) installed. Here is what you need to do then:
 
 1. Copy the code to your local machine: `$ git clone git@github.com:ueberdosis/tiptap.git`
-2. Install dependencies: `$ npm install`
-3. Start the development environment: `$ npm run start`
+2. Install dependencies: `$ pnpm install`
+3. Start the development environment: `$ pnpm run start`
 4. Open http://localhost:3000 in your favorite browser.
 5. Start playing around!
 
 ## Our code style
 
-There is an eslint config that ensures a consistent code style. To check for errors, run `$ npm run lint`. That’ll be checked when you send a pull request, too. Make sure it’s passing, before sending a pull request.
+There is an eslint config that ensures a consistent code style. To check for errors, run `$ pnpm run lint`. That’ll be checked when you send a pull request, too. Make sure it’s passing, before sending a pull request.
 
 ## Test for errors
 
-Your pull request will automatically execute all our existing tests. Make sure that they all pass, before sending a pull request. Run all tests locally with `$ npm run test` or run single tests (e. g. when writing new ones) with `$ npm run test:open`.
+Your pull request will automatically execute all our existing tests. Make sure that they all pass, before sending a pull request. Run all tests locally with `$ pnpm run test` or run single tests (e. g. when writing new ones) with `$ pnpm run test:open`.
 
 ## Create your own extensions
 
 If you want to create and maintain your own extensions, you can use your `create-tiptap-extension` CLI tool. It will create a new extension boilerplate with all necessary files and the build process. It's as easy as running
 
 ```bash
-npm init tiptap-extension
+pnpm init tiptap-extension
 ```
 
 If you want to let us know about your extension you can give us a hint on [X](https://x.com/tiptap_editor) or [Discord](https://tiptap.dev/discord).


### PR DESCRIPTION
# About
I checked the tiptap repo package.json and found that pnpm was used instead of npm, so I changed the command on the Contributing page to pnpm