### PR TITLE
bug: adjust preserve-images example to v2 import

### DIFF
--- a/src/content/conversion/import-export/docx/preserve-images.mdx
+++ b/src/content/conversion/import-export/docx/preserve-images.mdx
@@ -104,7 +104,19 @@ This example shows a simple server implementation that accepts image uploads & u
  const app = new Hono() as Hono<any>
 
  app.post('/upload', async (c) => {
+   // if you are using v2 import, you need this
    const file = await c.req.blob()
+
+   const filename = c.req.header('File-Name')
+   const fileType = c.req.header('Content-Type')
+   // end
+   // if you are using v1 import, you need this
+   const body = await c.req.parseBody()
+   const file = body['file']
+
+   const filename = file.name
+   const fileType = file.type
+   // end
 
    if (!file) {
      return c.json({ error: 'No file uploaded' }, 400)
@@ -115,9 +127,9 @@ This example shows a simple server implementation that accepts image uploads & u
        client: s3,
        params: {
          Bucket: AWS_S3_BUCKET,
-         Key: c.req.header('File-Name'),
+         Key: filename,
          Body: file,
-         ContentType: c.req.header('Content-Type'),
+         ContentType: fileType,
        },
      }).done()
 
@@ -152,6 +164,21 @@ Here is another implementation using bun with no dependencies:
 
      // Handle file uploads on the /upload endpoint
      if (url.pathname === '/upload') {
+
+       // if you are using v2 import, you need this
+       const file = await req.blob()
+
+       const filename = req.headers.get('File-Name')!
+       const fileType = req.headers.get('Content-Type')!
+       // end
+       // if you are using v1 import, you need this
+       const body = await req.formData()
+       const file = body.get('file')
+
+       const filename = file.name
+       const fileType = file.type
+       // end
+
        const file = await req.blob()
 
        if (!file) {
@@ -165,7 +192,7 @@ Here is another implementation using bun with no dependencies:
 
        try {
          // The file already has a name and type, so we can use it directly
-         const s3File = s3Client.file(req.headers.get('File-Name')!, { type: req.headers.get('Content-Type')! })
+         const s3File = s3Client.file(filename, { type: fileType })
          // Write the file to S3
          await s3File.write(file)
 

--- a/src/content/conversion/import-export/docx/preserve-images.mdx
+++ b/src/content/conversion/import-export/docx/preserve-images.mdx
@@ -104,10 +104,9 @@ This example shows a simple server implementation that accepts image uploads & u
  const app = new Hono() as Hono<any>
 
  app.post('/upload', async (c) => {
-   const body = await c.req.parseBody()
-   const file = body['file']
+   const file = await c.req.blob()
 
-   if (!file || typeof file === 'string') {
+   if (!file) {
      return c.json({ error: 'No file uploaded' }, 400)
    }
 
@@ -116,10 +115,9 @@ This example shows a simple server implementation that accepts image uploads & u
        client: s3,
        params: {
          Bucket: AWS_S3_BUCKET,
-         // file.name is just current timestamp & file extension
-         Key: file.name,
+         Key: c.req.header('File-Name'),
          Body: file,
-         ContentType: file.type,
+         ContentType: c.req.header('Content-Type'),
        },
      }).done()
 
@@ -154,10 +152,9 @@ Here is another implementation using bun with no dependencies:
 
      // Handle file uploads on the /upload endpoint
      if (url.pathname === '/upload') {
-       const formdata = await req.formData()
-       const file = formdata.get('file')
+       const file = await req.blob()
 
-       if (!file || typeof file === 'string') {
+       if (!file) {
          return new Response(JSON.stringify({ error: 'No file uploaded' }), {
            status: 400,
            headers: {
@@ -168,7 +165,7 @@ Here is another implementation using bun with no dependencies:
 
        try {
          // The file already has a name and type, so we can use it directly
-         const s3File = s3Client.file(file.name, { type: file.type })
+         const s3File = s3Client.file(req.headers.get('File-Name')!, { type: req.headers.get('Content-Type')! })
          // Write the file to S3
          await s3File.write(file)
 


### PR DESCRIPTION
v2 import doesnt use formdata but just sends the raw file content in the request body.