### PR TITLE
Fix mention of the wrong import package

### DIFF
--- a/src/content/conversion/import-export/docx/custom-node-conversion.mdx
+++ b/src/content/conversion/import-export/docx/custom-node-conversion.mdx
@@ -239,7 +239,7 @@ Import.configure({
 }),
 ```
 
-The latest version of the `@tiptap-pro/extension-import` has available the `promisemirrorNodes` configuration option. This option allows you to map custom nodes from the DOCX to your Tiptap schema. In the example above, we are mapping the `Hintbox` custom node from the DOCX to the `hintbox` custom node in our Tiptap schema. By doing so, whenever the DOCX contains a `Hintbox` custom node, it will be converted to a `hintbox` node in Tiptap when imported.
+The latest version of the `@tiptap-pro/extension-import-docx` has available the `promisemirrorNodes` configuration option. This option allows you to map custom nodes from the DOCX to your Tiptap schema. In the example above, we are mapping the `Hintbox` custom node from the DOCX to the `hintbox` custom node in our Tiptap schema. By doing so, whenever the DOCX contains a `Hintbox` custom node, it will be converted to a `hintbox` node in Tiptap when imported.
 
 <Callout title='DOCX, "prosemirrorNodes" and "prosemirrorMarks"' variant="info">
   Please note that the `promisemirrorNodes` and `prosemirrorMarks` options will only work if you're importing a `.docx` file. If you're importing another type of file, eg: an `.odt` file, the `/import` endpoint will be used instead of the `/import-docx` endpoint, and the `promisemirrorNodes` and `prosemirrorMarks` options will not be available, and therefore you'd need to rely on the [custom node and mark mapping API](/conversion/import-export/docx/rest-api#custom-node-and-mark-mapping) for those endpoints.


### PR DESCRIPTION
Fix mentioning the old import extension instead of the new docx import extension.