### PR TITLE
Fix JSON response handling in code examples

### DIFF
--- a/src/content/content-ai/capabilities/generation/custom-llms.mdx
+++ b/src/content/content-ai/capabilities/generation/custom-llms.mdx
@@ -81,7 +81,7 @@ Ai.configure({
     // Decide to use custom endpoint
     if (action === 'rephrase') {
       const response = await fetch('https://dummyjson.com/quotes/random')
-      const json = await response?.json()
+      const json = await response.json()
 
       if (!response.ok) {
         throw new Error(`${response.status} ${json?.message}`)
@@ -157,7 +157,7 @@ const editor = new Editor{
       }) => {
         if (action === 'customCommand') {
           const response = await fetch('https://dummyjson.com/quotes/random')
-          const json = await response?.json()
+          const json = await response.json()
 
           if (!response.ok) {
             throw new Error(`${response.status} ${json?.message}`)
@@ -219,13 +219,13 @@ Ai.configure({
     }
 
     const response = await fetch(`<YOUR_STREAMED_BACKEND_ENDPOINT>`, fetchOptions)
-    const json = await response?.json()
 
     if (!response.ok) {
+      const json = await response.json()
       throw new Error(`${json?.error} ${json?.message}`)
     }
 
-    return response?.body
+    return response.body
   },
 })
 ```

--- a/src/content/content-ai/capabilities/generation/text-generation/stream.mdx
+++ b/src/content/content-ai/capabilities/generation/text-generation/stream.mdx
@@ -10,15 +10,18 @@ import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 
 <Requirements>
-    <RequirementItem label="1. Activate trial or subscribe">
-        Start a free [trial in your Account](https://cloud.tiptap.dev/v2/billing) or subscribe to a [Tiptap plan](https://cloud.tiptap.dev/v2/billing).
-    </RequirementItem>
-    <RequirementItem label="2. Integrate an AI provider">
-        Configure OpenAI in your [AI settings](https://cloud.tiptap.dev/v2/cloud/ai) or review the [Custom LLM guides](/content-ai/capabilities/generation/custom-llms).
-    </RequirementItem>
-    <RequirementItem label="3. Install from private registry">
-        To install the frontend extensions, authenticate to Tiptap’s private npm registry by following the [setup guide](/guides/pro-extensions).
-    </RequirementItem>
+  <RequirementItem label="1. Activate trial or subscribe">
+    Start a free [trial in your Account](https://cloud.tiptap.dev/v2/billing) or subscribe to a
+    [Tiptap plan](https://cloud.tiptap.dev/v2/billing).
+  </RequirementItem>
+  <RequirementItem label="2. Integrate an AI provider">
+    Configure OpenAI in your [AI settings](https://cloud.tiptap.dev/v2/cloud/ai) or review the
+    [Custom LLM guides](/content-ai/capabilities/generation/custom-llms).
+  </RequirementItem>
+  <RequirementItem label="3. Install from private registry">
+    To install the frontend extensions, authenticate to Tiptap’s private npm registry by following
+    the [setup guide](/guides/pro-extensions).
+  </RequirementItem>
 </Requirements>
 
 The `streamContent` command is a low-level API to stream content into the editor. It supports both appending content and replacing a specified range of content. This command is useful when you need to stream something like an LLM model response into the editor.


### PR DESCRIPTION
Cherry-pick of #209

* fix: do not convert the response to json in the code example if the response format is not json

* fix: remove unnecessary optional chaining operators because response is never null or undefined.

* fix: convert response to json when it is json

* fix: remove line break