### PR TITLE
fix code-block.mdx changed references to details to CodeBlock

### DIFF
--- a/src/content/editor/extensions/nodes/code-block.mdx
+++ b/src/content/editor/extensions/nodes/code-block.mdx
@@ -45,10 +45,10 @@ npm install @tiptap/extension-code-block@next
 ## Usage
 
 ```js
-import { Details, DetailsSummary, DetailsContent } from '@tiptap-pro/extension-details'
+import CodeBlock from '@tiptap/extension-code-block'
 
 const editor = new Editor({
-  extensions: [Details, DetailSummary, DetailsContent],
+  extensions: [CodeBlock],
 })
 ```
 


### PR DESCRIPTION
Looks to be some docs that got copied and never got replaced.