### PR TITLE
Rename history property to undoRedo

### DIFF
--- a/src/content/collaboration/getting-started/install.mdx
+++ b/src/content/collaboration/getting-started/install.mdx
@@ -243,7 +243,7 @@ This action is only required if your project includes the Tiptap [StarterKit](/e
 const editor = useEditor({
   extensions: [
     StarterKit.configure({
-      undoRedo: false, // Disables default Undo/Redo exension to use Collaboration's history management
+      undoRedo: false, // Disables default Undo/Redo extension to use Collaboration's history management
     }),
   ],
 })

--- a/src/content/collaboration/getting-started/install.mdx
+++ b/src/content/collaboration/getting-started/install.mdx
@@ -235,7 +235,7 @@ This ensures the initial content is set only once. To test with new initial cont
 
 ## Disable Default Undo/Redo
 
-If you're integrating collaboration into an editor **other than the one provided in this demo**, you may need to disable the default history function of your Editor. This is necessary to avoid conflicts with the collaborative history management: You wouldn't want to revert someone else's changes.
+If you're integrating collaboration into an editor **other than the one provided in this demo**, you may need to disable the default Undo/Redo function of your Editor. This is necessary to avoid conflicts with the collaborative history management: You wouldn't want to revert someone else's changes.
 
 This action is only required if your project includes the Tiptap [StarterKit](/editor/extensions/functionality/starterkit) or [Undo/Redo](/editor/extensions/functionality/undo-redo) extension.
 
@@ -243,7 +243,7 @@ This action is only required if your project includes the Tiptap [StarterKit](/e
 const editor = useEditor({
   extensions: [
     StarterKit.configure({
-      history: false, // Disables default history to use Collaboration's history management
+      undoRedo: false, // Disables default Undo/Redo exension to use Collaboration's history management
     }),
   ],
 })

--- a/src/content/editor/extensions/functionality/starterkit.mdx
+++ b/src/content/editor/extensions/functionality/starterkit.mdx
@@ -95,7 +95,7 @@ const editor = new Editor({
   extensions: [
     StarterKit.configure({
       // Disable an included extension
-      history: false,
+      undoRedo: false,
 
       // Configure an included extension
       heading: {

--- a/src/content/editor/getting-started/configure.mdx
+++ b/src/content/editor/getting-started/configure.mdx
@@ -123,7 +123,7 @@ import StarterKit from '@tiptap/starter-kit'
 new Editor({
   extensions: [
     StarterKit.configure({
-      history: false,
+      undoRedo: false,
     }),
   ],
 })


### PR DESCRIPTION
In the StarterKit extension, rename history config property to undoRedo

This is because the History extension was renamed to UndoRedo, and the property was renamed in the StarterKit. But we forgot to update it in the docs 😬 