### PR TITLE
Replace hocuspocus provider with tiptap provider library

### DIFF
--- a/src/content/collaboration/getting-started/install.mdx
+++ b/src/content/collaboration/getting-started/install.mdx
@@ -140,7 +140,7 @@ import * as Y from 'yjs'
 
 // Importing the provider and useEffect
 import { useEffect } from 'react'
-import { TiptapCollabProvider } from '@hocuspocus/provider'
+import { TiptapCollabProvider } from '@tiptap-cloud/provider'
 
 const doc = new Y.Doc()
 
@@ -199,7 +199,7 @@ import * as Y from 'yjs'
 import Collaboration from '@tiptap/extension-collaboration'
 import { useEffect } from 'react'
 
-import { TiptapCollabProvider } from '@hocuspocus/provider'
+import { TiptapCollabProvider } from '@tiptap-cloud/provider'
 
 const doc = new Y.Doc()
 

--- a/src/content/collaboration/getting-started/install.mdx
+++ b/src/content/collaboration/getting-started/install.mdx
@@ -96,10 +96,20 @@ Your editor is now almost prepared for collaborative editing!
 
 ### Connect to your Document server
 
-For collaborative functionality, install the `@hocuspocus/provider` package:
+For collaborative functionality, install the `@tiptap-cloud/provider` package:
+
+<Callout title="Set up private registry" variant="hint">
+Note that you need to follow the instructions [here](https://cloud.tiptap.dev/pro-extensions) to set up access to the private registry.
+Additionally, you may need to add this line to your .npmrc:
+
+```
+@tiptap-cloud:registry=https://registry.tiptap.dev/
+```
+
+</Callout>
 
 ```bash
-npm install @hocuspocus/provider@next
+npm install @tiptap-cloud/provider@next
 ```
 
 Next, configure the provider in your index.jsx file with your server details:

--- a/src/content/collaboration/provider/integration.mdx
+++ b/src/content/collaboration/provider/integration.mdx
@@ -18,8 +18,18 @@ The `TiptapCollabProvider` adds advanced features tailored for collaborative env
 
 First, install the provider package in your project using:
 
+<Callout title="Set up private registry" variant="hint">
+Note that you need to follow the instructions [here](https://cloud.tiptap.dev/pro-extensions) to set up access to the private registry.
+Additionally, you may need to add this line to your .npmrc:
+
+```
+@tiptap-cloud:registry=https://registry.tiptap.dev/
+```
+
+</Callout>
+
 ```bash
-npm install @hocuspocus/provider@next
+npm install @tiptap-cloud/provider@next
 ```
 
 For a basic setup, connect to the Collaboration backend by specifying the document's name, your app's ID (for cloud setups), or the base URL (for on-premises), along with your JWT.

--- a/src/content/ui-components/components/thread.mdx
+++ b/src/content/ui-components/components/thread.mdx
@@ -80,4 +80,4 @@ Open source feature(s)
 
 Cloud feature(s)
 
-- `@hocuspocus/provider`
+- `@tiptap-cloud/provider`


### PR DESCRIPTION
Replace hocuspocus provider import with tiptap provider library 

Cherry-picks #182 and reviews the docs for any incorrect appearances of @hocuspocus/provider import