### PR TITLE
Add documentation for emitContentError property

### DIFF
--- a/src/content/editor/core-concepts/schema.mdx
+++ b/src/content/editor/core-concepts/schema.mdx
@@ -446,7 +446,7 @@ If you want to listen to the `contentError` event without enabling content check
 ```jsx
 new Editor({
   emitContentError: true,
-  ...options,
+  ...options, // Additional editor options
 })
 ```
 

--- a/src/content/editor/core-concepts/schema.mdx
+++ b/src/content/editor/core-concepts/schema.mdx
@@ -447,7 +447,7 @@ If you want to listen to the `contentError` event without enabling content check
 new Editor({
   enableContentCheck: false,
   emitContentError: true,
-  ...options, // Additional editor options
+  ...options,
 })
 ```
 

--- a/src/content/editor/core-concepts/schema.mdx
+++ b/src/content/editor/core-concepts/schema.mdx
@@ -439,6 +439,19 @@ editor.on('contentError', ({ editor, error, disableCollaboration }) => {
 
 For more implementation examples, refer to the [events](/editor/api/events) section.
 
+### Listen to the contentError event without enabling content checking
+
+If you want to listen to the `contentError` event without enabling content checking, set `emitContentError` to `true` when initializing your Tiptap editor:
+
+```jsx
+new Editor({
+  emitContentError: true,
+  ...options,
+})
+```
+
+This setting allows you to have invalid content in your editor, but still be notified when the content is invalid.
+
 ### Recommended Handling
 
 How you handle schema errors will be specific to your application and requirements but, here are our suggestions:

--- a/src/content/editor/core-concepts/schema.mdx
+++ b/src/content/editor/core-concepts/schema.mdx
@@ -445,6 +445,7 @@ If you want to listen to the `contentError` event without enabling content check
 
 ```jsx
 new Editor({
+  enableContentCheck: false,
   emitContentError: true,
   ...options,
 })

--- a/src/content/guides/invalid-schema.mdx
+++ b/src/content/guides/invalid-schema.mdx
@@ -72,6 +72,7 @@ If you want to listen to the `contentError` event without enabling content check
 
 ```jsx
 new Editor({
+  enableContentCheck: false,
   emitContentError: true,
   // ... other options
 })

--- a/src/content/guides/invalid-schema.mdx
+++ b/src/content/guides/invalid-schema.mdx
@@ -66,6 +66,19 @@ editor.on('contentError', ({ editor, error, disableCollaboration }) => {
 })
 ```
 
+## Listen to the contentError event without enabling content checking
+
+If you want to listen to the `contentError` event without enabling content checking, set `emitContentError` to `true` when initializing your Tiptap editor:
+
+```jsx
+new Editor({
+  emitContentError: true,
+  // ... other options
+})
+```
+
+This setting allows you to have invalid content in your editor, but still be notified when the content is invalid.
+
 ## A note on content types
 
 It's important to note that Tiptap's content checking is 100% accurate for JSON content types. However, when working with HTML content, there may be some limitations. While Tiptap does its best to alert on missing nodes, certain mark-related issues might be missed in some situations.


### PR DESCRIPTION
Introduce documentation on how to use the `emitContentError` property to listen for content errors without enabling content checking in the Tiptap editor.

Docs of PR [#6411](https://github.com/ueberdosis/tiptap/pull/6411)