### PR TITLE
fix[docs]: wrong import mentioned in extension-comments

### DIFF
--- a/src/content/comments/getting-started/install.mdx
+++ b/src/content/comments/getting-started/install.mdx
@@ -43,7 +43,7 @@ After installing the `comments` extension via npm or any other package manager, 
 The Comments extension consists of multiple components, including nodes and plugins. To include all the required features, use the `CommentsKit` extension.
 
 ```js
-import { ThreadsKit } from '@tiptap-pro/extension-comments'
+import { CommentsKit } from '@tiptap-pro/extension-comments'
 
 const editor = new Editor({
   ...


### PR DESCRIPTION
Please check Below link:
[Link](https://tiptap.dev/docs/comments/getting-started/install)
<img width="766" alt="Screenshot 2025-06-18 at 10 56 05 PM" src="https://github.com/user-attachments/assets/57d3dff7-3e3f-449c-84d7-db9720af264c" />
