### PR TITLE
Selection awareness in AI Agent

### DIFF
--- a/src/content/content-ai/capabilities/agent/features/add-context.mdx
+++ b/src/content/content-ai/capabilities/agent/features/add-context.mdx
@@ -27,4 +27,10 @@ the prompt input as a Tiptap text editor, and installing the [Mention extension]
 
 Sending the editor selection as context to the AI Agent can help it understand the user's request and make precise edits to the selection only.
 
-This feature is in our roadmap and we plan to implement it soon.
+To let the AI model know about the selected content, set the `addSelection` option to `true`. This will send the selected content as context to the AI Agent.
+
+```ts
+provider.addUserMessage('Summarize the selected document', {
+  addSelection: true, // Defaults to false
+})
+```


### PR DESCRIPTION
Docs of PR https://github.com/ueberdosis/tiptap-pro/pull/337

Add an addSelection option to the addUserMessage method of the AI Agent provider. This informs the LLM about the selected content of the editor, helping it locate the selected content and answer questions about it, or edit its contents in a focused way.