### PR TITLE
Fix description of chunk size

### DIFF
--- a/src/content/content-ai/capabilities/agent/features/reading-the-document.mdx
+++ b/src/content/content-ai/capabilities/agent/features/reading-the-document.mdx
@@ -14,7 +14,9 @@ The AI Agent reads the document in chunks to handle documents of any size effici
 
 ## Chunking mechanism
 
-By default, the document is split into chunks of approximately 8000 tokens each, while preserving HTML structure. The AI Agent maintains a pointer to the current chunk and can navigate through the document using specific tools.
+By default, the document is split into chunks of approximately 32000 characters each, while preserving HTML structure. The AI Agent reads one chunk at a time and can navigate to the next or previous chunk as needed.
+
+Customize the amount of characters per chunk by setting the `chunkSize` option:
 
 ```tsx
 const provider = new AiAgentProvider({

--- a/src/content/content-ai/capabilities/agent/overview.mdx
+++ b/src/content/content-ai/capabilities/agent/overview.mdx
@@ -27,7 +27,7 @@ import { Requirements, RequirementItem } from '@/components/Requirements'
   </RequirementItem>
 </Requirements>
 
-Tiptap Content AI enables you to build AI Agents that edit rich text documents - from simple chatbot assistants to complex document editing workflows.
+Build AI Agents that can edit rich text - from simple chatbot assistants to complex document editing workflows.
 
 <CodeDemo
   isPro
@@ -36,7 +36,7 @@ Tiptap Content AI enables you to build AI Agents that edit rich text documents -
   src="https://develop--tiptap-pro.netlify.app/preview/Extensions/AiAgent"
 />
 
-The AI Agent extension lets you integrate an AI Assistant that can read and edit your document based on a user-defined task.
+The AI Agent extension lets you integrate an AI Assistant that can read, answer questions, and edit your document based on a user-defined task.
 
 <Callout title="Integrate or test AI Agent" variant="warning">
   To test or integrate this feature you need an active trial or Tiptap Team subscription.
@@ -44,10 +44,12 @@ The AI Agent extension lets you integrate an AI Assistant that can read and edit
 
 ## Key features
 
-- Works out of the box with Tiptap Cloud. Zero configuration required.
-- Use with your own custom LLM and AI Agent framework of choice.
-- Combine Tiptap's text editing capabilities with your custom tools and RAG pipelines.
-- Compatible with the AI Changes extension. Let your users review and accept/reject AI-generated changes.
+- Edits large documents fast and efficiently.
+- Understands your document's structure and formatting, including custom elements.
+- Works out of the box with Tiptap Cloud. Zero config required.
+- Integrate it with your custom backend and LLM.
+- Add custom data sources and RAG pipelines.
+- Let your users review and accept/reject AI-generated changes.
 
 ## What are AI Agents?
 
@@ -59,7 +61,7 @@ The Tiptap AI Agent has the tools to perform these actions:
 - Re-write the document's contents
 - Make a plan, interact with the user, and create a summary of the changes it made.
 
-These built-in tools are optimized for rich text editing and follow LLM best practices, allowing you to focus on your application's core logic. You can combine them with custom tools for business logic and data retrieval.
+These built-in tools are optimized for rich text editing and follow LLM best practices, allowing you to focus on your application's core logic. You can combine them with custom tools for data retrieval.
 
 When an LLM is called with these tools, it selects one to execute. Then, the Tiptap AI Agent Extension applies it to the editor, modifying the document or reading its content in an efficient way. In a typical implementation, the LLM is called on the server, while the document editing happens in the browser.
 


### PR DESCRIPTION
Fix description of chunk size to be in terms of characters

Make it clear that the chunkSize configuration property is the number of characters of the chunk

Update and simplify intro.