### PR TITLE
[docs] Update floatingmenu.mdx

### DIFF
--- a/src/content/editor/extensions/functionality/floatingmenu.mdx
+++ b/src/content/editor/extensions/functionality/floatingmenu.mdx
@@ -29,6 +29,8 @@ Use the Floating Menu extension in Tiptap to make a menu appear on an empty line
 
 ## Install the extension
 
+Install the Floating Menu extension and the [Floating UI](https://floating-ui.com) library.
+
 ```bash
 npm install @tiptap/extension-floating-menu@beta @floating-ui/dom@^1.6.0
 ```

--- a/src/content/editor/extensions/functionality/floatingmenu.mdx
+++ b/src/content/editor/extensions/functionality/floatingmenu.mdx
@@ -30,7 +30,6 @@ Use the Floating Menu extension in Tiptap to make a menu appear on an empty line
 ## Install the extension
 
 ```bash
-# install the extension & Floating UI
 npm install @tiptap/extension-floating-menu@beta @floating-ui/dom@^1.6.0
 ```
 


### PR DESCRIPTION
Removing the bash comment. None of the other bash commands have the comment in there. It can cause issues with the copy code tool as it will copy the comment.