### PR TITLE
Schema awareness

### DIFF
--- a/src/content/content-ai/capabilities/agent/configure/custom-nodes.mdx
+++ b/src/content/content-ai/capabilities/agent/configure/custom-nodes.mdx
@@ -6,11 +6,20 @@ meta:
   category: Content AI
 ---
 
+import { CodeDemo } from '@/components/CodeDemo'
+
 The AI Agent extension understands the content of the document and the possible elements (Nodes and Marks) that can be in it.
 
 For example, the AI Agent extension detects the [Table](/editor/extensions/nodes/table) extension and knows how to generate tables. If the Table extension is not enabled and the user asks it to generate a table, the AI Agent will respond that the document doesn't support this type of element.
 
 This is automatically done for all built-in Tiptap extensions. However, if you have an editor with [custom nodes and marks](/editor/extensions/custom-extensions), you need to configure the AI Agent extension so that it can generate and understand them.
+
+<CodeDemo
+  isPro
+  isLarge
+  path="/Extensions/AiAgentCustomElements"
+  src="https://develop--tiptap-pro.netlify.app/preview/Extensions/AiAgentCustomElements"
+/>
 
 ## Configure custom nodes
 

--- a/src/content/content-ai/capabilities/agent/configure/custom-nodes.mdx
+++ b/src/content/content-ai/capabilities/agent/configure/custom-nodes.mdx
@@ -51,18 +51,6 @@ export const AlertNode = Node.create({
           }
         },
       },
-      title: {
-        default: null,
-        parseHTML: (element) => element.getAttribute('data-title'),
-        renderHTML: (attributes) => {
-          if (!attributes.title) {
-            return {}
-          }
-          return {
-            'data-title': attributes.title,
-          }
-        },
-      },
     }
   },
 
@@ -125,10 +113,6 @@ const provider = new AiAgentProvider({
           name: 'data-type',
           description: 'The type of alert: info, warning, error, or success',
         },
-        {
-          name: 'data-title',
-          description: 'Optional title for the alert box',
-        },
       ],
     },
   ],
@@ -156,10 +140,6 @@ const provider = new AiAgentProvider({
         {
           name: 'data-type',
           description: 'The type of alert: info, warning, error, or success',
-        },
-        {
-          name: 'data-title',
-          description: 'Optional title for the alert box',
         },
       ],
     },

--- a/src/content/content-ai/capabilities/agent/configure/custom-nodes.mdx
+++ b/src/content/content-ai/capabilities/agent/configure/custom-nodes.mdx
@@ -1,0 +1,218 @@
+---
+title: Configure custom nodes and marks
+meta:
+  title: Custom nodes/marks | Tiptap Content AI
+  description: Learn how to configure the AI Agent extension so that it can generate and understand custom nodes and marks.
+  category: Content AI
+---
+
+The AI Agent extension understands the content of the document and the possible elements (Nodes and Marks) that can be in it.
+
+For example, the AI Agent extension detects the [Table](/editor/extensions/nodes/table) extension and knows how to generate tables. If the Table extension is not enabled and the user asks it to generate a table, the AI Agent will respond that the document doesn't support this type of element.
+
+This is automatically done for all built-in Tiptap extensions. However, if you have an editor with [custom nodes and marks](/editor/extensions/custom-extensions), you need to configure the AI Agent extension so that it can generate and understand them.
+
+## Configure custom nodes
+
+To configure custom nodes for the AI Agent, you need to follow these steps:
+
+1. Define your custom Tiptap node extension
+2. Configure the AI Agent with schema awareness information
+
+Let's walk through each step with a practical example.
+
+### Step 1: Define a custom Tiptap node extension
+
+First, create your custom node extension. Here's an example of a custom "Alert" node:
+
+```ts
+import { Node, mergeAttributes } from '@tiptap/core'
+
+export const AlertNode = Node.create({
+  name: 'alert',
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    }
+  },
+
+  addAttributes() {
+    return {
+      type: {
+        default: 'info',
+        parseHTML: (element) => element.getAttribute('data-type'),
+        renderHTML: (attributes) => {
+          if (!attributes.type) {
+            return {}
+          }
+          return {
+            'data-type': attributes.type,
+          }
+        },
+      },
+      title: {
+        default: null,
+        parseHTML: (element) => element.getAttribute('data-title'),
+        renderHTML: (attributes) => {
+          if (!attributes.title) {
+            return {}
+          }
+          return {
+            'data-title': attributes.title,
+          }
+        },
+      },
+    }
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'div[data-alert]',
+      },
+    ]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'div',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        'data-alert': '',
+      }),
+      0,
+    ]
+  },
+})
+```
+
+Add the extension to your editor:
+
+```ts
+import { Editor } from '@tiptap/core'
+import { AlertNode } from './AlertNode'
+
+const editor = new Editor({
+  extensions: [
+    // ... other extensions
+    AlertNode,
+  ],
+})
+```
+
+### Step 2: Configure the AI Agent
+
+Now configure the AI Agent extension with schema awareness information about your custom node:
+
+```ts
+const provider = new AiAgentProvider({
+  schemaAwarenessCustomElements: [
+    {
+      extensionName: 'alert',
+      tag: 'div[data-alert]',
+      name: 'Alert Box',
+      description:
+        'A highlighted box used to display important information, warnings, or tips to the user',
+      // Describe the HTML attributes of the node as it is rendered in HTML
+      attributes: [
+        {
+          name: 'data-alert',
+          // Specify the "value" property if the attribute always has that value
+          value: '',
+          description: 'Indicates that this is an alert box',
+        }
+        {
+          name: 'data-type',
+          description: 'The type of alert: info, warning, error, or success',
+        },
+        {
+          name: 'data-title',
+          description: 'Optional title for the alert box',
+        },
+      ],
+    },
+  ],
+})
+```
+
+## Multiple custom elements
+
+You can configure multiple custom nodes and marks at once. Here's an example with both an Alert node and a custom highlight marks:
+
+```ts
+const provider = new AiAgentProvider({
+  schemaAwarenessCustomElements: [
+    {
+      extensionName: 'alert',
+      tag: 'div[data-alert]',
+      name: 'Alert Box',
+      description: 'A highlighted box used to display important information, warnings, or tips',
+      attributes: [
+        {
+          name: 'data-alert',
+          value: '',
+          description: 'Indicates that this is an alert box',
+        }
+        {
+          name: 'data-type',
+          description: 'The type of alert: info, warning, error, or success',
+        },
+        {
+          name: 'data-title',
+          description: 'Optional title for the alert box',
+        },
+      ],
+    },
+    // Custom marks are also configured in the same way
+    {
+      extensionName: 'customHighlight',
+      tag: 'span',
+      name: 'Custom Highlight',
+      description: 'Highlights text with a special background',
+      attributes: [
+        {
+          name: 'data-custom-highlight',
+          value: '',
+          description: 'Indicates that this is a custom highlight',
+        }
+      ],
+    },
+  ],
+})
+```
+
+## Best practices
+
+When configuring custom nodes and marks for the AI Agent extension:
+
+1. **Use descriptive names**: Choose clear, descriptive names that help the AI model understand what the element represents.
+
+2. **Provide detailed descriptions**: Include comprehensive descriptions that explain both what the element is and how it's displayed or used.
+
+3. **Document all attributes**: List all possible HTML attributes with their purposes and expected values.
+
+4. **Use consistent naming**: Match the `extensionName` with your actual Tiptap extension name.
+
+5. **Specify HTML structure**: Ensure `tag` and `atributes` match exactly how your extension renders HTML.
+
+## API Reference
+
+The `schemaAwarenessCustomElements` option accepts an array of `SchemaAwarenessItem` objects with the following properties:
+
+| Property        | Type                             | Required | Description                                               |
+| --------------- | -------------------------------- | -------- | --------------------------------------------------------- |
+| `extensionName` | `string`                         | Yes      | The name of the Tiptap extension (must match exactly)     |
+| `tag`           | `string`                         | Yes      | The HTML tag or selector that represents this element     |
+| `name`          | `string`                         | Yes      | A human-readable name for the element                     |
+| `description`   | `string \| null`                 | No       | Explanation of what the element is and how it's displayed |
+| `attributes`    | `SchemaAwarenessItemAttribute[]` | No       | Array of possible HTML attributes for this element        |
+
+### SchemaAwarenessItemAttribute
+
+Each attribute object in the `attributes` array has the following properties:
+
+| Property      | Type             | Required | Description                                                |
+| ------------- | ---------------- | -------- | ---------------------------------------------------------- |
+| `name`        | `string`         | Yes      | The name of the attribute in the HTML code                 |
+| `value`       | `string`         | No       | If specified, the attribute always has this exact value    |
+| `description` | `string \| null` | No       | Explanation of the attribute's purpose and expected values |

--- a/src/content/content-ai/capabilities/agent/configure/custom-nodes.mdx
+++ b/src/content/content-ai/capabilities/agent/configure/custom-nodes.mdx
@@ -117,7 +117,7 @@ const provider = new AiAgentProvider({
           // Specify the "value" property if the attribute always has that value
           value: '',
           description: 'Indicates that this is an alert box',
-        }
+        },
         {
           name: 'data-type',
           description: 'The type of alert: info, warning, error, or success',

--- a/src/content/content-ai/capabilities/agent/configure/options.mdx
+++ b/src/content/content-ai/capabilities/agent/configure/options.mdx
@@ -243,24 +243,24 @@ const provider = new AiAgentProvider({
 
 ## Key configuration options
 
-| Option                  | Type                                | Default                    | Description                                                                       |
-| ----------------------- | ----------------------------------- | -------------------------- | --------------------------------------------------------------------------------- |
-| `appId`                 | `string`                            | `""`                       | Your Tiptap Content AI app ID                                                     |
-| `token`                 | `string`                            | `""`                       | JWT token for authentication                                                      |
-| `baseUrl`               | `string`                            | `""`                       | Base URL of the AI service API                                                    |
-| `modelName`             | `AiAgentModelName`                  | `"gpt-4.1"`                | The OpenAI model to use (gpt-4.1 and gpt-4o recommended)                          |
-| `autoAccept`            | `"always" \| "never" \| "onlyRead"` | `"onlyRead"`               | Controls automatic acceptance of AI changes                                       |
-| `autoSaveCheckpoints`   | `boolean`                           | `false`                    | Automatically save checkpoints when user sends a message                          |
-| `chunkSize`             | `number`                            | `1000`                     | Size of document chunks when reading (in characters)                              |
-| `chunkHtml`             | `Function`                          | `defaultChunkHtmlFunction` | Customizes how the document is split into chunks                                  |
-| `useAiChangesExtension` | `boolean`                           | `true`                     | Whether to use the AI Changes extension                                           |
-| `initialChatMessages`   | `ChatMessage[]`                     | `[]`                       | Initial chat messages to populate the conversation                                |
-| `resolver`              | `Function`                          | `defaultAiAgentResolver`   | Function to resolve AI Agent requests with custom backend                         |
-| `toolHandlers`          | `AiAgentToolCallHandler[]`          | `toolHandlersStarterKit()` | Handlers for custom tools                                                         |
-| `onStateChange`         | `Function`                          | `undefined`                | Called when the state of the AI Agent changes                                     |
-| `onLoadingError`        | `Function`                          | `undefined`                | Called when there's an error loading the AI Agent                                 |
-| `onBeforeToolCall`      | `Function`                          | `undefined`                | Called before a tool call is executed                                             |
-| `onAfterToolCall`       | `Function`                          | `undefined`                | Called after a tool call is executed                                              |
-| `onStopRunning`         | `Function`                          | `undefined`                | Called when the AI Agent stops running                                            |
-| `systemPrompt`          | `string`                            | `undefined`                | Custom system prompt for the AI Agent when using it with Tiptap Cloud             |
-| `customNodes`           | `SchemaAwarenessItem[]`             | `[]`                       | Information for the AI model about the custom nodes that the document can contain |
+| Option                          | Type                                | Default                    | Description                                                                       |
+| ------------------------------- | ----------------------------------- | -------------------------- | --------------------------------------------------------------------------------- |
+| `appId`                         | `string`                            | `""`                       | Your Tiptap Content AI app ID                                                     |
+| `token`                         | `string`                            | `""`                       | JWT token for authentication                                                      |
+| `baseUrl`                       | `string`                            | `""`                       | Base URL of the AI service API                                                    |
+| `modelName`                     | `AiAgentModelName`                  | `"gpt-4.1"`                | The OpenAI model to use (gpt-4.1 and gpt-4o recommended)                          |
+| `autoAccept`                    | `"always" \| "never" \| "onlyRead"` | `"onlyRead"`               | Controls automatic acceptance of AI changes                                       |
+| `autoSaveCheckpoints`           | `boolean`                           | `false`                    | Automatically save checkpoints when user sends a message                          |
+| `chunkSize`                     | `number`                            | `1000`                     | Size of document chunks when reading (in characters)                              |
+| `chunkHtml`                     | `Function`                          | `defaultChunkHtmlFunction` | Customizes how the document is split into chunks                                  |
+| `useAiChangesExtension`         | `boolean`                           | `true`                     | Whether to use the AI Changes extension                                           |
+| `initialChatMessages`           | `ChatMessage[]`                     | `[]`                       | Initial chat messages to populate the conversation                                |
+| `resolver`                      | `Function`                          | `defaultAiAgentResolver`   | Function to resolve AI Agent requests with custom backend                         |
+| `toolHandlers`                  | `AiAgentToolCallHandler[]`          | `toolHandlersStarterKit()` | Handlers for custom tools                                                         |
+| `onStateChange`                 | `Function`                          | `undefined`                | Called when the state of the AI Agent changes                                     |
+| `onLoadingError`                | `Function`                          | `undefined`                | Called when there's an error loading the AI Agent                                 |
+| `onBeforeToolCall`              | `Function`                          | `undefined`                | Called before a tool call is executed                                             |
+| `onAfterToolCall`               | `Function`                          | `undefined`                | Called after a tool call is executed                                              |
+| `onStopRunning`                 | `Function`                          | `undefined`                | Called when the AI Agent stops running                                            |
+| `systemPrompt`                  | `string`                            | `undefined`                | Custom system prompt for the AI Agent when using it with Tiptap Cloud             |
+| `schemaAwarenessCustomElements` | `SchemaAwarenessItem[]`             | `[]`                       | Information for the AI model about the custom nodes that the document can contain |

--- a/src/content/content-ai/capabilities/agent/configure/options.mdx
+++ b/src/content/content-ai/capabilities/agent/configure/options.mdx
@@ -218,7 +218,7 @@ const provider = new AiAgentProvider({
 })
 ```
 
-### System prompt
+## System prompt
 
 You can [define a custom system prompt](/content-ai/capabilities/agent/configure/system-prompt) for the AI Agent when using it with Tiptap Cloud.
 
@@ -229,25 +229,38 @@ const provider = new AiAgentProvider({
 })
 ```
 
+## Custom nodes
+
+Configure the AI Agent extension so that it can [generate and understand custom nodes](/content-ai/capabilities/agent/configure/custom-nodes).
+
+```ts
+const provider = new AiAgentProvider({
+  schemaAwarenessCustomElements: [
+    /* Custom node configuration */
+  ],
+})
+```
+
 ## Key configuration options
 
-| Option                  | Type                                | Default                    | Description                                                           |
-| ----------------------- | ----------------------------------- | -------------------------- | --------------------------------------------------------------------- |
-| `appId`                 | `string`                            | `""`                       | Your Tiptap Content AI app ID                                         |
-| `token`                 | `string`                            | `""`                       | JWT token for authentication                                          |
-| `baseUrl`               | `string`                            | `""`                       | Base URL of the AI service API                                        |
-| `modelName`             | `AiAgentModelName`                  | `"gpt-4.1"`                | The OpenAI model to use (gpt-4.1 and gpt-4o recommended)              |
-| `autoAccept`            | `"always" \| "never" \| "onlyRead"` | `"onlyRead"`               | Controls automatic acceptance of AI changes                           |
-| `autoSaveCheckpoints`   | `boolean`                           | `false`                    | Automatically save checkpoints when user sends a message              |
-| `chunkSize`             | `number`                            | `1000`                     | Size of document chunks when reading (in characters)                  |
-| `chunkHtml`             | `Function`                          | `defaultChunkHtmlFunction` | Customizes how the document is split into chunks                      |
-| `useAiChangesExtension` | `boolean`                           | `true`                     | Whether to use the AI Changes extension                               |
-| `initialChatMessages`   | `ChatMessage[]`                     | `[]`                       | Initial chat messages to populate the conversation                    |
-| `resolver`              | `Function`                          | `defaultAiAgentResolver`   | Function to resolve AI Agent requests with custom backend             |
-| `toolHandlers`          | `AiAgentToolCallHandler[]`          | `toolHandlersStarterKit()` | Handlers for custom tools                                             |
-| `onStateChange`         | `Function`                          | `undefined`                | Called when the state of the AI Agent changes                         |
-| `onLoadingError`        | `Function`                          | `undefined`                | Called when there's an error loading the AI Agent                     |
-| `onBeforeToolCall`      | `Function`                          | `undefined`                | Called before a tool call is executed                                 |
-| `onAfterToolCall`       | `Function`                          | `undefined`                | Called after a tool call is executed                                  |
-| `onStopRunning`         | `Function`                          | `undefined`                | Called when the AI Agent stops running                                |
-| `systemPrompt`          | `string`                            | `undefined`                | Custom system prompt for the AI Agent when using it with Tiptap Cloud |
+| Option                  | Type                                | Default                    | Description                                                                       |
+| ----------------------- | ----------------------------------- | -------------------------- | --------------------------------------------------------------------------------- |
+| `appId`                 | `string`                            | `""`                       | Your Tiptap Content AI app ID                                                     |
+| `token`                 | `string`                            | `""`                       | JWT token for authentication                                                      |
+| `baseUrl`               | `string`                            | `""`                       | Base URL of the AI service API                                                    |
+| `modelName`             | `AiAgentModelName`                  | `"gpt-4.1"`                | The OpenAI model to use (gpt-4.1 and gpt-4o recommended)                          |
+| `autoAccept`            | `"always" \| "never" \| "onlyRead"` | `"onlyRead"`               | Controls automatic acceptance of AI changes                                       |
+| `autoSaveCheckpoints`   | `boolean`                           | `false`                    | Automatically save checkpoints when user sends a message                          |
+| `chunkSize`             | `number`                            | `1000`                     | Size of document chunks when reading (in characters)                              |
+| `chunkHtml`             | `Function`                          | `defaultChunkHtmlFunction` | Customizes how the document is split into chunks                                  |
+| `useAiChangesExtension` | `boolean`                           | `true`                     | Whether to use the AI Changes extension                                           |
+| `initialChatMessages`   | `ChatMessage[]`                     | `[]`                       | Initial chat messages to populate the conversation                                |
+| `resolver`              | `Function`                          | `defaultAiAgentResolver`   | Function to resolve AI Agent requests with custom backend                         |
+| `toolHandlers`          | `AiAgentToolCallHandler[]`          | `toolHandlersStarterKit()` | Handlers for custom tools                                                         |
+| `onStateChange`         | `Function`                          | `undefined`                | Called when the state of the AI Agent changes                                     |
+| `onLoadingError`        | `Function`                          | `undefined`                | Called when there's an error loading the AI Agent                                 |
+| `onBeforeToolCall`      | `Function`                          | `undefined`                | Called before a tool call is executed                                             |
+| `onAfterToolCall`       | `Function`                          | `undefined`                | Called after a tool call is executed                                              |
+| `onStopRunning`         | `Function`                          | `undefined`                | Called when the AI Agent stops running                                            |
+| `systemPrompt`          | `string`                            | `undefined`                | Custom system prompt for the AI Agent when using it with Tiptap Cloud             |
+| `customNodes`           | `SchemaAwarenessItem[]`             | `[]`                       | Information for the AI model about the custom nodes that the document can contain |

--- a/src/content/content-ai/capabilities/agent/custom-llms/get-started/anthropic-messages.mdx
+++ b/src/content/content-ai/capabilities/agent/custom-llms/get-started/anthropic-messages.mdx
@@ -49,11 +49,11 @@ import AiAgent, { AiAgentProvider } from '@tiptap-pro/extension-ai-agent'
 
 const provider = new AiAgentProvider({
   // The `chatMessages` property contains the chat messages of the conversation
-  resolver: async ({ chatMessages }) => {
+  resolver: async ({ chatMessages, schemaAwarenessData }) => {
     // Call the API endpoint of your backend
     const response = await fetch('/api-endpoint', {
       method: 'POST',
-      body: JSON.stringify({ chatMessages }),
+      body: JSON.stringify({ chatMessages, schemaAwarenessData }),
     })
     return await response.json()
   },
@@ -70,6 +70,13 @@ First, install the AI Agent and Anthropic server libraries.
 npm install @tiptap-pro/extension-ai-agent-server @anthropic-ai/sdk
 ```
 
+Get the chat messages and schema awareness data from the request parameters.
+
+```ts
+// Code inside your API endpoint. Code depends on your backend framework
+const { chatMessages, schemaAwarenessData } = request
+```
+
 Then, inside your API endpoint, create an `AiAgentToolkit` instance. It lets you configure the tools that will be available to the AI model.
 
 ```ts
@@ -77,6 +84,7 @@ import { AiAgentToolkit, anthropicMessagesAdapter } from '@tiptap-pro/extension-
 
 const toolkit = new AiAgentToolkit({
   adapter: anthropicMessagesAdapter,
+  schemaAwarenessData,
 })
 ```
 
@@ -105,8 +113,11 @@ import {
 } from '@tiptap-pro/extension-ai-agent-server'
 import Anthropic from '@anthropic-ai/sdk'
 
+const { chatMessages, schemaAwarenessData } = request
+
 const toolkit = new AiAgentToolkit({
   adapter: anthropicMessagesAdapter,
+  schemaAwarenessData,
 })
 
 const formatter = new ChatMessagesFormatter({

--- a/src/content/content-ai/capabilities/agent/custom-llms/get-started/openai-chat-completions.mdx
+++ b/src/content/content-ai/capabilities/agent/custom-llms/get-started/openai-chat-completions.mdx
@@ -49,11 +49,11 @@ import AiAgent, { AiAgentProvider } from '@tiptap-pro/extension-ai-agent'
 
 const provider = new AiAgentProvider({
   // The `chatMessages` property contains the chat messages of the conversation
-  resolver: async ({ chatMessages }) => {
+  resolver: async ({ chatMessages, schemaAwarenessData }) => {
     // Call the API endpoint of your backend
     const response = await fetch('/api-endpoint', {
       method: 'POST',
-      body: JSON.stringify({ chatMessages }),
+      body: JSON.stringify({ chatMessages, schemaAwarenessData }),
     })
     return await response.json()
   },
@@ -70,6 +70,13 @@ First, install the AI Agent and OpenAI server libraries.
 npm install @tiptap-pro/extension-ai-agent-server openai
 ```
 
+Get the chat messages and schema awareness data from the request parameters.
+
+```ts
+// Code inside your API endpoint. Code depends on your backend framework
+const { chatMessages, schemaAwarenessData } = request
+```
+
 Then, inside your API endpoint, create an `AiAgentToolkit` instance. It lets you configure the tools that will be available to the AI model.
 
 ```ts
@@ -77,6 +84,7 @@ import { AiAgentToolkit, openaiChatCompletionsAdapter } from '@tiptap-pro/extens
 
 const toolkit = new AiAgentToolkit({
   adapter: openaiChatCompletionsAdapter,
+  schemaAwarenessData,
 })
 ```
 
@@ -105,8 +113,11 @@ import {
 } from '@tiptap-pro/extension-ai-agent-server'
 import OpenAI from 'openai'
 
+const { chatMessages, schemaAwarenessData } = request
+
 const toolkit = new AiAgentToolkit({
   adapter: openaiChatCompletionsAdapter,
+  schemaAwarenessData,
 })
 
 const formatter = new ChatMessagesFormatter({

--- a/src/content/content-ai/capabilities/agent/custom-llms/get-started/openai-responses.mdx
+++ b/src/content/content-ai/capabilities/agent/custom-llms/get-started/openai-responses.mdx
@@ -49,11 +49,11 @@ import AiAgent, { AiAgentProvider } from '@tiptap-pro/extension-ai-agent'
 
 const provider = new AiAgentProvider({
   // The `chatMessages` property contains the chat messages of the conversation
-  resolver: async ({ chatMessages }) => {
+  resolver: async ({ chatMessages, schemaAwarenessData }) => {
     // Call the API endpoint of your backend
     const response = await fetch('/api-endpoint', {
       method: 'POST',
-      body: JSON.stringify({ chatMessages }),
+      body: JSON.stringify({ chatMessages, schemaAwarenessData }),
     })
     return await response.json()
   },
@@ -70,6 +70,13 @@ First, install the AI Agent and OpenAI server libraries.
 npm install @tiptap-pro/extension-ai-agent-server openai
 ```
 
+Get the chat messages and schema awareness data from the request parameters.
+
+```ts
+// Code inside your API endpoint. Code depends on your backend framework
+const { chatMessages, schemaAwarenessData } = request
+```
+
 Then, inside your API endpoint, create an `AiAgentToolkit` instance. It lets you configure the tools that will be available to the AI model.
 
 ```ts
@@ -77,6 +84,7 @@ import { AiAgentToolkit, openaiResponsesAdapter } from '@tiptap-pro/extension-ai
 
 const toolkit = new AiAgentToolkit({
   adapter: openaiResponsesAdapter,
+  schemaAwarenessData,
 })
 ```
 
@@ -105,8 +113,11 @@ import {
 } from '@tiptap-pro/extension-ai-agent-server'
 import OpenAI from 'openai'
 
+const { chatMessages, schemaAwarenessData } = request
+
 const toolkit = new AiAgentToolkit({
   adapter: openaiResponsesAdapter,
+  schemaAwarenessData,
 })
 
 const formatter = new ChatMessagesFormatter({

--- a/src/content/content-ai/capabilities/agent/custom-llms/get-started/vercel-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/agent/custom-llms/get-started/vercel-ai-sdk.mdx
@@ -49,11 +49,11 @@ import AiAgent, { AiAgentProvider } from '@tiptap-pro/extension-ai-agent'
 
 const provider = new AiAgentProvider({
   // The `chatMessages` property contains the chat messages of the conversation
-  resolver: async ({ chatMessages }) => {
+  resolver: async ({ chatMessages, schemaAwarenessData }) => {
     // Call the API endpoint of your backend
     const response = await fetch('/api-endpoint', {
       method: 'POST',
-      body: JSON.stringify({ chatMessages }),
+      body: JSON.stringify({ chatMessages, schemaAwarenessData }),
     })
     return await response.json()
   },
@@ -70,6 +70,13 @@ First, install the AI Agent, Vercel AI SDK, and your preferred AI provider (in t
 npm install @tiptap-pro/extension-ai-agent-server ai @ai-sdk/openai
 ```
 
+Get the chat messages and schema awareness data from the request parameters.
+
+```ts
+// Code inside your API endpoint. Code depends on your backend framework
+const { chatMessages, schemaAwarenessData } = request
+```
+
 Then, inside your API endpoint, create an `AiAgentToolkit` instance. It lets you configure the tools that will be available to the AI model.
 
 ```ts
@@ -77,6 +84,7 @@ import { AiAgentToolkit, vercelAiSdkAdapter } from '@tiptap-pro/extension-ai-age
 
 const toolkit = new AiAgentToolkit({
   adapter: vercelAiSdkAdapter,
+  schemaAwarenessData,
 })
 ```
 
@@ -106,8 +114,11 @@ import {
 import { generateText } from 'ai'
 import { openai } from '@ai-sdk/openai'
 
+const { chatMessages, schemaAwarenessData } = request
+
 const toolkit = new AiAgentToolkit({
   adapter: vercelAiSdkAdapter,
+  schemaAwarenessData,
 })
 
 const formatter = new ChatMessagesFormatter({

--- a/src/content/content-ai/capabilities/agent/custom-llms/server-side-tools/anthropic-messages.mdx
+++ b/src/content/content-ai/capabilities/agent/custom-llms/server-side-tools/anthropic-messages.mdx
@@ -44,8 +44,11 @@ import {
 } from '@tiptap-pro/extension-ai-agent-server'
 import Anthropic from '@anthropic-ai/sdk'
 
+const { chatMessages, schemaAwarenessData } = request
+
 const toolkit = new AiAgentToolkit({
   adapter: anthropicMessagesAdapter,
+  schemaAwarenessData,
 })
 
 const formatter = new ChatMessagesFormatter({

--- a/src/content/content-ai/capabilities/agent/custom-llms/server-side-tools/openai-chat-completions.mdx
+++ b/src/content/content-ai/capabilities/agent/custom-llms/server-side-tools/openai-chat-completions.mdx
@@ -47,8 +47,11 @@ import {
 } from '@tiptap-pro/extension-ai-agent-server'
 import OpenAI from 'openai'
 
+const { chatMessages, schemaAwarenessData } = request
+
 const toolkit = new AiAgentToolkit({
   adapter: openaiChatCompletionsAdapter,
+  schemaAwarenessData,
 })
 
 const formatter = new ChatMessagesFormatter({

--- a/src/content/content-ai/capabilities/agent/custom-llms/server-side-tools/openai-responses.mdx
+++ b/src/content/content-ai/capabilities/agent/custom-llms/server-side-tools/openai-responses.mdx
@@ -47,8 +47,11 @@ import {
 } from '@tiptap-pro/extension-ai-agent-server'
 import OpenAI from 'openai'
 
+const { chatMessages, schemaAwarenessData } = request
+
 const toolkit = new AiAgentToolkit({
   adapter: openaiResponsesAdapter,
+  schemaAwarenessData,
 })
 
 const formatter = new ChatMessagesFormatter({

--- a/src/content/content-ai/capabilities/agent/custom-llms/server-side-tools/vercel-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/agent/custom-llms/server-side-tools/vercel-ai-sdk.mdx
@@ -40,8 +40,11 @@ import {
 import { generateText } from 'ai'
 import { openai } from '@ai-sdk/openai'
 
+const { chatMessages, schemaAwarenessData } = request
+
 const toolkit = new AiAgentToolkit({
   adapter: vercelAiSdkAdapter,
+  schemaAwarenessData,
 })
 
 const formatter = new ChatMessagesFormatter({

--- a/src/content/content-ai/capabilities/agent/overview.mdx
+++ b/src/content/content-ai/capabilities/agent/overview.mdx
@@ -12,13 +12,13 @@ sidebars:
 ---
 
 import { CodeDemo } from '@/components/CodeDemo'
-import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 
 <Requirements>
-    <RequirementItem label="1. Activate trial or subscribe">
-        Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Team plan](https://cloud.tiptap.dev/v2/billing) in your account.
-    </RequirementItem>
+  <RequirementItem label="1. Activate trial or subscribe">
+    Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Team
+    plan](https://cloud.tiptap.dev/v2/billing) in your account.
+  </RequirementItem>
   <RequirementItem label="2. Integrate an AI provider">
     Configure OpenAI in your [AI settings](https://cloud.tiptap.dev/v2/cloud/ai) or review the
     [Custom LLM guide](/content-ai/capabilities/agent/custom-llms).

--- a/src/content/content-ai/sidebar.ts
+++ b/src/content/content-ai/sidebar.ts
@@ -254,6 +254,10 @@ export const sidebarConfig: SidebarConfig = {
                   title: 'System prompt',
                   href: '/content-ai/capabilities/agent/configure/system-prompt',
                 },
+                {
+                  title: 'Custom nodes/marks',
+                  href: '/content-ai/capabilities/agent/configure/custom-nodes',
+                },
               ],
             },
             {


### PR DESCRIPTION
Documentation of this tiptap-pro PR: https://github.com/ueberdosis/tiptap-pro/pull/354

Introduces schema awareness support for the AI Agent extension.

The schema awareness feature provides the AI context of the elements (Nodes and Marks) that can be in the document.

All Nodes and Marks that belong to official Tiptap extensions are automatically recognized. This is possible thanks to a list of schema awareness data that contains definitions for all existing Tiptap extensions. Then, this list is filtered so that only the nodes and marks that are included in the document schema are sent to the AI.

On the other hand, for custom Nodes and Marks, schema awareness information needs to be provided by the developer.

---

The changes in the docs include:


- Changes in the custom LLM examples for schema awareness support
- A guide on how to make the AI Agent aware of custom nodes and marks
- Update the list of configuration options
- A code demo

Do you think any information or guide is missing? Let me know!!