### PR TITLE
fix: list keymap extension typo

### DIFF
--- a/src/content/editor/extensions/functionality/listkeymap.mdx
+++ b/src/content/editor/extensions/functionality/listkeymap.mdx
@@ -59,22 +59,7 @@ new Editor({
 
 ### listTypes
 
-A array of list items and their parent wrapper node types.
-
-Default:
-
-```js
-;[
-  {
-    itemName: 'listItem',
-    wrapperNames: ['bulletList', 'orderedList'],
-  },
-  {
-    itemName: 'taskItem',
-    wrapperNames: ['taskList'],
-  },
-]
-```
+An array of list items and their parent wrapper node types.
 
 ```js
 ListKeymap.configure({
@@ -85,6 +70,21 @@ ListKeymap.configure({
     },
   ],
 })
+```
+
+Default value:
+
+```json
+[
+  {
+    "itemName": "listItem",
+    "wrapperNames": ["bulletList", "orderedList"]
+  },
+  {
+    "itemName": "taskItem",
+    "wrapperNames": ["taskList"]
+  }
+]
 ```
 
 ## Source code


### PR DESCRIPTION
Fixes typo reported here: #171