### PR TITLE
Add changelog of beta AI extensions

### DIFF
--- a/src/content/content-ai/capabilities/agent/changelog.mdx
+++ b/src/content/content-ai/capabilities/agent/changelog.mdx
@@ -1,0 +1,13 @@
+---
+title: Changelog
+meta:
+  title: AI Agent Changelog | Tiptap Content AI
+  description: Changelog for the AI Agent extension
+  category: Content AI
+---
+
+## 3.0.0-beta.32
+
+### Major Changes
+
+- Publish AI Agent extension (beta) for Tiptap 3

--- a/src/content/content-ai/capabilities/changes/changelog.mdx
+++ b/src/content/content-ai/capabilities/changes/changelog.mdx
@@ -1,0 +1,13 @@
+---
+title: Changelog
+meta:
+  title: AI Changes Changelog | Tiptap Content AI
+  description: Changelog for the AI Changes extension
+  category: Content AI
+---
+
+## 3.0.0-beta.32
+
+### Major Changes
+
+- Publish AI Changes extension (beta) for Tiptap 3

--- a/src/content/content-ai/capabilities/suggestion/changelog.mdx
+++ b/src/content/content-ai/capabilities/suggestion/changelog.mdx
@@ -1,0 +1,13 @@
+---
+title: Changelog
+meta:
+  title: AI Suggestion Changelog | Tiptap Content AI
+  description: Changelog for the AI Suggestion extension
+  category: Content AI
+---
+
+## 3.0.0-beta.32
+
+### Major Changes
+
+- Publish AI Suggestion extension (beta) for Tiptap 3

--- a/src/content/content-ai/sidebar.ts
+++ b/src/content/content-ai/sidebar.ts
@@ -191,6 +191,10 @@ export const sidebarConfig: SidebarConfig = {
               title: 'API Reference',
               href: '/content-ai/capabilities/suggestion/api-reference',
             },
+            {
+              title: 'Changelog',
+              href: '/content-ai/capabilities/suggestion/changelog',
+            },
           ],
         },
         {
@@ -228,6 +232,10 @@ export const sidebarConfig: SidebarConfig = {
             {
               title: 'API Reference',
               href: '/content-ai/capabilities/changes/api-reference',
+            },
+            {
+              title: 'Changelog',
+              href: '/content-ai/capabilities/changes/changelog',
             },
           ],
         },
@@ -374,6 +382,10 @@ export const sidebarConfig: SidebarConfig = {
             {
               title: 'API Reference',
               href: '/content-ai/capabilities/agent/api-reference',
+            },
+            {
+              title: 'Changelog',
+              href: '/content-ai/capabilities/agent/changelog',
             },
           ],
         },


### PR DESCRIPTION
Adds changelog to beta AI extensions

Does not include previous entries of the changelog because they did not provide helpful information about breaking changes or added functionality (most version messages were about cherry-picks). From now on I'll add the breaking changes in the documentation so that developers can upgrade easily.