### PR TITLE
chore: replace @tiptap-cloud/provider with @tiptap-pro/provider and remove tiptap-beta notices

### DIFF
--- a/src/content/collaboration/getting-started/install.mdx
+++ b/src/content/collaboration/getting-started/install.mdx
@@ -96,20 +96,14 @@ Your editor is now almost prepared for collaborative editing!
 
 ### Connect to your Document server
 
-For collaborative functionality, install the `@tiptap-cloud/provider` package:
+For collaborative functionality, install the `@tiptap-pro/provider` package:
 
 <Callout title="Set up private registry" variant="hint">
 Note that you need to follow the instructions [here](https://cloud.tiptap.dev/pro-extensions) to set up access to the private registry.
-Additionally, you may need to add this line to your .npmrc:
-
-```
-@tiptap-cloud:registry=https://registry.tiptap.dev/
-```
-
 </Callout>
 
 ```bash
-npm install @tiptap-cloud/provider
+npm install @tiptap-pro/provider
 ```
 
 Next, configure the provider in your index.jsx file with your server details:
@@ -140,7 +134,7 @@ import * as Y from 'yjs'
 
 // Importing the provider and useEffect
 import { useEffect } from 'react'
-import { TiptapCollabProvider } from '@tiptap-cloud/provider'
+import { TiptapCollabProvider } from '@tiptap-pro/provider'
 
 const doc = new Y.Doc()
 
@@ -199,7 +193,7 @@ import * as Y from 'yjs'
 import Collaboration from '@tiptap/extension-collaboration'
 import { useEffect } from 'react'
 
-import { TiptapCollabProvider } from '@tiptap-cloud/provider'
+import { TiptapCollabProvider } from '@tiptap-pro/provider'
 
 const doc = new Y.Doc()
 

--- a/src/content/collaboration/provider/integration.mdx
+++ b/src/content/collaboration/provider/integration.mdx
@@ -16,20 +16,14 @@ The `TiptapCollabProvider` adds advanced features tailored for collaborative env
 
 ## Set up the provider
 
-First, install the provider package (make sure to stay on provider v2, as v3 required Tiptap v3, which is still in beta) in your project using:
+First, install the provider package in your project using:
 
 <Callout title="Set up private registry" variant="hint">
 Note that you need to follow the instructions [here](https://cloud.tiptap.dev/pro-extensions) to set up access to the private registry.
-Additionally, you may need to add this line to your .npmrc:
-
-```
-@tiptap-cloud:registry=https://registry.tiptap.dev/
-```
-
 </Callout>
 
 ```bash
-npm install @tiptap-cloud/provider
+npm install @tiptap-pro/provider
 ```
 
 For a basic setup, connect to the Collaboration backend by specifying the document's name, your app's ID (for cloud setups), or the base URL (for on-premises), along with your JWT.

--- a/src/content/pages/guides/collaboration-with-pages.mdx
+++ b/src/content/pages/guides/collaboration-with-pages.mdx
@@ -29,13 +29,13 @@ You can enable real-time collaboration in your paginated editor by combining the
 ## 2. Install the required packages
 
 ```bash
-npm install @tiptap-pro/extension-pages@alpha @tiptap-cloud/provider @tiptap/extension-collaboration
+npm install @tiptap-pro/extension-pages@alpha @tiptap-pro/provider @tiptap/extension-collaboration
 ```
 
 ## 3. Set up your collaborative provider
 
 ```js
-import { TiptapCollabProvider } from '@tiptap-cloud/provider'
+import { TiptapCollabProvider } from '@tiptap-pro/provider'
 import Collaboration from '@tiptap/extension-collaboration'
 import * as Y from 'yjs'
 
@@ -56,7 +56,7 @@ const provider = new TiptapCollabProvider({
 import { Editor } from '@tiptap/core'
 import StarterKit from '@tiptap/starter-kit'
 import { Pages } from '@tiptap-pro/extension-pages'
-import { TiptapCollabProvider } from '@tiptap-cloud/provider'
+import { TiptapCollabProvider } from '@tiptap-pro/provider'
 import Collaboration from '@tiptap/extension-collaboration'
 import * as Y from 'yjs'
 
@@ -91,4 +91,4 @@ const editor = new Editor({
 
 ## 6. Next steps
 - Explore [Pages options](/pages/core-concepts/options) for more layout control
-- See the [Tiptap collaboration docs](https://tiptap.dev/collaboration) for advanced usage 
+- See the [Tiptap collaboration docs](https://tiptap.dev/collaboration) for advanced usage


### PR DESCRIPTION
https://github.com/ueberdosis/tiptap-pro/pull/379