### PR TITLE
Switch pages demos to new source

### DIFF
--- a/src/content/pages/core-concepts/headers-footers.mdx
+++ b/src/content/pages/core-concepts/headers-footers.mdx
@@ -13,7 +13,7 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 Headers and footers let you add useful information to the top and bottom of every page, like page numbers, document titles, or custom text.
 
-<CodeDemo isPro src="https://deploy-preview-369--tiptap-pro.netlify.app/preview/extensions/pagesheaderfooter" />
+<CodeDemo isPro src="https://feature-pages-extension--tiptap-pro.netlify.app/preview/extensions/pagesheaderfooter" />
 
 ## Header and footer content
 You can set a header and a footer for your document. Each can be a string or a function that returns a string. This allows you to display static or dynamic content, such as page numbers or document titles, at the top (header) or bottom (footer) of every page.

--- a/src/content/pages/core-concepts/page-format.mdx
+++ b/src/content/pages/core-concepts/page-format.mdx
@@ -13,7 +13,7 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 The `pageFormat` option controls the size and margins of each page in your document. This helps your content look consistent and professional, especially when printing or exporting.
 
-<CodeDemo isPro src="https://deploy-preview-369--tiptap-pro.netlify.app/preview/extensions/pagespageformat" />
+<CodeDemo isPro src="https://feature-pages-extension--tiptap-pro.netlify.app/preview/extensions/pagespageformat" />
 
 ## Available formats
 

--- a/src/content/pages/getting-started/overview.mdx
+++ b/src/content/pages/getting-started/overview.mdx
@@ -16,7 +16,7 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 Tiptap Pages is a powerful extension that transforms your editing experience from a traditional single-block editor into a sophisticated page-based interface.
 
-<CodeDemo isPro src="https://deploy-preview-369--tiptap-pro.netlify.app/preview/extensions/pages" />
+<CodeDemo isPro src="https://feature-pages-extension--tiptap-pro.netlify.app/preview/extensions/pages" />
 
 With Pages, you can create documents that feel more like real pages, complete with proper margins, page breaks, and layout controls. This makes it perfect for creating documents that need to maintain a professional, page-based structure – whether you're working on reports, articles, or any other content that benefits from a traditional document format.
 

--- a/src/content/pages/guides/collaboration-with-pages.mdx
+++ b/src/content/pages/guides/collaboration-with-pages.mdx
@@ -16,7 +16,7 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 You can enable real-time collaboration in your paginated editor by combining the Pages extension with a collaborative provider, such as TiptapCollabProvider.
 
-<CodeDemo isPro src="https://deploy-preview-369--tiptap-pro.netlify.app/preview/extensions/pagescollaboration" />
+<CodeDemo isPro src="https://feature-pages-extension--tiptap-pro.netlify.app/preview/extensions/pagescollaboration" />
 
 ---
 

--- a/src/content/pages/guides/pagekit-usage.mdx
+++ b/src/content/pages/guides/pagekit-usage.mdx
@@ -16,7 +16,7 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 PageKit is a convenience extension that bundles the Pages and Table extensions together. It lets you configure both at once for a paginated, table-ready editor.
 
-<CodeDemo isPro src="https://deploy-preview-369--tiptap-pro.netlify.app/preview/extensions/pagespagekit" />
+<CodeDemo isPro src="https://feature-pages-extension--tiptap-pro.netlify.app/preview/extensions/pagespagekit" />
 
 ---
 

--- a/src/content/pages/guides/table-with-pages.mdx
+++ b/src/content/pages/guides/table-with-pages.mdx
@@ -16,7 +16,7 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 To add tables to your paginated editor, you should use the TableKit extension included in the Pages package. This ensures full compatibility with pagination as in order to properly split tables across the pages we needed to heavily modify the behavior and layout of tables.
 
-<CodeDemo isPro src="https://deploy-preview-369--tiptap-pro.netlify.app/preview/extensions/pagestables" />
+<CodeDemo isPro src="https://feature-pages-extension--tiptap-pro.netlify.app/preview/extensions/pagestables" />
 
 ---
 

--- a/src/content/pages/guides/zero-to-print-ready.mdx
+++ b/src/content/pages/guides/zero-to-print-ready.mdx
@@ -16,7 +16,7 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 This guide will walk you through setting up a Tiptap editor from scratch, adding the Pages extension for pagination and print-like layout, and enabling DOCX export and import for a professional, print-ready workflow.
 
-<CodeDemo isPro src="https://deploy-preview-369--tiptap-pro.netlify.app/preview/extensions/pagesimportexportdocx" />
+<CodeDemo isPro src="https://feature-pages-extension--tiptap-pro.netlify.app/preview/extensions/pagesimportexportdocx" />
 
 ---
 


### PR DESCRIPTION
This pull request updates the `src` attribute of the `CodeDemo` component across several documentation files to point to a new feature-specific deployment URL (`feature-pages-extension--tiptap-pro.netlify.app`). These changes ensure that the examples in the documentation reflect the latest feature updates.

Updates to `CodeDemo` component URLs:

* [`src/content/pages/core-concepts/headers-footers.mdx`](diffhunk://#diff-88564e5c585c26a9a0d437f63298f17948c62f6fb305b165fab3150538393ea0L16-R16): Updated the `src` attribute to point to the new feature-specific deployment for the headers and footers example.
* [`src/content/pages/core-concepts/page-format.mdx`](diffhunk://#diff-4fb50350a11b7d1925b0ef4689d0af83d0d000865489e469b68a91a606d22d9cL16-R16): Updated the `src` attribute to use the new deployment for the page format example.
* [`src/content/pages/getting-started/overview.mdx`](diffhunk://#diff-c5fe9181a0ceb4f4eaf2ae5f58a7b55b8370d69378d2fb887a3ddb3cd174522dL19-R19): Updated the `src` attribute for the overview example to reflect the new deployment.

Updates in guides:

* [`src/content/pages/guides/collaboration-with-pages.mdx`](diffhunk://#diff-6005daa63530d82e041f144df988fe977028003802d654b353facb2af70695afL19-R19): Updated the `src` attribute to point to the new deployment for the collaboration example.
* [`src/content/pages/guides/pagekit-usage.mdx`](diffhunk://#diff-38deefc5c7730a90b1a02b9c46e6fccfec4ab594a970e915b6d7395a5a19e0cbL19-R19): Updated the `src` attribute for the PageKit usage example to the new deployment.
* [`src/content/pages/guides/table-with-pages.mdx`](diffhunk://#diff-b35c35366c0e099459ae698fb595af81331d16012e9e57dab11c52ae5ca73addL19-R19): Updated the `src` attribute for the tables example to the new deployment.
* [`src/content/pages/guides/zero-to-print-ready.mdx`](diffhunk://#diff-515c66b9df2d53cbb1c6ead1b86e6a7e84f3a74b2064e3352ae00329e6a4f734L19-R19): Updated the `src` attribute for the zero-to-print-ready example to the new deployment.