### PR TITLE
Docx page size export docs

### DIFF
--- a/src/content/conversion/import-export/docx/custom-page-layout.mdx
+++ b/src/content/conversion/import-export/docx/custom-page-layout.mdx
@@ -1,0 +1,210 @@
+---
+title: Custom page layouts in DOCX
+tags:
+  - type: start
+  - type: beta
+meta:
+    title: Custom page layouts in DOCX | Tiptap Conversion
+    description: Learn how to customize your DOCX (Word) page and margin sizes using the Export extension.
+    category: Conversion
+---
+
+import { Callout } from '@/components/ui/Callout'
+import { CodeDemo } from '@/components/CodeDemo'
+import { Requirements, RequirementItem } from '@/components/Requirements'
+
+<Requirements>
+    <RequirementItem label="1. Activate trial or subscribe">
+        Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start plan](https://cloud.tiptap.dev/v2/billing) in your account.
+    </RequirementItem>
+    <RequirementItem label="2. Install from private registry">
+        To install this frontend extension, authenticate to Tiptap's private npm registry by following the [setup guide](/guides/pro-extensions).
+    </RequirementItem>
+</Requirements>
+
+The DOCX Export extension now supports custom page sizes and margins, allowing you to create documents with precise layouts that match your requirements. Whether you need A5 pages, custom paper sizes, or specific margin configurations, you can configure these settings directly in the extension.
+
+<CodeDemo src="https://feature-beta-conversion-extensions--tiptap-pro.netlify.app/preview/Extensions/ExportDocxCustomPageSize" />
+
+## Page size configuration
+
+Use the `pageSize` option to define custom page dimensions for your exported DOCX files. The page size configuration accepts width and height values with various measurement units.
+
+### Supported units
+
+All page size and margin measurements support the following universal units:
+
+| Unit | Description            |
+|------|------------------------|
+| `cm` | Centimeters (default) |
+| `in` | Inches                |
+| `pt` | Points                |
+| `pc` | Picas                 |
+| `mm` | Millimeters           |
+| `px` | Pixels                |
+
+### Configuration options
+
+| Property | Type | Description | Default |
+|----------|------|-------------|---------|
+| `width` | `PositiveUniversalMeasure` | The width of the page. Must be positive | `"21.0cm"` (A4 width) |
+| `height` | `PositiveUniversalMeasure` | The height of the page. Must be positive | `"29.7cm"` (A4 height) |
+
+<Callout title="PositiveUniversalMeasure">
+A `PositiveUniversalMeasure` is a string representing a positive length with a unit, such as `"21cm"`, `"8.5in"`, `"148mm"`, `"595pt"`, `"50pc"`, or `"800px"`. Supported units include centimeters (`cm`), millimeters (`mm`), inches (`in`), points (`pt`), picas (`pc`), and pixels (`px`). The value must be greater than zero. If you provide a value without a unit, centimeters (`cm`) will be used by default.
+</Callout>
+
+```js
+ExportDocx.configure({
+  onCompleteExport: (result) => {
+    // Handle the exported file
+  },
+  pageSize: {
+    width: '14.8cm',    // A5 width
+    height: '21cm',     // A5 height
+  },
+})
+```
+
+## Page margins configuration
+
+The `pageMargins` option allows you to set custom margins for all sides of your document pages. Unlike page sizes, margins can accept negative values if needed.
+
+### Configuration options
+
+| Property | Type | Description | Default |
+|----------|------|-------------|---------|
+| `top` | `UniversalMeasure` | Top margin of the page.<br />Can be negative. | `"1.0cm"` |
+| `bottom` | `UniversalMeasure` | Bottom margin of the page.<br />Can be negative. | `"1.0cm"` |
+| `left` | `PositiveUniversalMeasure` | Left margin of the page. Must be positive. | `"1.0cm"` |
+| `right` | `PositiveUniversalMeasure` | Right margin of the page. Must be positive. | `"1.0cm"` |
+
+<Callout title="UniversalMeasure">
+A `UniversalMeasure` is a string representing a length with a unit, such as `"21cm"`, `"8.5in"`, `"148mm"`, `"595pt"`, `"50pc"`, or `"800px"`. Supported units include centimeters (`cm`), millimeters (`mm`), inches (`in`), points (`pt`), picas (`pc`), and pixels (`px`). **The value can be positive or negative**. If you provide a value without a unit, centimeters (`cm`) will be used by default.
+</Callout>
+
+<Callout title="PositiveUniversalMeasure">
+A `PositiveUniversalMeasure` is a string representing a positive length with a unit, such as `"21cm"`, `"8.5in"`, `"148mm"`, `"595pt"`, `"50pc"`, or `"800px"`. Supported units include centimeters (`cm`), millimeters (`mm`), inches (`in`), points (`pt`), picas (`pc`), and pixels (`px`). The value must be greater than zero. If you provide a value without a unit, centimeters (`cm`) will be used by default.
+</Callout>
+
+
+```js
+ExportDocx.configure({
+  onCompleteExport: (result) => {
+    // Handle the exported file
+  },
+  pageMargins: {
+    top: '2cm',
+    bottom: '2cm', 
+    left: '1.5cm',
+    right: '1.5cm',
+  },
+})
+```
+
+## Complete example
+
+Here's a complete example showing how to configure custom page layouts with the DOCX Export extension:
+
+```js
+import { ExportDocx } from '@tiptap-pro/extension-export-docx'
+
+const editor = new Editor({
+  extensions: [
+    // Other extensions...
+    ExportDocx.configure({
+      onCompleteExport: result => {
+        // Create and download the DOCX file
+        const blob = new Blob([result], {
+          type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        })
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        
+        a.href = url
+        a.download = 'custom-layout.docx'
+        a.click()
+        URL.revokeObjectURL(url)
+      },
+      // A5 page size
+      pageSize: {
+        width: '14.8cm',
+        height: '21cm',
+      },
+      // Custom margins
+      pageMargins: {
+        top: '2cm',
+        bottom: '2cm',
+        left: '2cm',
+        right: '2cm',
+      },
+    }),
+    // Other extensions...
+  ],
+})
+```
+
+## Common page sizes
+
+Here are some common page sizes you can use as reference:
+
+| Format | Width | Height |
+|--------|-------|--------|
+| **A4** | `21.0cm` | `29.7cm` |
+| **A5** | `14.8cm` | `21.0cm` |
+| **Letter** | `8.5in` | `11in` |
+| **Legal** | `8.5in` | `14in` |
+| **Tabloid** | `11in` | `17in` |
+
+## Different measurement units
+
+You can mix and match different units based on your preference:
+
+```js
+ExportDocx.configure({
+  onCompleteExport: (result) => {
+    // Handle the exported file
+  },
+  // US Letter size in inches
+  pageSize: {
+    width: '8.5in',
+    height: '11in',
+  },
+  // Margins in different units
+  pageMargins: {
+    top: '0.75in',    // Inches
+    bottom: '72pt',   // Points (1 inch = 72 points)
+    left: '2cm',      // Centimeters
+    right: '20mm',    // Millimeters
+  },
+})
+```
+
+<Callout title="Unit consistency" variant="hint">
+    While you can mix different units, it's generally recommended to use consistent units throughout your configuration for better maintainability and clarity.
+</Callout>
+
+## Runtime configuration
+
+You can also override page layout settings when calling the export command directly:
+
+```js
+// Export with different page layout settings
+editor.commands.exportDocx({
+  onCompleteExport: (result) => {
+    // Handle the exported file
+  },
+  pageSize: {
+    width: '11in',    // Tabloid width
+    height: '17in',   // Tabloid height
+  },
+  pageMargins: {
+    top: '0.5in',
+    bottom: '0.5in',
+    left: '0.75in',
+    right: '0.75in',
+  },
+})
+```
+
+This allows you to create different export configurations for different use cases without reconfiguring the entire extension.

--- a/src/content/conversion/sidebar.ts
+++ b/src/content/conversion/sidebar.ts
@@ -43,6 +43,11 @@ export const sidebarConfig: SidebarConfig = {
               href: '/conversion/import-export/docx/rest-api',
             },
             {
+              title: 'Custom page layout',
+              href: '/conversion/import-export/docx/custom-page-layout',
+              tags: ['New'],
+            },
+            {
               title: 'Convert custom nodes',
               href: '/conversion/import-export/docx/custom-node-conversion',
             },


### PR DESCRIPTION
This pull request introduces a new documentation page for configuring custom page layouts in DOCX exports, along with an update to the sidebar navigation to include this new page. The documentation provides detailed guidance on setting custom page sizes, margins, and runtime configurations for the DOCX Export extension.

### New Documentation and Features for DOCX Export:

* Added a new documentation page, `custom-page-layout.mdx`, explaining how to configure custom page sizes and margins in DOCX exports. This includes examples, supported measurement units, and runtime configuration options. (`[src/content/conversion/import-export/docx/custom-page-layout.mdxR1-R210](diffhunk://#diff-60fd0fb6ba60e4bbac5da5398881c83d32e3c6ae9a0335e47002eec1f894fc64R1-R210)`)
* Updated the `sidebar.ts` file to include a link to the new "Custom page layout" documentation under the DOCX section, with a "New" tag for visibility. (`[src/content/conversion/sidebar.tsR45-R49](diffhunk://#diff-0a84038e304a0cbe2483373a4e1b3940018da332a61acee643a6dc9e06230303R45-R49)`)