### PR TITLE
Export docx API header footer docs

### DIFF
--- a/src/content/conversion/import-export/docx/rest-api.mdx
+++ b/src/content/conversion/import-export/docx/rest-api.mdx
@@ -122,10 +122,7 @@ curl --output example.docx -X POST https://api.tiptap.dev/v2/convert/export \
     -H "Authorization: Bearer <your-jwt-token>" \
     -H "X-App-Id: <your-app-id>" \
     -F 'doc={"type":"doc","content":[{"type":"paragraph","attrs":{"textAlign":"left"},"content":[{"type":"text","text":"Welcome to this demonstration of our editor'\''s ability to export a wide array of formatting options to DOCX, ensuring that your content retains its intended appearance in Word."}]}]}' \
-    -F 'exportType=blob' \
-    -F 'styleOverrides={}'
-    -F 'headers={}'
-    -F 'footers={}'
+    -F 'exportType=blob'
 ```
 
 <Callout title="Subscription required" variant="warning">
@@ -146,8 +143,51 @@ curl --output example.docx -X POST https://api.tiptap.dev/v2/convert/export \
 | `doc`                    | `String` | Tiptap's JSON             | `N/A`       |
 | `exportType`             | `string` | The expected export type  | `blob`      |
 | `styleOverrides`         | `Object` | Style overrides           | `{}`        |
+| `pageSize`               | `Object` | Page size configuration   | `undefined` |
+| `pageMargins`            | `Object` | Page margins configuration| `undefined` |
 | `headers`                | `Object` | Page header configuration | `undefined` |
 | `footers`                | `Object` | Page footer configuration | `undefined` |
+
+#### Page Size Configuration
+
+The `pageSize` object allows you to customize the dimensions of your exported DOCX document:
+
+| Property | Type | Description | Default |
+| --- | --- | --- | --- |
+| `width` | `string` | The width of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px). | `"21.0cm"` |
+| `height` | `string` | The height of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px). | `"29.7cm"` |
+
+**Example cURL with custom page size:**
+```bash
+curl --output example.docx -X POST https://api.tiptap.dev/v2/convert/export \
+    -H "Authorization: Bearer <your-jwt-token>" \
+    -H "X-App-Id: <your-app-id>" \
+    -F 'doc={"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Document with custom page size"}]}]}' \
+    -F 'exportType=blob' \
+    -F 'pageSize={"width":"21.0cm","height":"29.7cm"}'
+```
+
+#### Page Margins Configuration
+
+The `pageMargins` object allows you to customize the margins of your exported DOCX document:
+
+| Property | Type | Description | Default |
+| --- | --- | --- | --- |
+| `top` | `string` | The top margin of the page. Can be negative. Must be a number followed by a valid unit (cm, in, pt, pc, mm, px). | `"1.0cm"` |
+| `bottom` | `string` | The bottom margin of the page. Can be negative. Must be a number followed by a valid unit (cm, in, pt, pc, mm, px). | `"1.0cm"` |
+| `left` | `string` | The left margin of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px). | `"1.0cm"` |
+| `right` | `string` | The right margin of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px). | `"1.0cm"` |
+
+
+**Example cURL with custom page margins:**
+```bash
+curl --output example.docx -X POST https://api.tiptap.dev/v2/convert/export \
+    -H "Authorization: Bearer <your-jwt-token>" \
+    -H "X-App-Id: <your-app-id>" \
+    -F 'doc={"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Document with custom margins"}]}]}' \
+    -F 'exportType=blob' \
+    -F 'pageMargins={"top":"2.0cm","bottom":"2.0cm","left":"1.5cm","right":"1.5cm"}'
+```
 
 #### Headers and footers
 
@@ -172,6 +212,16 @@ The `headers` object allows you to customize the headers of your exported DOCX d
     Since API calls cannot properly serialize very complex objects or functions, the headers configuration is limited to plain strings that we then will convert for you, without any styling, to a standard DOCX heading.
 </Callout>
 
+**Example cURL with custom headers:**
+```bash
+curl --output example.docx -X POST https://api.tiptap.dev/v2/convert/export \
+    -H "Authorization: Bearer <your-jwt-token>" \
+    -H "X-App-Id: <your-app-id>" \
+    -F 'doc={"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Document with custom headers"}]}]}' \
+    -F 'exportType=blob' \
+    -F 'headers={"evenAndOddHeaders":true,"default":"Default Header","first":"First Page Header","even":"Even Page Header"}'
+```
+
 #### Footers Configuration
 
 The `footers` object allows you to customize the footers of your exported DOCX document:
@@ -186,3 +236,13 @@ The `footers` object allows you to customize the footers of your exported DOCX d
 <Callout title="Limitations">
     Since API calls cannot properly serialize very complex objects or functions, the footers configuration is limited to plain strings that we then will convert for you, without any styling, to a standard DOCX footer.
 </Callout>
+
+**Example cURL with custom footers:**
+```bash
+curl --output example.docx -X POST https://api.tiptap.dev/v2/convert/export \
+    -H "Authorization: Bearer <your-jwt-token>" \
+    -H "X-App-Id: <your-app-id>" \
+    -F 'doc={"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Document with custom footers"}]}]}' \
+    -F 'exportType=blob' \
+    -F 'footers={"evenAndOddFooters":true,"default":"Default Footer","first":"First Page Footer","even":"Even Page Footer"}'
+```

--- a/src/content/conversion/import-export/docx/rest-api.mdx
+++ b/src/content/conversion/import-export/docx/rest-api.mdx
@@ -153,7 +153,7 @@ curl --output example.docx -X POST https://api.tiptap.dev/v2/convert/export \
 
 The headers and footers objects allows you to configure a set of headers and footers options for your exported DOCX.
 
-<Callout title="Headers and footers">
+<Callout title="Team License Requirement">
     In order to be able to use the headers and footers within the REST API you must have a `Team` license.
 </Callout>
 

--- a/src/content/conversion/import-export/docx/rest-api.mdx
+++ b/src/content/conversion/import-export/docx/rest-api.mdx
@@ -124,6 +124,8 @@ curl --output example.docx -X POST https://api.tiptap.dev/v2/convert/export \
     -F 'doc={"type":"doc","content":[{"type":"paragraph","attrs":{"textAlign":"left"},"content":[{"type":"text","text":"Welcome to this demonstration of our editor'\''s ability to export a wide array of formatting options to DOCX, ensuring that your content retains its intended appearance in Word."}]}]}' \
     -F 'exportType=blob' \
     -F 'styleOverrides={}'
+    -F 'headers={}'
+    -F 'footers={}'
 ```
 
 <Callout title="Subscription required" variant="warning">
@@ -139,8 +141,48 @@ curl --output example.docx -X POST https://api.tiptap.dev/v2/convert/export \
 
 ### Body
 
-| Name                     | Type     | Description              | Default |
-| ------------------------ | -------- | -------------------------|---------|
-| `doc`                    | `String` | Tiptap's JSON            | `N/A`   |
-| `exportType`             | `string` | The expected export type | `blob`  |
-| `styleOverrides`         | `Object` | Style overrides          | `{}`    |
+| Name                     | Type     | Description               | Default     |
+| ------------------------ | -------- | --------------------------|-------------|
+| `doc`                    | `String` | Tiptap's JSON             | `N/A`       |
+| `exportType`             | `string` | The expected export type  | `blob`      |
+| `styleOverrides`         | `Object` | Style overrides           | `{}`        |
+| `headers`                | `Object` | Page header configuration | `undefined` |
+| `footers`                | `Object` | Page footer configuration | `undefined` |
+
+#### Headers and footers
+
+The headers and footers objects allows you to configure a set of headers and footers options for your exported DOCX.
+
+<Callout title="Headers and footers">
+    In order to be able to use the headers and footers within the REST API you must have a `Team` license.
+</Callout>
+
+##### Headers Configuration
+
+The `headers` object allows you to customize the headers of your exported DOCX document:
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `evenAndOddHeaders` | `boolean` | Whether to use different headers for odd and even pages |
+| `default` | `string` | The standard default header on every page, or header on odd pages when the `evenAndOddHeaders` option is activated. |
+| `first` | `string` | The header on the first page when the 'Different First Page' option is activated. |
+| `even` | `string` | The header on even pages when the `evenAndOddHeaders` option is activated. |
+
+<Callout title="Limitations">
+    Since API calls cannot properly serialize very complex objects or functions, the headers configuration is limited to plain strings that we then will convert for you, without any styling, to a standard DOCX heading.
+</Callout>
+
+#### Footers Configuration
+
+The `footers` object allows you to customize the footers of your exported DOCX document:
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `evenAndOddFooters` | `boolean` | Whether to use different footers for odd and even pages |
+| `default` | `string` | The standard default footer on every page, or footer on odd pages when the `evenAndOddFooters` option is activated. |
+| `first` | `string` | The footer on the first page when the 'Different First Page' option is activated. |
+| `even` | `string` | The footer on even pages when the `evenAndOddFooters` option is activated. |
+
+<Callout title="Limitations">
+    Since API calls cannot properly serialize very complex objects or functions, the footers configuration is limited to plain strings that we then will convert for you, without any styling, to a standard DOCX footer.
+</Callout>


### PR DESCRIPTION
This pull request enhances the DOCX export functionality in the REST API by introducing support for customizable headers and footers. It also updates the documentation to reflect these changes, including detailed configuration options and limitations.

### Enhancements to DOCX Export:

* Added support for `headers` and `footers` configuration in the DOCX export API. These allow users to customize page headers and footers with options such as `evenAndOddHeaders`, `default`, `first`, and `even`. [[1]](diffhunk://#diff-1368f6e4a5073e8c56f10de8817962de3169063eac5006f14db3ee34c4c36dc0R127-R128) [[2]](diffhunk://#diff-1368f6e4a5073e8c56f10de8817962de3169063eac5006f14db3ee34c4c36dc0L143-R188)
* Documented the new `headers` and `footers` objects, including their properties and usage, in the `src/content/conversion/import-export/docx/rest-api.mdx` file.

### Documentation Improvements:

* Added a section explaining the limitations of headers and footers configuration, noting that only plain strings are supported due to API serialization constraints.
* Updated the table of request body parameters to include `headers` and `footers`, with their types, descriptions, and default values.