### PR TITLE
docs: add move-node-button documentation

### DIFF
--- a/.changeset/floppy-parts-smile.md
+++ b/.changeset/floppy-parts-smile.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+docs: add move-node-button documentation

--- a/src/content/ui-components/components/move-node-button.mdx
+++ b/src/content/ui-components/components/move-node-button.mdx
@@ -2,7 +2,7 @@
 title: Move Node Button
 meta:
   title: Move Node Button | Tiptap UI Components
-  description: Move selected nodes and blocks up or down in Tiptap editors with keyboard shortcuts, intelligent selection handling, and accessibility support.
+  description: Move selected nodes and blocks up or down in the Tiptap editor with keyboard shortcuts, intelligent selection handling, and accessibility support.
   category: UI Components
 component:
   name: Move Node Button

--- a/src/content/ui-components/components/move-node-button.mdx
+++ b/src/content/ui-components/components/move-node-button.mdx
@@ -1,0 +1,193 @@
+---
+title: Move Node Button
+meta:
+  title: Move Node Button | Tiptap UI Components
+  description: Move selected nodes and blocks up or down in Tiptap editors with keyboard shortcuts, intelligent selection handling, and accessibility support.
+  category: UI Components
+component:
+  name: Move Node Button
+  description: A prebuilt React component that moves nodes up or down in the editor.
+  type: component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: AlignTopIcon
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+A fully accessible move node button for Tiptap editors. Reorder selected nodes or blocks in the editor with keyboard shortcut support and smart selection handling.
+
+<CodeDemo isScrollable src="https://template.tiptap.dev/preview/tiptap-ui/move-node-button" />
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add move-node-button
+```
+
+## Components
+
+### `<MoveNodeButton />`
+
+A prebuilt React component that moves nodes up or down in the editor.
+
+#### Usage
+
+```tsx
+export default function MyEditor() {
+  return (
+    <>
+      <MoveNodeButton
+        editor={editor}
+        direction="up"
+        text="Move Up"
+        hideWhenUnavailable={true}
+        showShortcut={true}
+        onMoved={(direction) => console.log(`Node moved ${direction}!`)}
+      />
+      <MoveNodeButton
+        editor={editor}
+        direction="down"
+        text="Move Down"
+        hideWhenUnavailable={true}
+        showShortcut={true}
+        onMoved={(direction) => console.log(`Node moved ${direction}!`)}
+      />
+    </>
+  )
+}
+```
+
+#### Props
+
+| Name                  | Type                                  | Default      | Description                                    |
+| --------------------- | ------------------------------------- | ------------ | ---------------------------------------------- |
+| `editor`              | `Editor \| null`                      | `undefined`  | The Tiptap editor instance                     |
+| `direction`           | `"up" \| "down"`                      | **Required** | Direction to move the node                     |
+| `text`                | `string`                              | `undefined`  | Optional text label for the button             |
+| `hideWhenUnavailable` | `boolean`                             | `false`      | Hides the button when moving is not available  |
+| `onMoved`             | `(direction: "up" \| "down") => void` | `undefined`  | Callback fired after a successful move         |
+| `showShortcut`        | `boolean`                             | `false`      | Shows a keyboard shortcut badge (if available) |
+
+## Hooks
+
+### `useMoveNode()`
+
+A custom hook to build your own move node button with full control over rendering and behavior.
+
+#### Usage
+
+```tsx
+function MyMoveNodeButton({ direction }: { direction: 'up' | 'down' }) {
+  const { isVisible, handleMoveNode, canMoveNode, label, shortcutKeys, Icon } = useMoveNode({
+    editor: myEditor,
+    direction,
+    hideWhenUnavailable: true,
+    onMoved: (direction) => console.log(`Node moved ${direction}!`),
+  })
+
+  if (!isVisible) return null
+
+  return (
+    <button onClick={handleMoveNode} disabled={!canMoveNode} aria-label={label}>
+      <Icon />
+      {label}
+      {shortcutKeys && <Badge>{parseShortcutKeys({ shortcutKeys })}</Badge>}
+    </button>
+  )
+}
+```
+
+#### Props
+
+| Name                  | Type                                  | Default      | Description                                    |
+| --------------------- | ------------------------------------- | ------------ | ---------------------------------------------- |
+| `editor`              | `Editor \| null`                      | `undefined`  | The Tiptap editor instance                     |
+| `direction`           | `"up" \| "down"`                      | **Required** | Direction to move the node                     |
+| `hideWhenUnavailable` | `boolean`                             | `false`      | Hides the button if moving cannot be performed |
+| `onMoved`             | `(direction: "up" \| "down") => void` | `undefined`  | Callback fired after successful move           |
+
+#### Return Values
+
+| Name             | Type            | Description                                                       |
+| ---------------- | --------------- | ----------------------------------------------------------------- |
+| `isVisible`      | `boolean`       | Whether the button should be rendered                             |
+| `canMoveNode`    | `boolean`       | If a node can be moved in the specified direction                 |
+| `handleMoveNode` | `() => boolean` | Function to move the selected node                                |
+| `label`          | `string`        | Accessible label text for the button                              |
+| `shortcutKeys`   | `string`        | Keyboard shortcut for the direction                               |
+| `Icon`           | `React.FC`      | Icon component for the move button (AlignTopIcon/AlignBottomIcon) |
+
+## Utilities
+
+### `canMoveNode(editor, direction)`
+
+Checks if a node can be moved in the specified direction in the current editor state.
+
+```tsx
+import { canMoveNode } from '@/components/tiptap-ui/move-node-button'
+
+const canMoveUp = canMoveNode(editor, 'up')
+const canMoveDown = canMoveNode(editor, 'down')
+```
+
+### `moveNode(editor, direction)`
+
+Programmatically moves the selected node or block in the specified direction.
+
+```tsx
+import { moveNode } from '@/components/tiptap-ui/move-node-button'
+
+const success = moveNode(editor, 'up')
+if (success) {
+  console.log('Node moved successfully!')
+}
+```
+
+### `shouldShowButton(props)`
+
+Utility to determine if the move button should be visible based on editor state and configuration.
+
+```tsx
+import { shouldShowButton } from '@/components/tiptap-ui/move-node-button'
+
+const shouldShow = shouldShowButton({
+  editor,
+  direction: 'up',
+  hideWhenUnavailable: true,
+})
+```
+
+## Keyboard Shortcuts
+
+The move node button supports the following keyboard shortcuts:
+
+- **Cmd/Ctrl + Shift + Arrow Up**: Move the selected node up
+- **Cmd/Ctrl + Shift + Arrow Down**: Move the selected node down
+
+The shortcuts are automatically registered when using either the `<MoveNodeButton />` component or the `useMoveNode()` hook. These shortcuts work with any block-level node including paragraphs, headings, blockquotes, and code blocks.
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` - Core Tiptap React integration
+- `@tiptap/pm/state` - ProseMirror state management
+- `react-hotkeys-hook` - Keyboard shortcut management
+
+### Referenced Components
+
+- `use-tiptap-editor` (hook)
+- `use-mobile` (hook)
+- `button` (primitive)
+- `badge` (primitive)
+- `tiptap-utils` (lib)
+- `tiptap-advanced-utils` (lib)
+- `align-top-icon` (icon)
+- `align-bottom-icon` (icon)

--- a/src/content/ui-components/sidebar.ts
+++ b/src/content/ui-components/sidebar.ts
@@ -90,7 +90,7 @@ export const sidebarConfig: SidebarConfig = {
               href: '/ui-components/components/ai-ask-button',
             },
             {
-              title: 'Ai Menu',
+              title: 'Ai menu',
               href: '/ui-components/components/ai-menu',
             },
             {
@@ -184,6 +184,10 @@ export const sidebarConfig: SidebarConfig = {
             {
               title: 'Mention trigger button',
               href: '/ui-components/components/mention-trigger-button',
+            },
+            {
+              title: 'Move node button',
+              href: '/ui-components/components/move-node-button',
             },
             {
               title: 'Reset all formatting button',


### PR DESCRIPTION
Adds comprehensive documentation for `move-node-button` component.