### PR TITLE
add History's new name to migration tutorial

### DIFF
--- a/src/content/guides/upgrade-tiptap-v2.mdx
+++ b/src/content/guides/upgrade-tiptap-v2.mdx
@@ -220,7 +220,7 @@ The new `@tiptap/extensions` package combines multiple utility extensions:
 - [CharacterCount](/editor/extensions/functionality/character-count)
 - [Dropcursor](/editor/extensions/functionality/dropcursor)
 - [Gapcursor](/editor/extensions/functionality/gapcursor)
-- [History](/editor/extensions/functionality/undo-redo)
+- [History](/editor/extensions/functionality/undo-redo) (now named `UndoRedo`)
 - [Placeholder](/editor/extensions/functionality/placeholder)
 - [TrailingNode](/editor/extensions/functionality/trailing-node)
 - [Focus](/editor/extensions/functionality/focus)


### PR DESCRIPTION
Yes, you do mention earlier in the doc that the name has changed. I had read it, made a mental note, but silly old me forgot it 30 min later. Then ended up on this part of the tutorial and wasted 20 min until I realized my mistake. Just trying to save someone else that time.