### PR TITLE
docs(drag-handle): document onElementDragStart and onElementDragEnd props

### DIFF
--- a/.changeset/dark-taxes-lead.md
+++ b/.changeset/dark-taxes-lead.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Added documentation for `onElementDragStart` and `onElementDragEnd` props in `DragHandle`. These callbacks allow consumers to hook into the start and end of a drag interaction for custom behavior.

--- a/src/content/editor/extensions/functionality/drag-handle-react.mdx
+++ b/src/content/editor/extensions/functionality/drag-handle-react.mdx
@@ -101,6 +101,34 @@ Default: `undefined`
 </DragHandle>
 ```
 
+### onElementDragStart
+
+A function that is called when the element starts to be dragged. This can be used to add custom logic when dragging starts.
+
+```jsx
+<DragHandle
+  onElementDragStart={(e: DragEvent) => {
+    // do something when dragging starts
+  }}
+>
+  <div>Drag Me!</div>
+</DragHandle>
+```
+
+### onElementDragEnd
+
+A function that is called when the element stops being dragged. This can be used to add custom logic when dragging ends.
+
+```jsx
+<DragHandle
+  onElementDragEnd={(e: DragEvent) => {
+    // do something when dragging ends
+  }}
+>
+  <div>Drag Me!</div>
+</DragHandle>
+```
+
 ### Commands
 
 See the [DragHandle](/editor/extensions/functionality/drag-handle) extension for available editor commands.


### PR DESCRIPTION
### What’s Changed
- Added documentation for `onElementDragStart` and `onElementDragEnd` props in `DragHandle`.
- Each prop includes usage examples showing how to attach custom logic when drag starts and ends.

### Why
These callbacks were previously undocumented, making it unclear how to customize drag interactions. This update provides clear examples for developers who need to extend drag behavior.