### PR TITLE
fix: conditional tooltip text for templates vs extensions

### DIFF
--- a/src/app/[...markdownPath]/page.tsx
+++ b/src/app/[...markdownPath]/page.tsx
@@ -113,7 +113,10 @@ export default async function MarkdownPage({ params }: Props) {
                 </div>
               ) : null}
               {pageMdx.frontmatter?.tags ? (
-                <PageHeader.Tags tags={pageMdx.frontmatter.tags} />
+                <PageHeader.Tags
+                  tags={pageMdx.frontmatter.tags}
+                  isTemplate={params.markdownPath.includes('templates')}
+                />
               ) : null}
               {pageMdx.frontmatter.description ? (
                 <PageHeader.Description

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -103,7 +103,7 @@ export type GridItemParagraph = {
 
 export const ItemParagraph = forwardRef<HTMLParagraphElement, GridItemParagraph>(
   ({ asChild, className, children, ...props }, ref) => {
-    const Component = asChild ? Slot : 'p'
+    const Component = asChild ? Slot : 'div'
     const itemParagraphClass = cn('text-base leading-[140%]', className)
 
     return (

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -75,19 +75,26 @@ const isImageTag = (tag: PageTag): tag is ImagePageTag => {
 
 export type PageHeaderTagsProps = {
   tags: PageTag[]
+  isTemplate?: boolean
 }
 
-export const PageHeaderTags = ({ tags }: PageHeaderTagsProps) => {
+export const PageHeaderTags = ({ tags, isTemplate = false }: PageHeaderTagsProps) => {
   return (
     <div className="flex items-center gap-1 flex-wrap mt-6 last:mb-12">
       {tags.map((tag, index) => (
-        <PageHeaderTag tag={tag} key={index} />
+        <PageHeaderTag tag={tag} isTemplate={isTemplate} key={index} />
       ))}
     </div>
   )
 }
 
-export const PageHeaderTag = ({ tag }: { tag: PageTag }) => {
+export const PageHeaderTag = ({
+  tag,
+  isTemplate = false,
+}: {
+  tag: PageTag
+  isTemplate?: boolean
+}) => {
   if (isImageTag(tag)) {
     return (
       <Link href={tag.url} target="_blank" rel="noopener noreferrer">
@@ -113,16 +120,10 @@ export const PageHeaderTag = ({ tag }: { tag: PageTag }) => {
   }
 
   if (tag.type === 'start') {
-    return (
-      <Tag
-        tooltip={
-          tag.tooltip ||
-          'Integrate and use while subscribed to the Start plan. Usage of this template is subject to our Pro License and ToS.'
-        }
-      >
-        Available in Start plan
-      </Tag>
-    )
+    const defaultTooltip = isTemplate
+      ? 'Integrate and use while subscribed to the Start plan. Usage of this template is subject to our Pro License and ToS.'
+      : 'Integrate and use while subscribed to the Start plan.'
+    return <Tag tooltip={tag.tooltip || defaultTooltip}>Available in Start plan</Tag>
   }
 
   if (tag.type === 'mit') {
@@ -134,16 +135,10 @@ export const PageHeaderTag = ({ tag }: { tag: PageTag }) => {
   }
 
   if (tag.type === 'team') {
-    return (
-      <Tag
-        tooltip={
-          tag.tooltip ||
-          'Integrate and use while subscribed to the Team plan. Usage of this template is subject to our Pro License and ToS.'
-        }
-      >
-        Available in Team plan
-      </Tag>
-    )
+    const defaultTooltip = isTemplate
+      ? 'Integrate and use while subscribed to the Team plan. Usage of this template is subject to our Pro License and ToS.'
+      : 'Integrate and use while subscribed to the Team plan.'
+    return <Tag tooltip={tag.tooltip || defaultTooltip}>Available in Team plan</Tag>
   }
 
   if (tag.type === 'ai') {


### PR DESCRIPTION
- Add isTemplate prop to PageHeader.Tags component
- Pass isTemplate flag based on URL path containing 'templates'
- Show Pro License/ToS text only for templates, not extensions
- Fix hydration error by changing Grid.ItemParagraph from <p> to <div>

Fixes bug where "Usage of this template is subject to our Pro License and ToS" was incorrectly shown on extension pages instead of just template pages.