### PR TITLE
Feat/enterprise callout

### DIFF
--- a/src/components/EnterpriseCallout.tsx
+++ b/src/components/EnterpriseCallout.tsx
@@ -7,11 +7,14 @@ import { cn } from '@/utils'
 export type EnterpriseCalloutProps = {
   variant: 'migration' | 'ai-agent' | 'pages' | 'semantic-search'
   inline?: boolean
+  title?: string
+  description?: string
+  waitlistText?: string
 } & React.HTMLAttributes<HTMLDivElement>
 
 export const EnterpriseCallout = forwardRef<HTMLDivElement, EnterpriseCalloutProps>(
-  ({ variant, inline = false, className, ...rest }, ref) => {
-    const title =
+  ({ variant, inline = false, title, description, waitlistText, className, ...rest }, ref) => {
+    const defaultTitle =
       variant === 'migration'
         ? 'Migration support'
         : variant === 'ai-agent'
@@ -20,7 +23,7 @@ export const EnterpriseCallout = forwardRef<HTMLDivElement, EnterpriseCalloutPro
             ? 'Document layouts'
             : 'AI document search'
 
-    const description =
+    const defaultDescription =
       variant === 'migration'
         ? 'Get hands-on help migrating your content as part of Enterprise onboarding.'
         : variant === 'ai-agent'
@@ -29,7 +32,7 @@ export const EnterpriseCallout = forwardRef<HTMLDivElement, EnterpriseCalloutPro
             ? 'Get real-time integration support in a shared Slack channel for Enterprise customers.'
             : 'Semantic Search is currently available to Enterprise customers as part of a limited rollout.'
 
-    const waitlistText =
+    const defaultWaitlistText =
       variant === 'migration'
         ? 'On a different plan? Join the migration tools'
         : variant === 'ai-agent'
@@ -37,6 +40,10 @@ export const EnterpriseCallout = forwardRef<HTMLDivElement, EnterpriseCalloutPro
           : variant === 'pages'
             ? 'On a different plan? Join the'
             : 'On a different plan? Join the'
+
+    const finalTitle = title ?? defaultTitle
+    const finalDescription = description ?? defaultDescription
+    const finalWaitlistText = waitlistText ?? defaultWaitlistText
 
     if (inline) {
       return (
@@ -48,17 +55,17 @@ export const EnterpriseCallout = forwardRef<HTMLDivElement, EnterpriseCalloutPro
           )}
           {...rest}
         >
-          <h3 className="text-lg font-semibold mb-3">{title}</h3>
+          <h3 className="text-lg font-semibold mb-3">{finalTitle}</h3>
 
           <div className="grid md:grid-cols-3 gap-6">
             <div className="md:col-span-2">
-              <p className="text-sm text-grayAlpha-700 mb-3">{description.split('\n\n')[0]}</p>
-              {description.split('\n\n')[1] && (
-                <p className="text-sm text-grayAlpha-700 mb-3">{description.split('\n\n')[1]}</p>
+              <p className="text-sm text-grayAlpha-700 mb-3">{finalDescription.split('\n\n')[0]}</p>
+              {finalDescription.split('\n\n')[1] && (
+                <p className="text-sm text-grayAlpha-700 mb-3">{finalDescription.split('\n\n')[1]}</p>
               )}
 
               <p className="text-xs text-grayAlpha-600 mt-4">
-                {waitlistText}{' '}
+                {finalWaitlistText}{' '}
                 <Link
                   href="https://tiptap-suite.notion.site/1b601ffa3ebc80a281a8ea0b03b19bdd?pvs=105"
                   target="_blank"
@@ -96,8 +103,8 @@ export const EnterpriseCallout = forwardRef<HTMLDivElement, EnterpriseCalloutPro
         className={cn('p-5 rounded-xl border border-grayAlpha-200 bg-white', className)}
         {...rest}
       >
-        <h3 className="text-lg font-semibold mb-3">{title}</h3>
-        <p className="text-sm text-grayAlpha-700 mb-4 whitespace-pre-line">{description}</p>
+        <h3 className="text-lg font-semibold mb-3">{finalTitle}</h3>
+        <p className="text-sm text-grayAlpha-700 mb-4 whitespace-pre-line">{finalDescription}</p>
 
         <Button asChild className="w-full mb-3">
           <Link
@@ -112,7 +119,7 @@ export const EnterpriseCallout = forwardRef<HTMLDivElement, EnterpriseCalloutPro
 
         <div className="text-left mb-2">
           <p className="text-xs text-grayAlpha-600">
-            {waitlistText}{' '}
+            {finalWaitlistText}{' '}
             <Link
               href="https://tiptap-suite.notion.site/1b601ffa3ebc80a281a8ea0b03b19bdd?pvs=105"
               target="_blank"

--- a/src/components/EnterpriseCallout.tsx
+++ b/src/components/EnterpriseCallout.tsx
@@ -1,0 +1,136 @@
+import { forwardRef } from 'react'
+import { ArrowRightIcon } from 'lucide-react'
+import Link from './Link'
+import { Button } from './ui/Button'
+import { cn } from '@/utils'
+
+export type EnterpriseCalloutProps = {
+  variant: 'migration' | 'ai-agent' | 'pages' | 'semantic-search'
+  inline?: boolean
+} & React.HTMLAttributes<HTMLDivElement>
+
+export const EnterpriseCallout = forwardRef<HTMLDivElement, EnterpriseCalloutProps>(
+  ({ variant, inline = false, className, ...rest }, ref) => {
+    const title =
+      variant === 'migration'
+        ? 'Migration support'
+        : variant === 'ai-agent'
+          ? 'Build AI Agents with expert Support'
+          : variant === 'pages'
+            ? 'Document layouts'
+            : 'AI document search'
+
+    const description =
+      variant === 'migration'
+        ? 'Get hands-on help migrating your content as part of Enterprise onboarding.'
+        : variant === 'ai-agent'
+          ? "We're onboarding Enterprise teams building real-time editors and content tools. Get direct support for Agent setup, LLM integration, and performance tuning."
+          : variant === 'pages'
+            ? 'Get real-time integration support in a shared Slack channel for Enterprise customers.'
+            : 'Semantic Search is currently available to Enterprise customers as part of a limited rollout.'
+
+    const waitlistText =
+      variant === 'migration'
+        ? 'On a different plan? Join the migration tools'
+        : variant === 'ai-agent'
+          ? 'On a different plan? Join the'
+          : variant === 'pages'
+            ? 'On a different plan? Join the'
+            : 'On a different plan? Join the'
+
+    if (inline) {
+      return (
+        <div
+          ref={ref}
+          className={cn(
+            'p-6 rounded-xl border border-grayAlpha-200 bg-white max-w-[42rem]',
+            className,
+          )}
+          {...rest}
+        >
+          <h3 className="text-lg font-semibold mb-3">{title}</h3>
+
+          <div className="grid md:grid-cols-3 gap-6">
+            <div className="md:col-span-2">
+              <p className="text-sm text-grayAlpha-700 mb-3">{description.split('\n\n')[0]}</p>
+              {description.split('\n\n')[1] && (
+                <p className="text-sm text-grayAlpha-700 mb-3">{description.split('\n\n')[1]}</p>
+              )}
+
+              <p className="text-xs text-grayAlpha-600 mt-4">
+                {waitlistText}{' '}
+                <Link
+                  href="https://tiptap-suite.notion.site/1b601ffa3ebc80a281a8ea0b03b19bdd?pvs=105"
+                  target="_blank"
+                  className="font-medium text-purpleAlpha-600 hover:text-purpleAlpha-700 underline whitespace-nowrap"
+                >
+                  waitlist
+                </Link>
+              </p>
+            </div>
+
+            <div className="md:col-span-1 flex flex-col gap-2">
+              <Button asChild className="w-full">
+                <Link
+                  href="https://tiptap.dev/contact-sales"
+                  target="_blank"
+                  className="inline-flex items-center justify-center gap-2"
+                >
+                  Talk to an engineer
+                  <ArrowRightIcon className="w-4 h-4" />
+                </Link>
+              </Button>
+
+              <p className="text-xs text-grayAlpha-500 text-center">
+                Trusted by Axios, PostHog, Beehiiv, GitLab and more.
+              </p>
+            </div>
+          </div>
+        </div>
+      )
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn('p-5 rounded-xl border border-grayAlpha-200 bg-white', className)}
+        {...rest}
+      >
+        <h3 className="text-lg font-semibold mb-3">{title}</h3>
+        <p className="text-sm text-grayAlpha-700 mb-4 whitespace-pre-line">{description}</p>
+
+        <Button asChild className="w-full mb-3">
+          <Link
+            href="https://tiptap.dev/contact-sales"
+            target="_blank"
+            className="inline-flex items-center justify-center gap-2"
+          >
+            Talk to an engineer
+            <ArrowRightIcon className="w-4 h-4" />
+          </Link>
+        </Button>
+
+        <div className="text-left mb-2">
+          <p className="text-xs text-grayAlpha-600">
+            {waitlistText}{' '}
+            <Link
+              href="https://tiptap-suite.notion.site/1b601ffa3ebc80a281a8ea0b03b19bdd?pvs=105"
+              target="_blank"
+              className="font-medium text-purpleAlpha-600 hover:text-purpleAlpha-700 underline whitespace-nowrap"
+            >
+              waitlist
+            </Link>
+          </p>
+        </div>
+
+        <div className="border-t border-grayAlpha-100 my-2" />
+
+        <p className="text-xs text-grayAlpha-500">
+          Trusted by Axios, PostHog, Beehiiv, GitLab and more.
+        </p>
+      </div>
+    )
+  },
+)
+
+EnterpriseCallout.displayName = 'EnterpriseCallout'

--- a/src/components/EnterpriseCallout.tsx
+++ b/src/components/EnterpriseCallout.tsx
@@ -61,7 +61,9 @@ export const EnterpriseCallout = forwardRef<HTMLDivElement, EnterpriseCalloutPro
             <div className="md:col-span-2">
               <p className="text-sm text-grayAlpha-700 mb-3">{finalDescription.split('\n\n')[0]}</p>
               {finalDescription.split('\n\n')[1] && (
-                <p className="text-sm text-grayAlpha-700 mb-3">{finalDescription.split('\n\n')[1]}</p>
+                <p className="text-sm text-grayAlpha-700 mb-3">
+                  {finalDescription.split('\n\n')[1]}
+                </p>
               )}
 
               <p className="text-xs text-grayAlpha-600 mt-4">

--- a/src/components/EnterpriseCallout.tsx
+++ b/src/components/EnterpriseCallout.tsx
@@ -5,45 +5,45 @@ import { Button } from './ui/Button'
 import { cn } from '@/utils'
 
 export type EnterpriseCalloutProps = {
-  variant: 'migration' | 'ai-agent' | 'pages' | 'semantic-search'
+  variant: 'migration' | 'ai-agent' | 'pages' | 'semantic-search' | 'docx'
   inline?: boolean
-  title?: string
-  description?: string
-  waitlistText?: string
+  disableWaitlist?: boolean
 } & React.HTMLAttributes<HTMLDivElement>
 
 export const EnterpriseCallout = forwardRef<HTMLDivElement, EnterpriseCalloutProps>(
-  ({ variant, inline = false, title, description, waitlistText, className, ...rest }, ref) => {
-    const defaultTitle =
+  ({ variant, inline = false, disableWaitlist = false, className, ...rest }, ref) => {
+    const title =
       variant === 'migration'
         ? 'Migration support'
         : variant === 'ai-agent'
           ? 'Build AI Agents with expert Support'
           : variant === 'pages'
-            ? 'Document layouts'
-            : 'AI document search'
+            ? 'Integrate Pages with expert support'
+            : variant === 'docx'
+              ? 'Ship DOCX faster with expert support'
+              : 'Join the semantic search beta'
 
-    const defaultDescription =
+    const description =
       variant === 'migration'
         ? 'Get hands-on help migrating your content as part of Enterprise onboarding.'
         : variant === 'ai-agent'
-          ? "We're onboarding Enterprise teams building real-time editors and content tools. Get direct support for Agent setup, LLM integration, and performance tuning."
+          ? "We're onboarding Enterprise teams building real-time editors. Get direct support for Agent setup, LLM integration, and performance tuning."
           : variant === 'pages'
-            ? 'Get real-time integration support in a shared Slack channel for Enterprise customers.'
-            : 'Semantic Search is currently available to Enterprise customers as part of a limited rollout.'
+            ? "We're onboarding Enterprise teams ready to implement the page layout. Get direct engineering support and shape the product roadmap."
+            : variant === 'docx'
+              ? 'Get dedicated Slack support, priority features, and hands-on help from our engineers to integrate DOCX into your enterprise application.'
+              : 'Build intelligent search with dedicated engineering help and shape vector search capabilities by joining the Enterprise Beta program.'
 
-    const defaultWaitlistText =
+    const waitlistText =
       variant === 'migration'
-        ? 'On a different plan? Join the migration tools'
+        ? 'On a different plan? Join the'
         : variant === 'ai-agent'
           ? 'On a different plan? Join the'
           : variant === 'pages'
             ? 'On a different plan? Join the'
-            : 'On a different plan? Join the'
-
-    const finalTitle = title ?? defaultTitle
-    const finalDescription = description ?? defaultDescription
-    const finalWaitlistText = waitlistText ?? defaultWaitlistText
+            : variant === 'docx'
+              ? 'On a different plan? Join the'
+              : 'On a different plan? Join the'
 
     if (inline) {
       return (
@@ -55,27 +55,27 @@ export const EnterpriseCallout = forwardRef<HTMLDivElement, EnterpriseCalloutPro
           )}
           {...rest}
         >
-          <h3 className="text-lg font-semibold mb-3">{finalTitle}</h3>
+          <h3 className="text-lg font-semibold mb-3">{title}</h3>
 
           <div className="grid md:grid-cols-3 gap-6">
             <div className="md:col-span-2">
-              <p className="text-sm text-grayAlpha-700 mb-3">{finalDescription.split('\n\n')[0]}</p>
-              {finalDescription.split('\n\n')[1] && (
-                <p className="text-sm text-grayAlpha-700 mb-3">
-                  {finalDescription.split('\n\n')[1]}
-                </p>
+              <p className="text-sm text-grayAlpha-700 mb-3">{description.split('\n\n')[0]}</p>
+              {description.split('\n\n')[1] && (
+                <p className="text-sm text-grayAlpha-700 mb-3">{description.split('\n\n')[1]}</p>
               )}
 
-              <p className="text-xs text-grayAlpha-600 mt-4">
-                {finalWaitlistText}{' '}
-                <Link
-                  href="https://tiptap-suite.notion.site/1b601ffa3ebc80a281a8ea0b03b19bdd?pvs=105"
-                  target="_blank"
-                  className="font-medium text-purpleAlpha-600 hover:text-purpleAlpha-700 underline whitespace-nowrap"
-                >
-                  waitlist
-                </Link>
-              </p>
+              {!disableWaitlist && (
+                <p className="text-xs text-grayAlpha-600 mt-4">
+                  {waitlistText}{' '}
+                  <Link
+                    href="https://tiptap-suite.notion.site/1b601ffa3ebc80a281a8ea0b03b19bdd?pvs=105"
+                    target="_blank"
+                    className="font-medium text-purpleAlpha-600 hover:text-purpleAlpha-700 underline whitespace-nowrap"
+                  >
+                    waitlist
+                  </Link>
+                </p>
+              )}
             </div>
 
             <div className="md:col-span-1 flex flex-col gap-2">
@@ -105,8 +105,8 @@ export const EnterpriseCallout = forwardRef<HTMLDivElement, EnterpriseCalloutPro
         className={cn('p-5 rounded-xl border border-grayAlpha-200 bg-white', className)}
         {...rest}
       >
-        <h3 className="text-lg font-semibold mb-3">{finalTitle}</h3>
-        <p className="text-sm text-grayAlpha-700 mb-4 whitespace-pre-line">{finalDescription}</p>
+        <h3 className="text-lg font-semibold mb-3">{title}</h3>
+        <p className="text-sm text-grayAlpha-700 mb-4 whitespace-pre-line">{description}</p>
 
         <Button asChild className="w-full mb-3">
           <Link
@@ -119,18 +119,20 @@ export const EnterpriseCallout = forwardRef<HTMLDivElement, EnterpriseCalloutPro
           </Link>
         </Button>
 
-        <div className="text-left mb-2">
-          <p className="text-xs text-grayAlpha-600">
-            {finalWaitlistText}{' '}
-            <Link
-              href="https://tiptap-suite.notion.site/1b601ffa3ebc80a281a8ea0b03b19bdd?pvs=105"
-              target="_blank"
-              className="font-medium text-purpleAlpha-600 hover:text-purpleAlpha-700 underline whitespace-nowrap"
-            >
-              waitlist
-            </Link>
-          </p>
-        </div>
+        {!disableWaitlist && (
+          <div className="text-left mb-2">
+            <p className="text-xs text-grayAlpha-600">
+              {waitlistText}{' '}
+              <Link
+                href="https://tiptap-suite.notion.site/1b601ffa3ebc80a281a8ea0b03b19bdd?pvs=105"
+                target="_blank"
+                className="font-medium text-purpleAlpha-600 hover:text-purpleAlpha-700 underline whitespace-nowrap"
+              >
+                waitlist
+              </Link>
+            </p>
+          </div>
+        )}
 
         <div className="border-t border-grayAlpha-100 my-2" />
 

--- a/src/components/EnterpriseCalloutAuto.tsx
+++ b/src/components/EnterpriseCalloutAuto.tsx
@@ -5,13 +5,15 @@ import { createPortal } from 'react-dom'
 import { EnterpriseCallout } from './EnterpriseCallout'
 
 export type EnterpriseCalloutAutoProps = {
-  variant: 'migration' | 'ai-agent' | 'pages' | 'semantic-search'
-  renderMode?: 'inline' | 'portal-sidebar'
+  variant: 'migration' | 'ai-agent' | 'pages' | 'semantic-search' | 'docx'
+  renderMode?: 'inline' | 'sidebar'
+  disableWaitlist?: boolean
 }
 
 export const EnterpriseCalloutAuto = ({
   variant,
-  renderMode = 'portal-sidebar',
+  renderMode = 'sidebar',
+  disableWaitlist = false,
 }: EnterpriseCalloutAutoProps) => {
   const [mounted, setMounted] = useState(false)
   const [sidebarElement, setSidebarElement] = useState<Element | null>(null)
@@ -19,7 +21,7 @@ export const EnterpriseCalloutAuto = ({
   useEffect(() => {
     setMounted(true)
 
-    if (renderMode === 'portal-sidebar') {
+    if (renderMode === 'sidebar') {
       // Find the secondary sidebar by looking for the requirements-slot's parent
       const requirementsSlot = document.getElementById('requirements-slot')
       if (requirementsSlot && requirementsSlot.parentElement) {
@@ -40,12 +42,22 @@ export const EnterpriseCalloutAuto = ({
 
   // Render inline
   if (renderMode === 'inline') {
-    return <EnterpriseCallout variant={variant} inline className="mt-12" />
+    return (
+      <EnterpriseCallout
+        variant={variant}
+        inline
+        disableWaitlist={disableWaitlist}
+        className="mt-12"
+      />
+    )
   }
 
   // Render in sidebar via portal
-  if (mounted && sidebarElement && renderMode === 'portal-sidebar') {
-    return createPortal(<EnterpriseCallout variant={variant} />, sidebarElement)
+  if (mounted && sidebarElement && renderMode === 'sidebar') {
+    return createPortal(
+      <EnterpriseCallout variant={variant} disableWaitlist={disableWaitlist} />,
+      sidebarElement,
+    )
   }
 
   return null

--- a/src/components/EnterpriseCalloutAuto.tsx
+++ b/src/components/EnterpriseCalloutAuto.tsx
@@ -6,12 +6,12 @@ import { EnterpriseCallout } from './EnterpriseCallout'
 
 export type EnterpriseCalloutAutoProps = {
   variant: 'migration' | 'ai-agent' | 'pages' | 'semantic-search'
-  placement?: 'inline' | 'sidebar'
+  renderMode?: 'inline' | 'portal-sidebar'
 }
 
 export const EnterpriseCalloutAuto = ({
   variant,
-  placement = 'sidebar',
+  renderMode = 'portal-sidebar',
 }: EnterpriseCalloutAutoProps) => {
   const [mounted, setMounted] = useState(false)
   const [sidebarElement, setSidebarElement] = useState<Element | null>(null)
@@ -19,7 +19,7 @@ export const EnterpriseCalloutAuto = ({
   useEffect(() => {
     setMounted(true)
 
-    if (placement === 'sidebar') {
+    if (renderMode === 'portal-sidebar') {
       // Find the secondary sidebar by looking for the requirements-slot's parent
       const requirementsSlot = document.getElementById('requirements-slot')
       if (requirementsSlot && requirementsSlot.parentElement) {
@@ -36,15 +36,15 @@ export const EnterpriseCalloutAuto = ({
         setSidebarElement(container)
       }
     }
-  }, [placement])
+  }, [renderMode])
 
   // Render inline
-  if (placement === 'inline') {
+  if (renderMode === 'inline') {
     return <EnterpriseCallout variant={variant} inline className="mt-12" />
   }
 
   // Render in sidebar via portal
-  if (mounted && sidebarElement && placement === 'sidebar') {
+  if (mounted && sidebarElement && renderMode === 'portal-sidebar') {
     return createPortal(<EnterpriseCallout variant={variant} />, sidebarElement)
   }
 

--- a/src/components/EnterpriseCalloutAuto.tsx
+++ b/src/components/EnterpriseCalloutAuto.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { EnterpriseCallout } from './EnterpriseCallout'
+
+type CalloutConfig = {
+  variant: 'migration' | 'ai-agent' | 'pages' | 'semantic-search'
+  paths: string[]
+}
+
+// Define which pages should show which callout variant
+const CALLOUT_CONFIGS: CalloutConfig[] = [
+  {
+    variant: 'migration',
+    paths: [
+      '/guides/migrate-from-quill',
+      '/guides/migrate-from-draftjs',
+      '/guides/migrate-from-ckeditor5',
+      '/guides/migrate-from-ckeditor4',
+      '/guides/migrate-from-lexical',
+      '/guides/migrate-from-editorjs',
+      '/guides/upgrade-tiptap-v2',
+    ],
+  },
+  {
+    variant: 'ai-agent',
+    paths: [
+      '/editor/extensions/functionality/ai-agent',
+      '/content-ai/tools-for-ai-agents',
+      '/content-ai/capabilities/agent',
+    ],
+  },
+  {
+    variant: 'pages',
+    paths: ['/pages'],
+  },
+  {
+    variant: 'semantic-search',
+    paths: ['/collaboration/documents/semantic-search'],
+  },
+]
+
+export type EnterpriseCalloutAutoProps = {
+  inline?: boolean
+}
+
+export const EnterpriseCalloutAuto = ({ inline = false }: EnterpriseCalloutAutoProps) => {
+  const pathname = usePathname()
+  
+  // Find the matching config for the current path
+  const config = CALLOUT_CONFIGS.find(({ paths }) =>
+    paths.some((path) => pathname.startsWith(path))
+  )
+  
+  if (!config) {
+    return null
+  }
+  
+  // Render based on explicit inline prop
+  if (inline) {
+    return <EnterpriseCallout variant={config.variant} inline className="mt-12" />
+  }
+  
+  // Otherwise render for sidebar
+  return (
+    <div className="mt-8">
+      <EnterpriseCallout variant={config.variant} />
+    </div>
+  )
+}

--- a/src/components/EnterpriseCalloutAuto.tsx
+++ b/src/components/EnterpriseCalloutAuto.tsx
@@ -9,16 +9,16 @@ export type EnterpriseCalloutAutoProps = {
   placement?: 'inline' | 'sidebar'
 }
 
-export const EnterpriseCalloutAuto = ({ 
-  variant, 
-  placement = 'sidebar' 
+export const EnterpriseCalloutAuto = ({
+  variant,
+  placement = 'sidebar',
 }: EnterpriseCalloutAutoProps) => {
   const [mounted, setMounted] = useState(false)
   const [sidebarElement, setSidebarElement] = useState<Element | null>(null)
 
   useEffect(() => {
     setMounted(true)
-    
+
     if (placement === 'sidebar') {
       // Find the secondary sidebar by looking for the requirements-slot's parent
       const requirementsSlot = document.getElementById('requirements-slot')
@@ -37,19 +37,16 @@ export const EnterpriseCalloutAuto = ({
       }
     }
   }, [placement])
-  
+
   // Render inline
   if (placement === 'inline') {
     return <EnterpriseCallout variant={variant} inline className="mt-12" />
   }
-  
+
   // Render in sidebar via portal
   if (mounted && sidebarElement && placement === 'sidebar') {
-    return createPortal(
-      <EnterpriseCallout variant={variant} />,
-      sidebarElement
-    )
+    return createPortal(<EnterpriseCallout variant={variant} />, sidebarElement)
   }
-  
+
   return null
 }

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -14,7 +14,6 @@ import { DocsSidebar } from '../SidebarRenderer'
 import { MobileNavigationDropdown } from '../MobileNavigationDropdown'
 import { SidebarTableOfContent } from '../SidebarTableOfContent'
 import { VersionSwitch } from '../VersionSwitch'
-import { EnterpriseCalloutAuto } from '../EnterpriseCalloutAuto'
 import styles from './Layout.module.css'
 import Link from '@/components/Link'
 import { cn } from '@/utils'
@@ -181,7 +180,6 @@ const LayoutSecondarySidebar = forwardRef<HTMLDivElement, LayoutSecondarySidebar
         >
           <SidebarTableOfContent />
           <div id="requirements-slot" className="flex flex-col gap-8 mt-8" />
-          <EnterpriseCalloutAuto />
         </div>
       </>
     )

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -14,6 +14,7 @@ import { DocsSidebar } from '../SidebarRenderer'
 import { MobileNavigationDropdown } from '../MobileNavigationDropdown'
 import { SidebarTableOfContent } from '../SidebarTableOfContent'
 import { VersionSwitch } from '../VersionSwitch'
+import { EnterpriseCalloutAuto } from '../EnterpriseCalloutAuto'
 import styles from './Layout.module.css'
 import Link from '@/components/Link'
 import { cn } from '@/utils'
@@ -180,6 +181,7 @@ const LayoutSecondarySidebar = forwardRef<HTMLDivElement, LayoutSecondarySidebar
         >
           <SidebarTableOfContent />
           <div id="requirements-slot" className="flex flex-col gap-8 mt-8" />
+          <EnterpriseCalloutAuto />
         </div>
       </>
     )

--- a/src/content/collaboration/documents/semantic-search.mdx
+++ b/src/content/collaboration/documents/semantic-search.mdx
@@ -12,6 +12,9 @@ meta:
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { Callout } from '@/components/ui/Callout'
 import { CodeDemo } from '@/components/CodeDemo'
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="semantic-search" placement="sidebar" />
 
 Tiptap Semantic Search brings AI-native search capabilities to your document library, making it easy to discover relationships and connections across all your documents through contextual understanding provided by large language models.
 

--- a/src/content/collaboration/documents/semantic-search.mdx
+++ b/src/content/collaboration/documents/semantic-search.mdx
@@ -14,7 +14,7 @@ import { Callout } from '@/components/ui/Callout'
 import { CodeDemo } from '@/components/CodeDemo'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="semantic-search" renderMode="portal-sidebar" />
+<EnterpriseCalloutAuto variant="semantic-search" renderMode="sidebar" />
 
 Tiptap Semantic Search brings AI-native search capabilities to your document library, making it easy to discover relationships and connections across all your documents through contextual understanding provided by large language models.
 

--- a/src/content/collaboration/documents/semantic-search.mdx
+++ b/src/content/collaboration/documents/semantic-search.mdx
@@ -14,7 +14,7 @@ import { Callout } from '@/components/ui/Callout'
 import { CodeDemo } from '@/components/CodeDemo'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="semantic-search" placement="sidebar" />
+<EnterpriseCalloutAuto variant="semantic-search" renderMode="portal-sidebar" />
 
 Tiptap Semantic Search brings AI-native search capabilities to your document library, making it easy to discover relationships and connections across all your documents through contextual understanding provided by large language models.
 

--- a/src/content/collaboration/documents/semantic-search.mdx
+++ b/src/content/collaboration/documents/semantic-search.mdx
@@ -15,10 +15,6 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 Tiptap Semantic Search brings AI-native search capabilities to your document library, making it easy to discover relationships and connections across all your documents through contextual understanding provided by large language models.
 
-<Callout title="Limited release" variant="hint">
-    Tiptap Semantic Search is currently available to enterprise customers as part of a limited rollout. Want in? <a href="https://tiptap-suite.notion.site/1b601ffa3ebc80a281a8ea0b03b19bdd?pvs=105">Get in touch with our team.</a>
-</Callout>
-
 <Requirements>
     <RequirementItem label="1. Request access">
         <a href="https://tiptap-suite.notion.site/1b601ffa3ebc80a281a8ea0b03b19bdd?pvs=105">Share your use case</a> to be considered for early access to Semantic search.

--- a/src/content/content-ai/capabilities/agent/install.mdx
+++ b/src/content/content-ai/capabilities/agent/install.mdx
@@ -13,7 +13,7 @@ import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="ai-agent" renderMode="portal-sidebar" />
+<EnterpriseCalloutAuto variant="ai-agent" renderMode="sidebar" />
 
 <Requirements>
   <RequirementItem label="1. Activate trial or subscribe">

--- a/src/content/content-ai/capabilities/agent/install.mdx
+++ b/src/content/content-ai/capabilities/agent/install.mdx
@@ -13,7 +13,7 @@ import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="ai-agent" placement="sidebar" />
+<EnterpriseCalloutAuto variant="ai-agent" renderMode="portal-sidebar" />
 
 <Requirements>
   <RequirementItem label="1. Activate trial or subscribe">

--- a/src/content/content-ai/capabilities/agent/install.mdx
+++ b/src/content/content-ai/capabilities/agent/install.mdx
@@ -11,6 +11,9 @@ tags:
 
 import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="ai-agent" placement="sidebar" />
 
 <Requirements>
   <RequirementItem label="1. Activate trial or subscribe">

--- a/src/content/content-ai/capabilities/agent/overview.mdx
+++ b/src/content/content-ai/capabilities/agent/overview.mdx
@@ -81,4 +81,4 @@ Think of the LLM as the "brain" of the AI Agent, making decisions about which to
 
 By using the AI Agent extension with Tiptap Cloud, you don't need to worry about the server — we have it built for you. However, if you want to customize the LLM and the tools that the AI Agent has available (so that it can perform other actions, like searching an external data source), you can integrate the AI Agent extension with your own backend.
 
-<EnterpriseCalloutAuto inline />
+<EnterpriseCalloutAuto variant="ai-agent" placement="inline" />

--- a/src/content/content-ai/capabilities/agent/overview.mdx
+++ b/src/content/content-ai/capabilities/agent/overview.mdx
@@ -81,4 +81,4 @@ Think of the LLM as the "brain" of the AI Agent, making decisions about which to
 
 By using the AI Agent extension with Tiptap Cloud, you don't need to worry about the server — we have it built for you. However, if you want to customize the LLM and the tools that the AI Agent has available (so that it can perform other actions, like searching an external data source), you can integrate the AI Agent extension with your own backend.
 
-<EnterpriseCalloutAuto variant="ai-agent" placement="inline" />
+<EnterpriseCalloutAuto variant="ai-agent" renderMode="inline" />

--- a/src/content/content-ai/capabilities/agent/overview.mdx
+++ b/src/content/content-ai/capabilities/agent/overview.mdx
@@ -14,6 +14,7 @@ sidebars:
 import { CodeDemo } from '@/components/CodeDemo'
 import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
 <Requirements>
   <RequirementItem label="1. Activate trial or subscribe">
@@ -79,3 +80,5 @@ When an LLM is called with these tools, it selects one to execute. Then, the Tip
 Think of the LLM as the "brain" of the AI Agent, making decisions about which tools to call. The Tiptap AI Agent Extension acts as the "hands" and "eyes," enabling the agent to read and interact with the document.
 
 By using the AI Agent extension with Tiptap Cloud, you don't need to worry about the server — we have it built for you. However, if you want to customize the LLM and the tools that the AI Agent has available (so that it can perform other actions, like searching an external data source), you can integrate the AI Agent extension with your own backend.
+
+<EnterpriseCalloutAuto inline />

--- a/src/content/conversion/getting-started/overview.mdx
+++ b/src/content/conversion/getting-started/overview.mdx
@@ -11,6 +11,9 @@ meta:
 
 import { Callout } from '@/components/ui/Callout'
 import { CodeDemo } from '@/components/CodeDemo'
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="docx" renderMode="sidebar" />
 
 The Tiptap Conversion Service makes it easy to import and export content between Tiptap and document file formats. It offers:
 

--- a/src/content/conversion/import-export/docx/editor-export.mdx
+++ b/src/content/conversion/import-export/docx/editor-export.mdx
@@ -9,9 +9,11 @@ meta:
     category: Conversion
 ---
 
-import { Callout } from '@/components/ui/Callout'
 import { CodeDemo } from '@/components/CodeDemo'
 import { Requirements, RequirementItem } from '@/components/Requirements'
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="docx" renderMode="sidebar" disableWaitlist />
 
 <Requirements>
     <RequirementItem label="1. Activate trial or subscribe">

--- a/src/content/conversion/import-export/docx/editor-import.mdx
+++ b/src/content/conversion/import-export/docx/editor-import.mdx
@@ -9,9 +9,11 @@ meta:
     category: Conversion
 ---
 
-import { Callout } from '@/components/ui/Callout'
 import { CodeDemo } from '@/components/CodeDemo'
 import { Requirements, RequirementItem } from '@/components/Requirements'
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="docx" renderMode="sidebar" disableWaitlist />
 
 <Requirements>
     <RequirementItem label="1. Activate trial or subscribe">

--- a/src/content/conversion/import-export/docx/index.mdx
+++ b/src/content/conversion/import-export/docx/index.mdx
@@ -10,6 +10,9 @@ meta:
 ---
 
 import { Callout } from '@/components/ui/Callout'
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="docx" renderMode="sidebar" disableWaitlist />
 
 Integrating `DOCX` (Microsoft Word) conversion with Tiptap can be done in several ways, from adding in-editor “Import/Export DOCX” buttons to using the REST API for server-side workflows.
 

--- a/src/content/guides/migrate-from-ckeditor4.mdx
+++ b/src/content/guides/migrate-from-ckeditor4.mdx
@@ -8,6 +8,10 @@ meta:
   category: Editor
 ---
 
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="migration" placement="sidebar" />
+
 Migrating from CKEditor 4 to Tiptap is straightforward and offers significant benefits in terms of modern architecture and flexibility. This guide will walk you through the migration process step by step.
 
 ## Content migration

--- a/src/content/guides/migrate-from-ckeditor4.mdx
+++ b/src/content/guides/migrate-from-ckeditor4.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="migration" renderMode="portal-sidebar" />
+<EnterpriseCalloutAuto variant="migration" renderMode="sidebar" disableWaitlist/>
 
 Migrating from CKEditor 4 to Tiptap is straightforward and offers significant benefits in terms of modern architecture and flexibility. This guide will walk you through the migration process step by step.
 

--- a/src/content/guides/migrate-from-ckeditor4.mdx
+++ b/src/content/guides/migrate-from-ckeditor4.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="migration" placement="sidebar" />
+<EnterpriseCalloutAuto variant="migration" renderMode="portal-sidebar" />
 
 Migrating from CKEditor 4 to Tiptap is straightforward and offers significant benefits in terms of modern architecture and flexibility. This guide will walk you through the migration process step by step.
 

--- a/src/content/guides/migrate-from-ckeditor5.mdx
+++ b/src/content/guides/migrate-from-ckeditor5.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="migration" renderMode="portal-sidebar" />
+<EnterpriseCalloutAuto variant="migration" renderMode="sidebar" disableWaitlist/>
 
 If you're moving away from CKEditor, Tiptap is a great alternative.Migrating from CKEditor 5 to Tiptap is straightforward. This guide covers everything you need to know for a smooth transition.
 

--- a/src/content/guides/migrate-from-ckeditor5.mdx
+++ b/src/content/guides/migrate-from-ckeditor5.mdx
@@ -7,6 +7,11 @@ meta:
   description: Learn how to migrate your existing CKEditor 5 editor to Tiptap. Complete guide covering content migration, setup, and feature mapping.
   category: Editor
 ---
+
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="migration" placement="sidebar" />
+
 If you're moving away from CKEditor, Tiptap is a great alternative.Migrating from CKEditor 5 to Tiptap is straightforward. This guide covers everything you need to know for a smooth transition.
 
 ## Content migration

--- a/src/content/guides/migrate-from-ckeditor5.mdx
+++ b/src/content/guides/migrate-from-ckeditor5.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="migration" placement="sidebar" />
+<EnterpriseCalloutAuto variant="migration" renderMode="portal-sidebar" />
 
 If you're moving away from CKEditor, Tiptap is a great alternative.Migrating from CKEditor 5 to Tiptap is straightforward. This guide covers everything you need to know for a smooth transition.
 

--- a/src/content/guides/migrate-from-draftjs.mdx
+++ b/src/content/guides/migrate-from-draftjs.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="migration" placement="sidebar" />
+<EnterpriseCalloutAuto variant="migration" renderMode="portal-sidebar" />
 
 Tiptap is a popular alternative to Draft.js and migrating from Draft.js to Tiptap is straightforward. This guide will help you transition from Draft.js's immutable state model to Tiptap's extension system.
 

--- a/src/content/guides/migrate-from-draftjs.mdx
+++ b/src/content/guides/migrate-from-draftjs.mdx
@@ -8,6 +8,10 @@ meta:
   category: Editor
 ---
 
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="migration" placement="sidebar" />
+
 Tiptap is a popular alternative to Draft.js and migrating from Draft.js to Tiptap is straightforward. This guide will help you transition from Draft.js's immutable state model to Tiptap's extension system.
 
 ## Content migration

--- a/src/content/guides/migrate-from-draftjs.mdx
+++ b/src/content/guides/migrate-from-draftjs.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="migration" renderMode="portal-sidebar" />
+<EnterpriseCalloutAuto variant="migration" renderMode="sidebar" disableWaitlist/>
 
 Tiptap is a popular alternative to Draft.js and migrating from Draft.js to Tiptap is straightforward. This guide will help you transition from Draft.js's immutable state model to Tiptap's extension system.
 

--- a/src/content/guides/migrate-from-editorjs.mdx
+++ b/src/content/guides/migrate-from-editorjs.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="migration" renderMode="portal-sidebar" />
+<EnterpriseCalloutAuto variant="migration" renderMode="sidebar" disableWaitlist/>
 
 If you want to replace your Editor.js editor, Tiptap is a popular alternative.Migrating from Editor.js to Tiptap is straightforward. This guide will help you transition from Editor.js's block-based structure to Tiptap's document model.
 

--- a/src/content/guides/migrate-from-editorjs.mdx
+++ b/src/content/guides/migrate-from-editorjs.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="migration" placement="sidebar" />
+<EnterpriseCalloutAuto variant="migration" renderMode="portal-sidebar" />
 
 If you want to replace your Editor.js editor, Tiptap is a popular alternative.Migrating from Editor.js to Tiptap is straightforward. This guide will help you transition from Editor.js's block-based structure to Tiptap's document model.
 

--- a/src/content/guides/migrate-from-editorjs.mdx
+++ b/src/content/guides/migrate-from-editorjs.mdx
@@ -8,6 +8,10 @@ meta:
   category: Editor
 ---
 
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="migration" placement="sidebar" />
+
 If you want to replace your Editor.js editor, Tiptap is a popular alternative.Migrating from Editor.js to Tiptap is straightforward. This guide will help you transition from Editor.js's block-based structure to Tiptap's document model.
 
 ## Content migration

--- a/src/content/guides/migrate-from-lexical.mdx
+++ b/src/content/guides/migrate-from-lexical.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="migration" renderMode="portal-sidebar" />
+<EnterpriseCalloutAuto variant="migration" renderMode="sidebar" disableWaitlist/>
 
 Replace your Lexical editor with a better alternative like Tiptap. Migrating from Lexical to Tiptap is straightforward. This guide will help you transition from Lexical's node-based architecture to Tiptap's extension system.
 

--- a/src/content/guides/migrate-from-lexical.mdx
+++ b/src/content/guides/migrate-from-lexical.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="migration" placement="sidebar" />
+<EnterpriseCalloutAuto variant="migration" renderMode="portal-sidebar" />
 
 Replace your Lexical editor with a better alternative like Tiptap. Migrating from Lexical to Tiptap is straightforward. This guide will help you transition from Lexical's node-based architecture to Tiptap's extension system.
 

--- a/src/content/guides/migrate-from-lexical.mdx
+++ b/src/content/guides/migrate-from-lexical.mdx
@@ -8,6 +8,10 @@ meta:
   category: Editor
 ---
 
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="migration" placement="sidebar" />
+
 Replace your Lexical editor with a better alternative like Tiptap. Migrating from Lexical to Tiptap is straightforward. This guide will help you transition from Lexical's node-based architecture to Tiptap's extension system.
 
 ## Content migration

--- a/src/content/guides/migrate-from-quill.mdx
+++ b/src/content/guides/migrate-from-quill.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="migration" renderMode="portal-sidebar" />
+<EnterpriseCalloutAuto variant="migration" renderMode="sidebar" disableWaitlist/>
 
 Tiptap is a popular Quill alternative and migrating from Quill to Tiptap is straightforward. This guide will help you transition smoothly from Quill's Delta format to Tiptap's extension system.
 

--- a/src/content/guides/migrate-from-quill.mdx
+++ b/src/content/guides/migrate-from-quill.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="migration" placement="sidebar" />
+<EnterpriseCalloutAuto variant="migration" renderMode="portal-sidebar" />
 
 Tiptap is a popular Quill alternative and migrating from Quill to Tiptap is straightforward. This guide will help you transition smoothly from Quill's Delta format to Tiptap's extension system.
 

--- a/src/content/guides/migrate-from-quill.mdx
+++ b/src/content/guides/migrate-from-quill.mdx
@@ -8,6 +8,10 @@ meta:
   category: Editor
 ---
 
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="migration" placement="sidebar" />
+
 Tiptap is a popular Quill alternative and migrating from Quill to Tiptap is straightforward. This guide will help you transition smoothly from Quill's Delta format to Tiptap's extension system.
 
 ## Content migration

--- a/src/content/guides/migrate-from-slate.mdx
+++ b/src/content/guides/migrate-from-slate.mdx
@@ -8,6 +8,10 @@ meta:
   category: Editor
 ---
 
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="migration" placement="sidebar" />
+
 Tiptap is a popular Slate alternative and migrating from Slate to Tiptap is straightforward. This guide will help you transition from Slate's JSON structure to Tiptap's extension system.
 
 ## Content migration

--- a/src/content/guides/migrate-from-slate.mdx
+++ b/src/content/guides/migrate-from-slate.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="migration" renderMode="portal-sidebar" />
+<EnterpriseCalloutAuto variant="migration" renderMode="sidebar" disableWaitlist/>
 
 Tiptap is a popular Slate alternative and migrating from Slate to Tiptap is straightforward. This guide will help you transition from Slate's JSON structure to Tiptap's extension system.
 

--- a/src/content/guides/migrate-from-slate.mdx
+++ b/src/content/guides/migrate-from-slate.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="migration" placement="sidebar" />
+<EnterpriseCalloutAuto variant="migration" renderMode="portal-sidebar" />
 
 Tiptap is a popular Slate alternative and migrating from Slate to Tiptap is straightforward. This guide will help you transition from Slate's JSON structure to Tiptap's extension system.
 

--- a/src/content/guides/migrate-from-tinymce.mdx
+++ b/src/content/guides/migrate-from-tinymce.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="migration" renderMode="portal-sidebar" />
+<EnterpriseCalloutAuto variant="migration" renderMode="sidebar" disableWaitlist/>
 
 Tiptap is a powerful alternative to TinyMCE. Migrating from TinyMCE to Tiptap is straightforward. This guide will walk you through the migration process step by step.
 

--- a/src/content/guides/migrate-from-tinymce.mdx
+++ b/src/content/guides/migrate-from-tinymce.mdx
@@ -8,6 +8,10 @@ meta:
   category: Editor
 ---
 
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="migration" placement="sidebar" />
+
 Tiptap is a powerful alternative to TinyMCE. Migrating from TinyMCE to Tiptap is straightforward. This guide will walk you through the migration process step by step.
 
 ## Content migration

--- a/src/content/guides/migrate-from-tinymce.mdx
+++ b/src/content/guides/migrate-from-tinymce.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="migration" placement="sidebar" />
+<EnterpriseCalloutAuto variant="migration" renderMode="portal-sidebar" />
 
 Tiptap is a powerful alternative to TinyMCE. Migrating from TinyMCE to Tiptap is straightforward. This guide will walk you through the migration process step by step.
 

--- a/src/content/guides/upgrade-tiptap-v2.mdx
+++ b/src/content/guides/upgrade-tiptap-v2.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="migration" renderMode="portal-sidebar" />
+<EnterpriseCalloutAuto variant="migration" renderMode="sidebar" disableWaitlist/>
 
 Tiptap v3 is a major update with breaking changes. This guide will help you upgrade your Tiptap v2 project to version 3.
 

--- a/src/content/guides/upgrade-tiptap-v2.mdx
+++ b/src/content/guides/upgrade-tiptap-v2.mdx
@@ -8,6 +8,10 @@ meta:
   category: Collaboration
 ---
 
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="migration" placement="sidebar" />
+
 Tiptap v3 is a major update with breaking changes. This guide will help you upgrade your Tiptap v2 project to version 3.
 
 ## Breaking Changes

--- a/src/content/guides/upgrade-tiptap-v2.mdx
+++ b/src/content/guides/upgrade-tiptap-v2.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="migration" placement="sidebar" />
+<EnterpriseCalloutAuto variant="migration" renderMode="portal-sidebar" />
 
 Tiptap v3 is a major update with breaking changes. This guide will help you upgrade your Tiptap v2 project to version 3.
 

--- a/src/content/pages/getting-started/install.mdx
+++ b/src/content/pages/getting-started/install.mdx
@@ -14,7 +14,7 @@ import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="pages" placement="sidebar" />
+<EnterpriseCalloutAuto variant="pages" renderMode="portal-sidebar" />
 
 Install and configure the Pages extension by following this guide.
 

--- a/src/content/pages/getting-started/install.mdx
+++ b/src/content/pages/getting-started/install.mdx
@@ -12,6 +12,9 @@ meta:
 import { CodeDemo } from '@/components/CodeDemo'
 import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="pages" placement="sidebar" />
 
 Install and configure the Pages extension by following this guide.
 

--- a/src/content/pages/getting-started/install.mdx
+++ b/src/content/pages/getting-started/install.mdx
@@ -14,7 +14,7 @@ import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="pages" renderMode="portal-sidebar" />
+<EnterpriseCalloutAuto variant="pages" renderMode="sidebar" />
 
 Install and configure the Pages extension by following this guide.
 

--- a/src/content/pages/getting-started/overview.mdx
+++ b/src/content/pages/getting-started/overview.mdx
@@ -29,4 +29,4 @@ Key features of Tiptap Pages include:
 
 We are continuously improving the pages extension. Support for other more extensions and other complex features are in active development.
 
-<EnterpriseCalloutAuto inline />
+<EnterpriseCalloutAuto variant="pages" placement="inline" />

--- a/src/content/pages/getting-started/overview.mdx
+++ b/src/content/pages/getting-started/overview.mdx
@@ -29,4 +29,4 @@ Key features of Tiptap Pages include:
 
 We are continuously improving the pages extension. Support for other more extensions and other complex features are in active development.
 
-<EnterpriseCalloutAuto variant="pages" placement="inline" />
+<EnterpriseCalloutAuto variant="pages" renderMode="inline" />

--- a/src/content/pages/getting-started/overview.mdx
+++ b/src/content/pages/getting-started/overview.mdx
@@ -11,18 +11,14 @@ sidebars:
     hideSecondary: true
 ---
 
-import { Callout } from '@/components/ui/Callout'
 import { CodeDemo } from '@/components/CodeDemo'
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
 Tiptap Pages is a powerful extension that transforms your editing experience from a traditional single-block editor into a sophisticated page-based interface.
 
 <CodeDemo isPro src="https://feature-pages-extension--tiptap-pro.netlify.app/preview/extensions/pages" />
 
 With Pages, you can create documents that feel more like real pages, complete with proper margins, page breaks, and layout controls. This makes it perfect for creating documents that need to maintain a professional, page-based structure – whether you're working on reports, articles, or any other content that benefits from a traditional document format.
-
-<Callout title="Limited release" variant="hint">
-    Tiptap Pages is currently available to enterprise customers as part of a limited rollout. Want in? <a href="https://tiptap-suite.notion.site/1b601ffa3ebc80a281a8ea0b03b19bdd?pvs=105">Get in touch with our team.</a>
-</Callout>
 
 Key features of Tiptap Pages include:
 - Page-based layout with proper margins and spacing
@@ -32,3 +28,5 @@ Key features of Tiptap Pages include:
 - Familiar interface similar to popular word processors
 
 We are continuously improving the pages extension. Support for other more extensions and other complex features are in active development.
+
+<EnterpriseCalloutAuto inline />

--- a/src/content/resources/whats-new.mdx
+++ b/src/content/resources/whats-new.mdx
@@ -66,11 +66,6 @@ If you’re upgrading from Tiptap 2.x to 3.x, refer to our [upgrade guide](/guid
 
 We're already exploring future features for releases beyond Tiptap 3.0.
 
-<Callout title="Provide Feedback" variant="info">
-  If you have any feedback on an additional use case you’d like us to consider, please [let us
-  know](https://tiptap-suite.notion.site/1b601ffa3ebc80a281a8ea0b03b19bdd?pvs=105).
-</Callout>
-
 - **Content migrations**: Migrations allow you to rewrite your document JSON to align with your current schema, facilitating document updates during schema changes with fully customizable solutions tailored to your needs.
 - **Markdown support**: Enhance your editing capabilities by enabling the editor to both accept and output content in markdown, meeting the demands of modern applications and leveraging the strengths of LLMs in markdown generation.
 - **Decorations API**: The new Decorations API allows you to influence document presentation without altering its content, providing an intuitive way to add visual enhancements beyond complex ProseMirror internals.


### PR DESCRIPTION
Summary
  - Adds a reusable enterprise callout component to promote enterprise 
  features across documentation
  - Supports 4 variants: migration support, AI Agent beta, Pages beta, and 
  Semantic Search beta
  - Enables manual placement control by content editors

  ## Implementation Details

  ### Components Added
  - **EnterpriseCallout**: Base component with variant-specific content and
   styling
  - **EnterpriseCalloutAuto**: Wrapper component that handles placement 
  (inline vs sidebar)

  ### Features
  - **Explicit control**: Content editors specify both variant and 
  placement via props
  - **Portal rendering**: Sidebar callouts render in the actual right 
  sidebar using React Portals
  - **Two placement modes**:
    - `inline`: Renders at the bottom of page content (for pages without 
  sidebars)
    - `sidebar`: Renders in the right sidebar next to table of contents
  - **Consistent design**: Thin border, rounded corners, primary CTA, and 
  waitlist option

  ### Pages Updated
  - **Migration guides**: All 9 migration guides now have sidebar callouts
  - **AI Agent**: Overview (inline) and Install (sidebar) pages
  - **Pages**: Overview (inline) and Install (sidebar) pages  
  - **Semantic Search**: Documentation page (sidebar)

  ### Usage
  \`\`\`tsx
  // For sidebar placement
  <EnterpriseCalloutAuto variant=\"migration\" placement=\"sidebar\" />

  // For inline placement
  <EnterpriseCalloutAuto variant=\"ai-agent\" placement=\"inline\" />
  \`\`\`

  ## Testing
  - Verified callouts render correctly in both sidebar and inline positions
  - Tested across all updated documentation pages
  - Confirmed portal rendering works for sidebar placement"