### PR TITLE
Update link.mdx

### DIFF
--- a/src/content/editor/extensions/marks/link.mdx
+++ b/src/content/editor/extensions/marks/link.mdx
@@ -38,6 +38,22 @@ Pasted URLs will be transformed to links automatically.
 npm install @tiptap/extension-link
 ```
 
+### ⚠️ Using `StarterKit` with the `Link` extension
+
+The `StarterKit` bundle includes its own `Link` extension by default.  
+If you also add the standalone `Link` extension, they may **conflict** with each other.
+
+To avoid issues:  
+- **Order matters** → configure your custom `Link` extension *after* `StarterKit`.  
+- Or, **disable** the built-in link from `StarterKit` and use only your own:
+
+```js
+StarterKit.configure({
+  link: false, // disables the built-in Link extension
+}),
+Link.configure({ ... })
+```
+
 ## Settings
 
 ### protocols


### PR DESCRIPTION
Fix: prevent conflict between StarterKit and Link extension

StarterKit includes its own Link extension by default.   When combined with the standalone Link extension, this caused links to become navigable inside the editor during editing.  

Updated documentation to explain the conflict and how to disable the built-in Link extension from StarterKit if needed.