### PR TITLE
docs: fix import path

### DIFF
--- a/src/content/editor/api/utilities/static-renderer.mdx
+++ b/src/content/editor/api/utilities/static-renderer.mdx
@@ -36,7 +36,7 @@ Given a JSON document, the `renderToHTMLString` function will return an HTML str
 
 ```js
 import StarterKit from '@tiptap/starter-kit'
-import { renderToHTMLString } from '@tiptap/static-renderer/pm/html'
+import { renderToHTMLString } from '@tiptap/static-renderer/pm/html-string'
 
 renderToHTMLString({
   extensions: [StarterKit], // using your extensions
@@ -307,7 +307,7 @@ The `renderToHTMLString`, `renderToMarkdown`, and `renderToReactElement` functio
 
 ```js
 import StarterKit from '@tiptap/starter-kit'
-import { renderToHTMLString, serializeChildrenToHTMLString } from '@tiptap/static-renderer/pm/html'
+import { renderToHTMLString, serializeChildrenToHTMLString } from '@tiptap/static-renderer/pm/html-string'
 
 renderToHTMLString({
   extensions: [StarterKit], // using your extensions
@@ -354,11 +354,11 @@ renderToHTMLString({
 
 ### Namespaced imports
 
-To cut down on bundle size in your application, the static renderer is split into three separate packages: `@tiptap/static-renderer/pm/html`, `@tiptap/static-renderer/pm/markdown`, and `@tiptap/static-renderer/pm/react`. This way, you only need to import the parts of the static renderer that you need. If you want the most flexibility, you can import the entire static renderer package with `@tiptap/static-renderer`.
+To cut down on bundle size in your application, the static renderer is split into three separate packages: `@tiptap/static-renderer/pm/html-string`, `@tiptap/static-renderer/pm/markdown`, and `@tiptap/static-renderer/pm/react`. This way, you only need to import the parts of the static renderer that you need. If you want the most flexibility, you can import the entire static renderer package with `@tiptap/static-renderer`.
 
 ```ts
 // Just the HTML renderer
-import { renderToHTMLString } from '@tiptap/static-renderer/pm/html'
+import { renderToHTMLString } from '@tiptap/static-renderer/pm/html-string'
 
 // Just the markdown renderer
 import { renderToMarkdown } from '@tiptap/static-renderer/pm/markdown'


### PR DESCRIPTION
The docs reference `@tiptap/static-renderer/pm/html` but that module doesn't exist. It exists at [`static-renderer /pm/html-string`](https://github.com/ueberdosis/tiptap/tree/ba8d13fa83e17689b03a1fdee131fb870b0e4586/packages/static-renderer/src/pm/html-string)