### PR TITLE
Update Svelte docs to use runes syntax and fix Svelte playground demo

### DIFF
--- a/.changeset/big-mammals-play.md
+++ b/.changeset/big-mammals-play.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': minor
+---
+
+Update Svelte docs to use runes syntax and fix Svelte playground demo

--- a/src/content/editor/getting-started/install/svelte.mdx
+++ b/src/content/editor/getting-started/install/svelte.mdx
@@ -10,7 +10,7 @@ Learn how to integrate Tiptap with your SvelteKit project using this step-by-sep
 
 ## Take a shortcut: Svelte REPL with Tiptap
 
-If you want to jump into it right away, here is a [Svelte REPL with Tiptap](https://svelte.dev/repl/798f1b81b9184780aca18d9a005487d2?version=3.31.2).
+If you want to jump into it right away, here is a [Svelte REPL with Tiptap](https://svelte.dev/playground/66be82691d304dc981502659e93f8b92).
 
 ### Requirements
 
@@ -45,6 +45,103 @@ If you followed steps 1 and 2, you can now start your project with `npm run dev`
 To start using Tiptap, you'll need to add a new component to your app. Let's call it `Tiptap` and add the following example code in `src/lib/Tiptap.svelte`.
 
 This is the fastest way to get Tiptap up and running with SvelteKit. It will give you a very basic version of Tiptap, without any buttons. No worries, you will be able to add more functionality soon.
+
+```svelte
+import { Editor } from '@tiptap/core'
+  import { StarterKit } from '@tiptap/starter-kit'
+  import BubbleMenu from '@tiptap/extension-bubble-menu'
+
+  let bubbleMenu = $state()
+  let element = $state()
+  let editorState = $state({editor: null})
+
+  onMount(() => {
+    editor = new Editor({
+      element: element,
+      extensions: [
+        StarterKit,
+        BubbleMenu.configure({
+          element: bubbleMenu,
+        }),
+      ],
+      content: `
+        <h1>Hello Svelte! 🌍️ </h1>
+        <p>This editor is running in Svelte.</p>
+        <p>Select some text to see the bubble menu popping up.</p>
+      `,
+      onTransaction: ({editor}) => {
+        // force re-render so `editor.isActive` works as expected
+		editorState = { editor }
+      },
+    })
+  })
+  onDestroy(() => {
+    editor.destroy()
+  })
+</script>
+
+<div style="position: relative" class="app">
+  {#if editorState.editor}
+    <div class="fixed-menu">
+      <button
+        onclick={() => editorState.editor.chain().focus().toggleHeading({ level: 1 }).run()}
+        class:active={editorState.editor.isActive('heading', { level: 1 })}
+      >
+        H1
+      </button>
+      <button
+        onclick={() => editorState.editor.chain().focus().toggleHeading({ level: 2 }).run()}
+        class:active={editorState.editor.isActive('heading', { level: 2 })}
+      >
+        H2
+      </button>
+      <button onclick={() => editorState.editor.chain().focus().setParagraph().run()} class:active={editorState.editor.isActive('paragraph')}>
+        P
+      </button>
+    </div>
+  {/if}
+
+  <div bind:this={element}></div>
+</div>
+
+<style>
+  button.active {
+    background: black;
+    color: white;
+  }
+</style>
+
+```
+
+
+
+## Add it to your app
+
+Now, let's replace the content of `src/routes/+page.svelte` with the following example code to use our new `Tiptap` component in our app.
+
+```svelte
+<script>
+  import Tiptap from '$lib/Tiptap.svelte'
+</script>
+
+<main>
+  <Tiptap />
+</main>
+```
+
+Tiptap should now be visible in your browser. Time to give yourself a pat on the back! :)
+
+## Next steps
+
+- [Configure your editor](/editor/getting-started/configure)
+- [Add styles to your editor](/editor/getting-started/style-editor)
+- [Learn more about Tiptap's concepts](/editor/core-concepts/introduction)
+- [Learn how to persist the editor state](/editor/core-concepts/persistence)
+- [Start building your own extensions](/editor/extensions/custom-extensions)
+
+## Setup with Svelte legacy syntax
+
+The example above uses the [Svelte runes syntax](https://svelte.dev/docs/svelte/what-are-runes). If your Svelte app is in [legacy mode](https://svelte.dev/docs/svelte/legacy-let), use this code for the `Tiptap.svelte` component instead.
 
 ```svelte
 <script>
@@ -104,27 +201,3 @@ This is the fastest way to get Tiptap up and running with SvelteKit. It will giv
 	}
 </style>
 ```
-
-## Add it to your app
-
-Now, let's replace the content of `src/routes/+page.svelte` with the following example code to use our new `Tiptap` component in our app.
-
-```svelte
-<script>
-  import Tiptap from '$lib/Tiptap.svelte'
-</script>
-
-<main>
-  <Tiptap />
-</main>
-```
-
-Tiptap should now be visible in your browser. Time to give yourself a pat on the back! :)
-
-## Next steps
-
-- [Configure your editor](/editor/getting-started/configure)
-- [Add styles to your editor](/editor/getting-started/style-editor)
-- [Learn more about Tiptap's concepts](/editor/core-concepts/introduction)
-- [Learn how to persist the editor state](/editor/core-concepts/persistence)
-- [Start building your own extensions](/editor/extensions/custom-extensions)


### PR DESCRIPTION
- Update Svelte docs to use the runes syntax. The runes syntax is now the default in Svelte and the syntax we currently use is supported, but scheduled for retirement.
- Update the Svelte playground demo, which didn't work.