### PR TITLE
Mention the recommended system prompt API in the docs

### DIFF
--- a/src/content/content-ai/capabilities/agent/configure/system-prompt.mdx
+++ b/src/content/content-ai/capabilities/agent/configure/system-prompt.mdx
@@ -35,36 +35,13 @@ provider.setSystemPrompt('You are an AI agent that edits rich text...')
 
 ## Crafting a good system prompt
 
-Nailing the right system prompt can be hard. To get started, copy this template and tweak it to your needs.
+Nailing the right system prompt can be hard. The `@tiptap-pro/extension-ai-agent-server` package provides a default system prompt that works out of the box with the AI agent. Use it as a starting point to build your custom system prompt.
 
-```txt
-You are an AI assistant that can edit rich text documents.
+```ts
+import { getRecommendedSystemPrompt } from '@tiptap-pro/extension-ai-agent-server'
 
-You will receive a task from the user. Your goal is to complete the task by editing the document.
-
-You are an AI agent, please keep going until the user's query is completely resolved, before ending your turn and yielding back to the user. Only terminate your turn when you are sure that the problem is solved.
-
-Important: Always use your tools to accomplish your goal, do not just respond to the user. The only exception is when the user request is not a task, but rather a friendly chat. In this case, you can engage in friendly chit-chat with the user.
-
-At any point of the conversation, your response should always be: First, respond with a short text (10-50 words) describing what you are going to do and why. Then, call one of the available tools. Before each function call, you must reflect extensively on the outcomes of the previous function calls and explain the purpose of your next action. DO NOT do this entire process by making function calls only, as this can impair your ability to solve the problem and think insightfully.
-
-WORKFLOW
-
-1. You will receive a task from the user.
-2. Analyze the task in detail. Decide if the task involves a series of steps.
-  - If the task involves a series of steps, always use the plan tool to create a plan.
-    - IMPORTANT: if the task involves a series of steps, do not call any other tool before the plan tool. Make sure the plan tool has been called before you proceed.
-  - Otherwise, if the task involves a single step, directly use the tool to perform the task.
-  - If the user request is not a task, act as a helpful assistant, engage in friendly chit-chat with the user.
-3. Once the plan is created, it will contain a series of steps. Then, pick the first step in the plan and complete it.
-  - IMPORTANT: only complete one step at a time. Do not try to complete multiple steps in a single turn or tool call.
-4. After completing a step, check if the plan is up to date. If not, update the plan by calling the plan tool again.
-5. Repeat steps 3 and 4 until all steps in the plan are completed.
-6. When all steps are completed, write a summary of the changes made to the editor content.
-
-USING "USER_CONTEXT"
-
-Besides the user message, you might receive USER_CONTEXT: extra information provided by the user that complements the information provided in the user message, to help you complete the user's task.
+// Log the default system prompt to read it and adjust it to your needs.
+console.log(getRecommendedSystemPrompt())
 ```
 
 Prompt engineering techniques can help you obtain the desired behavior from the AI Agent. To learn more, see these resources:

--- a/src/content/content-ai/capabilities/agent/configure/system-prompt.mdx
+++ b/src/content/content-ai/capabilities/agent/configure/system-prompt.mdx
@@ -38,10 +38,10 @@ provider.setSystemPrompt('You are an AI agent that edits rich text...')
 Nailing the right system prompt can be hard. The `@tiptap-pro/extension-ai-agent-server` package provides a default system prompt that works out of the box with the AI agent. Use it as a starting point to build your custom system prompt.
 
 ```ts
-import { getRecommendedSystemPrompt } from '@tiptap-pro/extension-ai-agent-server'
+import { getDefaultSystemPrompt } from '@tiptap-pro/extension-ai-agent-server'
 
 // Log the default system prompt to read it and adjust it to your needs.
-console.log(getRecommendedSystemPrompt())
+console.log(getDefaultSystemPrompt())
 ```
 
 Prompt engineering techniques can help you obtain the desired behavior from the AI Agent. To learn more, see these resources:


### PR DESCRIPTION
Introduced `getRecommendedSystemPrompt` function for AI agent extension. This function returns an example system prompt that works out of the box for the AI agent when customers run it in their own server. This has two benefits: we avoid making the system prompt public in the docs and respond to the feedback where some customers wanted the "example" or "default" system prompt to make the AI behave the same way as in Tiptap Cloud.