### PR TITLE
fix: missing import and define, weird indent, unopened script tag

### DIFF
--- a/src/content/editor/getting-started/install/svelte.mdx
+++ b/src/content/editor/getting-started/install/svelte.mdx
@@ -48,7 +48,7 @@ This is the fastest way to get Tiptap up and running with SvelteKit. It will giv
 
 ```svelte
 <script>
-  import { onDestroy, onMount } from "svelte"
+  import { onDestroy, onMount } from 'svelte'
   import { Editor } from '@tiptap/core'
   import { StarterKit } from '@tiptap/starter-kit'
   import BubbleMenu from '@tiptap/extension-bubble-menu'

--- a/src/content/editor/getting-started/install/svelte.mdx
+++ b/src/content/editor/getting-started/install/svelte.mdx
@@ -47,10 +47,13 @@ To start using Tiptap, you'll need to add a new component to your app. Let's cal
 This is the fastest way to get Tiptap up and running with SvelteKit. It will give you a very basic version of Tiptap, without any buttons. No worries, you will be able to add more functionality soon.
 
 ```svelte
-import { Editor } from '@tiptap/core'
+<script>
+  import { onDestroy, onMount } from "svelte"
+  import { Editor } from '@tiptap/core'
   import { StarterKit } from '@tiptap/starter-kit'
   import BubbleMenu from '@tiptap/extension-bubble-menu'
 
+  let editor = $state()
   let bubbleMenu = $state()
   let element = $state()
   let editorState = $state({editor: null})


### PR DESCRIPTION
The script content of [`/docs/editor/getting-started/install/svelte`](https://tiptap.dev/docs/editor/getting-started/install/svelte) was broken, so I fixed it.

<img width="464.5" height="359" alt="{E323D6C5-FAFC-4F98-BE9A-D93DF558C6FB}" src="https://github.com/user-attachments/assets/7488a89a-3e60-427b-b784-4284d37ba69f" />

- - -

Supersedes #374
