### PR TITLE
Add link to floating UI library

### DIFF
--- a/src/content/editor/extensions/functionality/bubble-menu.mdx
+++ b/src/content/editor/extensions/functionality/bubble-menu.mdx
@@ -103,7 +103,7 @@ Type: `(props) => boolean`
 
 ### getReferencedVirtualElement
 
-A callback to provide the anchor coordinates used to position the menu. Should return a [virtual element](https://floating-ui.com/docs/virtual-elements) as expected via [Floating UI](https://floating-ui.com/).
+A callback to provide the anchor coordinates used to position the menu. Should return a [virtual element](https://floating-ui.com/docs/virtual-elements) as expected by [Floating UI](https://floating-ui.com/).
 
 Type: `() => VirtualElement | null`
 

--- a/src/content/editor/extensions/functionality/bubble-menu.mdx
+++ b/src/content/editor/extensions/functionality/bubble-menu.mdx
@@ -103,11 +103,11 @@ Type: `(props) => boolean`
 
 ### getReferencedVirtualElement
 
-A callback to provide the anchor coordinates used to position the menu.
+A callback to provide the anchor coordinates used to position the menu. Should return a [virtual element](https://floating-ui.com/docs/virtual-elements) from the [Floating UI library](https://floating-ui.com/).
 
 Type: `() => VirtualElement | null`
 
-Default: null, anchor is implied by the editor selection.
+Default: `null`, anchor is implied by the editor selection.
 
 ## Source code
 

--- a/src/content/editor/extensions/functionality/bubble-menu.mdx
+++ b/src/content/editor/extensions/functionality/bubble-menu.mdx
@@ -103,7 +103,7 @@ Type: `(props) => boolean`
 
 ### getReferencedVirtualElement
 
-A callback to provide the anchor coordinates used to position the menu. Should return a [virtual element](https://floating-ui.com/docs/virtual-elements) from the [Floating UI library](https://floating-ui.com/).
+A callback to provide the anchor coordinates used to position the menu. Should return a [virtual element](https://floating-ui.com/docs/virtual-elements) as expected via [Floating UI](https://floating-ui.com/).
 
 Type: `() => VirtualElement | null`
 


### PR DESCRIPTION
Add link to Floating UI library to disambiguate what is a `VirtualElement` type. So developers know how to implement the `getReferencedVirtualElement` property.