### PR TITLE
Restructure the AI Toolkit overview page

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/overview.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/overview.mdx
@@ -30,7 +30,9 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
   </RequirementItem>
 </Requirements>
 
-The **AI Toolkit** is a flexible set of methods that help you build AI agents and extensions.
+The **AI Toolkit** is a set of tools to integrate AI into the Tiptap editor.
+
+Use it to build AI agents with text-editing superpowers. Or add any custom AI functionality to the Tiptap editor with its flexible primitives.
 
 <Callout title="Closed alpha" variant="hint">
   The AI Toolkit is currently in closed alpha. [Contact us](mailto:humans@tiptap.dev) to get access.
@@ -48,7 +50,7 @@ The **AI Toolkit** is a flexible set of methods that help you build AI agents an
 
 ## Installation guide
 
-The AI Toolkit is a Tiptap Pro extension. Before installing, get access by following the [private registry guide](/guides/pro-extensions).
+The AI Toolkit is a Pro extension. First, get access by following the [private registry guide](/guides/pro-extensions).
 
 Then, install the package:
 
@@ -78,7 +80,7 @@ toolkit.insertText('AI-generated content')
 
 New to the AI Toolkit? Begin with the quickstart guides:
 
-- [Build an AI agent](/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot)
+- [Build an AI agent chatbot](/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot)
 - [Review changes](/content-ai/capabilities/ai-toolkit/guides/review-changes)
 - [Review changes (as a summary)](/content-ai/capabilities/ai-toolkit/guides/review-changes-as-summary)
 

--- a/src/content/content-ai/capabilities/ai-toolkit/overview.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/overview.mdx
@@ -46,17 +46,11 @@ The **AI Toolkit** is a flexible set of methods that help you build AI agents an
   - **Display suggestions**: Let users review AI-generated content
   - **Compare documents** in real-time and show a diff view
 
-## Get started
+## Installation guide
 
-New to the AI Toolkit? Get started quickly with the quickstart guides:
+The AI Toolkit is a Tiptap Pro extension. Before installing, get access by following the [private registry guide](/guides/pro-extensions).
 
-- [Build an AI agent](/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot)
-- [Review changes](/content-ai/capabilities/ai-toolkit/guides/review-changes)
-- [Review changes (as a summary)](/content-ai/capabilities/ai-toolkit/guides/review-changes-as-summary)
-
-## Example usage
-
-Install the package:
+Then, install the package:
 
 ```bash
 npm install @tiptap-pro/ai-toolkit
@@ -79,6 +73,14 @@ const toolkit = getAiToolkit(editor)
 // Call the AI Toolkit methods
 toolkit.insertText('AI-generated content')
 ```
+
+## Next steps
+
+New to the AI Toolkit? Begin with the quickstart guides:
+
+- [Build an AI agent](/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot)
+- [Review changes](/content-ai/capabilities/ai-toolkit/guides/review-changes)
+- [Review changes (as a summary)](/content-ai/capabilities/ai-toolkit/guides/review-changes-as-summary)
 
 ## API reference
 


### PR DESCRIPTION
- Show the installation guide first so users don't forget adding the extension to the editor (Dave feedback)
- In the installation guide, mention that the AI Toolkit is a pro extension and that you need to configure access to the private registry.
- Simplfy wording
- Improve the description of the AI Toolkit