### PR TITLE
Snapshot compare styling guide

### DIFF
--- a/src/content/collaboration/documents/snapshot-compare.mdx
+++ b/src/content/collaboration/documents/snapshot-compare.mdx
@@ -21,22 +21,26 @@ Snapshot Compare lets you line-up two document versions and highlights everythin
 
 The Snapshot Compare extension adds extra functionality to the [Snapshots](/collaboration/documents/snapshot) by allowing you to visually compare changes made between two versions of a document so you can track what’s been added, removed, or modified. These comparisons are called _diffs_.
 
-
 <Requirements>
-    <RequirementItem label="1. Activate trial or subscribe">
-        Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Team plan](https://cloud.tiptap.dev/v2/billing) in your account.
-    </RequirementItem>
-    <RequirementItem label="2. Start Document server">
-        [Add an Environment](https://cloud.tiptap.dev/v2/configuration/document-server) in your dashboard and configure your [Document server](https://cloud.tiptap.dev/v2/configuration/document-server).
-    </RequirementItem>
-    <RequirementItem label="3. Install from private registry">
-        To install this extension, authenticate to Tiptap’s private npm registry by following the [setup guide](/guides/pro-extensions).
-    </RequirementItem>
+  <RequirementItem label="1. Activate trial or subscribe">
+    Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Team
+    plan](https://cloud.tiptap.dev/v2/billing) in your account.
+  </RequirementItem>
+  <RequirementItem label="2. Start Document server">
+    [Add an Environment](https://cloud.tiptap.dev/v2/configuration/document-server) in your
+    dashboard and configure your [Document
+    server](https://cloud.tiptap.dev/v2/configuration/document-server).
+  </RequirementItem>
+  <RequirementItem label="3. Install from private registry">
+    To install this extension, authenticate to Tiptap’s private npm registry by following the [setup
+    guide](/guides/pro-extensions).
+  </RequirementItem>
 </Requirements>
 
 <CodeDemo isPro path="/Extensions/SnapshotCompare" />
 
 ## Access the private registry
+
 The Snapshot Compare extension is published in Tiptap’s private npm registry. Integrate the extension by following the [private registry guide](/guides/pro-extensions). If you already authenticated your Tiptap account you can go straight to [#Install](#install).
 
 ## Install
@@ -267,7 +271,114 @@ Use the `hideDiff` command to hide the diff and restore the previous content.
 editor.commands.hideDiff()
 ```
 
-## Working with NodeView (Advanced)
+## Add styles
+
+The Snapshot Compare extension applies classes to the elements of the diff view to help you style inserted and deleted text. See a complete example of how to style the diff view in the [Code Demo](#) at the top of this page.
+
+### Basic diff styling
+
+The extension applies the following attributes to diff elements:
+
+- `data-diff-type="inline-insert"` - for inserted text
+- `data-diff-type="inline-delete"` - for deleted text
+- `data-diff-type="inline-update"` - for updated text
+- `data-diff-type="block-insert"` - for inserted blocks
+- `data-diff-type="block-delete"` - for deleted blocks
+
+You can target the elements with these data attributes by using CSS selectors.
+
+Here's an example of basic styling for inserted and deleted text:
+
+```css
+/* When there is no user involved, fallback to red and green colors */
+/* Style inserted text */
+[data-diff-type='inline-insert'],
+[data-diff-type='inline-update'],
+[data-diff-type='block-insert'] {
+  background-color: green;
+}
+
+/* Style deleted text */
+[data-diff-type='inline-delete'],
+[data-diff-type='block-delete'] {
+  background-color: red;
+  text-decoration: line-through;
+}
+```
+
+### Resetting mark styles for deleted text
+
+When text with formatting (like **bold**, _italic_, or `code`) is added, the deleted text (the text before the formatting was applied) can have that formatting applied to it. This issue occurs because the deleted text appears inside the HTML tag of the formatting. To prevent this, reset the mark styles inside the deleted content.
+
+First, reset the outer mark styles inside the deleted content.
+
+```scss
+/* Reset strong/bold formatting for deleted content */
+strong {
+  [data-diff-type='inline-delete'],
+  [data-diff-type='block-delete'] {
+    font-weight: normal;
+  }
+}
+
+/* Reset italic formatting for deleted content */
+em {
+  [data-diff-type='inline-delete'],
+  [data-diff-type='block-delete'] {
+    font-style: normal;
+  }
+}
+
+/* Reset code formatting for deleted content */
+code {
+  [data-diff-type='inline-delete'],
+  [data-diff-type='block-delete'] {
+    font-family: sans-serif;
+  }
+}
+```
+
+Then, if there is a mark tag inside the deleted content, re-apply the mark styles to it. This will ensure that the formatting is correctly applied to the deleted content.
+
+```scss
+/* Ensure mark styles work properly inside the deleted content */
+[data-diff-type='inline-delete'],
+[data-diff-type='block-delete'] {
+  strong {
+    font-weight: bold;
+  }
+  em {
+    font-style: italic;
+  }
+  code {
+    font-family: monospace;
+  }
+}
+```
+
+### User attribution styling
+
+When user attribution is available, you can style diffs based on the user who made the change:
+
+```css
+/* Style diffs with user attribution */
+[data-diff-user-id] {
+  position: relative;
+}
+
+/* Tooltip showing user name */
+[data-diff-user-id]::before {
+  content: attr(data-diff-user-id);
+  position: absolute;
+  visibility: hidden;
+}
+
+[data-diff-user-id]:hover::before {
+  visibility: visible;
+}
+```
+
+## Working with NodeView (advanced)
 
 When using [custom node views](/editor/extensions/custom-extensions/node-views), the default diff mapping may not work as expected. You can customize the mapping and render the diffs directly within the custom node view.
 

--- a/src/content/collaboration/documents/snapshot-compare.mdx
+++ b/src/content/collaboration/documents/snapshot-compare.mdx
@@ -273,7 +273,7 @@ editor.commands.hideDiff()
 
 ## Add styles
 
-The Snapshot Compare extension applies classes to the elements of the diff view to help you style inserted and deleted text. See a complete example of how to style the diff view in the [code demo](#) at the top of this page.
+The Snapshot Compare extension applies classes to the elements of the diff view to help you style inserted and deleted text. See a complete example of how to style the diff view in the [code demo](#page-title) at the top of this page.
 
 ### Basic diff styling
 

--- a/src/content/collaboration/documents/snapshot-compare.mdx
+++ b/src/content/collaboration/documents/snapshot-compare.mdx
@@ -273,7 +273,7 @@ editor.commands.hideDiff()
 
 ## Add styles
 
-The Snapshot Compare extension applies classes to the elements of the diff view to help you style inserted and deleted text. See a complete example of how to style the diff view in the [Code Demo](#) at the top of this page.
+The Snapshot Compare extension applies classes to the elements of the diff view to help you style inserted and deleted text. See a complete example of how to style the diff view in the [code demo](#) at the top of this page.
 
 ### Basic diff styling
 
@@ -308,7 +308,7 @@ Here's an example of basic styling for inserted and deleted text:
 
 ### Resetting mark styles for deleted text
 
-When text with formatting (like **bold**, _italic_, or `code`) is added, the deleted text (the text before the formatting was applied) can have that formatting applied to it. This issue occurs because the deleted text appears inside the HTML tag of the formatting. To prevent this, reset the mark styles inside the deleted content.
+When styling marks are applied (like **bold**, _italic_, or `code`), the deleted text (the text before the formatting was applied) can have that formatting applied to it. This issue occurs because the deleted text appears inside the HTML tag of the formatting. To prevent this, reset the mark styles inside the deleted content.
 
 First, reset the outer mark styles inside the deleted content.
 


### PR DESCRIPTION
Add a guide to add styles to the Snapshot Compare extension, explaining how to accomplish basic use cases and avoid common pitfalls.

Related to this bug fix: https://github.com/ueberdosis/tiptap-pro/pull/425