### PR TITLE
Remove all references to the old Notion-like template

### DIFF
--- a/src/content/content-ai/capabilities/generation/image-generation.mdx
+++ b/src/content/content-ai/capabilities/generation/image-generation.mdx
@@ -3,27 +3,29 @@ title: AI image generation editor command
 tags:
   - type: start
 meta:
-    title: Generate images | Tiptap Content AI Docs
-    description: Integrate the aiImagePrompt into your editor to generate images with AI with a custom prompt and style. More in the docs!
-    category: Content AI
+  title: Generate images | Tiptap Content AI Docs
+  description: Integrate the aiImagePrompt into your editor to generate images with AI with a custom prompt and style. More in the docs!
+  category: Content AI
 ---
+
 import { Requirements, RequirementItem } from '@/components/Requirements'
 
 <Requirements>
-    <RequirementItem label="1. Activate trial or subscribe">
-        Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start plan](https://cloud.tiptap.dev/v2/billing) in your account.
-    </RequirementItem>
-    <RequirementItem label="2. Integrate an AI provider">
-        Configure OpenAI in your [AI settings](https://cloud.tiptap.dev/v2/cloud/ai) or review the [Custom LLM guides](/content-ai/capabilities/generation/custom-llms).
-    </RequirementItem>
-    <RequirementItem label="3. Install from private registry">
-        To install the frontend extensions, authenticate to Tiptap’s private npm registry by following the [setup guide](/guides/pro-extensions).
-    </RequirementItem>
+  <RequirementItem label="1. Activate trial or subscribe">
+    Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start
+    plan](https://cloud.tiptap.dev/v2/billing) in your account.
+  </RequirementItem>
+  <RequirementItem label="2. Integrate an AI provider">
+    Configure OpenAI in your [AI settings](https://cloud.tiptap.dev/v2/cloud/ai) or review the
+    [Custom LLM guides](/content-ai/capabilities/generation/custom-llms).
+  </RequirementItem>
+  <RequirementItem label="3. Install from private registry">
+    To install the frontend extensions, authenticate to Tiptap’s private npm registry by following
+    the [setup guide](/guides/pro-extensions).
+  </RequirementItem>
 </Requirements>
 
 The `aiImagePrompt` command in Tiptap Content AI enables you to generate images directly within the editor. You can use different OpenAI models and customize the style of the generated images.
-
-To see how this command is used, check out the [notion-like template](https://templates.tiptap.dev/).
 
 ## Integrate aiImagePrompt
 

--- a/src/content/content-ai/getting-started/overview.mdx
+++ b/src/content/content-ai/getting-started/overview.mdx
@@ -105,8 +105,6 @@ Plug in our library of ready-made React components and full-featured templates t
   </CardGrid.Wrapper>
 </div>
 
-Tiptap’s new AI-ready UI component library and templates are in progress. Until then, you can explore our [legacy Notion-style template](https://templates.tiptap.dev/) as an inspiration for wiring AI into an editor. We no longer maintain this template or provide the source code. Migrate to the upcoming components and templates for an easier upgrade path.
-
 ## Examples and demos
 
 We provide examples for integrating AI features into your editor. Check our demos:


### PR DESCRIPTION
Remove all references to the legacy Block Editor template.

In the image generation guide, remove all references to this template and do not mention the new one, because it does not have image generation capabilities.