### PR TITLE
Update drag handle options

### DIFF
--- a/src/content/editor/extensions/functionality/drag-handle-react.mdx
+++ b/src/content/editor/extensions/functionality/drag-handle-react.mdx
@@ -50,16 +50,17 @@ The content that should be displayed inside of the drag handle.
 </DragHandle>
 ```
 
-### tippyOptions
+### computePositionConfig
 
-Options for tippy.js. You can pass any options that are available in the [tippy.js documentation](https://atomiks.github.io/tippyjs/v6/all-props/).
+Configuration for position computation of the drag handle using the floating-ui/dom package. You can pass any options that are available in the [floating-ui documentation](https://floating-ui.com/docs/computePosition).
 
-Default: `undefined`
+Default: `{ placement: 'left-start', strategy: 'absolute' }`
 
 ```jsx
 <DragHandle
-  tippyOptions={{
+  computePositionConfig={{
     placement: 'left',
+    strategy: 'fixed',
   }}
 >
   <div>Drag Me!</div>
@@ -87,6 +88,35 @@ function Component() {
     </DragHandle>
   )
 }
+```
+
+### getReferencedVirtualElement
+
+A function that returns the virtual element for the drag handle. This is useful when the menu needs to be positioned relative to a specific DOM element.
+
+Default: `undefined`
+
+```jsx
+<DragHandle
+  getReferencedVirtualElement={() => {
+    // Return a virtual element for custom positioning
+    return null
+  }}
+>
+  <div>Drag Me!</div>
+</DragHandle>
+```
+
+### locked
+
+Locks the draghandle in place and visibility. If the drag handle was visible, it will remain visible until unlocked. If it was hidden, it will remain hidden until unlocked.
+
+Default: `false`
+
+```jsx
+<DragHandle locked={true}>
+  <div>Drag Me!</div>
+</DragHandle>
 ```
 
 ### pluginKey

--- a/src/content/editor/extensions/functionality/drag-handle-vue.mdx
+++ b/src/content/editor/extensions/functionality/drag-handle-vue.mdx
@@ -57,14 +57,14 @@ The content that should be displayed inside of the drag handle.
 </drag-handle>
 ```
 
-### tippyOptions
+### computePositionConfig
 
-Options for tippy.js. You can pass any options that are available in the [tippy.js documentation](https://atomiks.github.io/tippyjs/v6/all-props/).
+Configuration for position computation of the drag handle using the floating-ui/dom package. You can pass any options that are available in the [floating-ui documentation](https://floating-ui.com/docs/computePosition).
 
-Default: `undefined`
+Default: `{ placement: 'left-start', strategy: 'absolute' }`
 
 ```vue
-<drag-handle :tippy-options="{ placement: 'left' }">
+<drag-handle :compute-position-config="{ placement: 'left', strategy: 'fixed' }">
   <div>Drag Me!</div>
 </drag-handle>
 ```
@@ -105,6 +105,47 @@ export default {
   },
 }
 </script>
+```
+
+### getReferencedVirtualElement
+
+A function that returns the virtual element for the drag handle. This is useful when the menu needs to be positioned relative to a specific DOM element.
+
+Default: `undefined`
+
+```vue
+<template>
+  <drag-handle :get-referenced-virtual-element="getVirtualElement">
+    <div>Drag Me!</div>
+  </drag-handle>
+</template>
+
+<script>
+export default {
+  setup() {
+    const getVirtualElement = () => {
+      // Return a virtual element for custom positioning
+      return null
+    }
+
+    return {
+      getVirtualElement,
+    }
+  },
+}
+</script>
+```
+
+### locked
+
+Locks the draghandle in place and visibility. If the drag handle was visible, it will remain visible until unlocked. If it was hidden, it will remain hidden until unlocked.
+
+Default: `false`
+
+```vue
+<drag-handle :locked="true">
+  <div>Drag Me!</div>
+</drag-handle>
 ```
 
 ### pluginKey

--- a/src/content/editor/extensions/functionality/drag-handle.mdx
+++ b/src/content/editor/extensions/functionality/drag-handle.mdx
@@ -39,7 +39,7 @@ npm install @tiptap/extension-drag-handle
 
 ### render
 
-Renders an element that is positioned with tippy.js. This is the element that will be displayed as the handle when dragging a node around.
+Renders an element that is positioned with the floating-ui/dom package. This is the element that will be displayed as the handle when dragging a node around.
 
 ```js
 DragHandle.configure({
@@ -54,17 +54,45 @@ DragHandle.configure({
 })
 ```
 
-### tippyOptions
+### computePositionConfig
 
-Options for tippy.js. You can pass any options that are available in the [tippy.js documentation](https://atomiks.github.io/tippyjs/v6/all-props/).
+Configuration for position computation of the drag handle using the floating-ui/dom package. You can pass any options that are available in the [floating-ui documentation](https://floating-ui.com/docs/computePosition).
+
+Default: `{ placement: 'left-start', strategy: 'absolute' }`
+
+```js
+DragHandle.configure({
+  computePositionConfig: {
+    placement: 'left',
+    strategy: 'fixed',
+  },
+})
+```
+
+### getReferencedVirtualElement
+
+A function that returns the virtual element for the drag handle. This is useful when the menu needs to be positioned relative to a specific DOM element.
 
 Default: `undefined`
 
 ```js
 DragHandle.configure({
-  tippyOptions: {
-    placement: 'left',
+  getReferencedVirtualElement: () => {
+    // Return a virtual element for custom positioning
+    return null
   },
+})
+```
+
+### locked
+
+Locks the draghandle in place and visibility. If the drag handle was visible, it will remain visible until unlocked. If it was hidden, it will remain hidden until unlocked.
+
+Default: `false`
+
+```js
+DragHandle.configure({
+  locked: true,
 })
 ```
 


### PR DESCRIPTION
Update the options of the drag handle extension in the documentation so that they no longer longer the Tippy.js options (the drag handle extension is no longer implemented with Tippy.js)