### PR TITLE
AI Toolkit: advanced reading tools documentation

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 3.0.0-alpha.7
+
+### Major Changes
+
+- Requires upgrading to a version of the `@tiptap-pro/ai-toolkit` package that is equal or higher than `3.0.0-alpha.14`
+- Improved tool definitions for reading and editing the document
+
 ## 3.0.0-alpha.6
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 3.0.0-alpha.3
+
+### Major Changes
+
+- Requires upgrading to a version of the `@tiptap-pro/ai-toolkit` package that is equal or higher than `3.0.0-alpha.14`
+- Improved tool definitions for reading and editing the document
+
 ## 3.0.0-alpha.2
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 3.0.0-alpha.2
+
+### Major Changes
+
+- Requires upgrading to a version of the `@tiptap-pro/ai-toolkit` package that is equal or higher than `3.0.0-alpha.14`
+- Improved tool definitions for reading and editing the document
+
 ## 3.0.0-alpha.1
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 3.0.0-alpha.4
+
+### Major Changes
+
+- Requires upgrading to a version of the `@tiptap-pro/ai-toolkit` package that is equal or higher than `3.0.0-alpha.14`
+- Improved tool definitions for reading and editing the document
+
 ## 3.0.0-alpha.3
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,26 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.14
+
+### Major Changes
+
+- Requires upgrading to a version of these provider libraries that is equal or higher than:
+  - `@tiptap-pro/ai-toolkit-tool-definitions@3.0.0-alpha.4`
+  - `@tiptap-pro/ai-toolkit-ai-sdk@3.0.0-alpha.7`
+  - `@tiptap-pro/ai-toolkit-langchain@3.0.0-alpha.3`
+  - `@tiptap-pro/ai-toolkit-openai@3.0.0-alpha.2`
+- Remove `currentChunk` parameter and return value from the `executeTool` method
+  - The `executeTool` method no longer accepts `currentChunk` parameter
+  - The `executeTool` method no longer returns `currentChunk` field
+- Add `getActiveNodeRange` method to get the active node range. The active node range is the range of top-level nodes that can be edited in the next tool call, it helps the AI make more precise edits when editing the document with the `applyDiff` tool. It replaces the `currentChunk` parameter.
+- Add `setActiveNodeRange` method to set the active node range
+- Remove tools `readFirstChunk`, `readNextChunk` and `readPreviousChunk`.
+- Add `readNodeRange` tool. This tool allows the AI to read any range of top-level nodes in the document. It is much more flexible than the previous chunk-based reading tools.
+
+### Minor Changes
+- Add `streamTool` method to stream a tool call into the editor
+
 ## 3.0.0-alpha.13
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot.mdx
@@ -75,7 +75,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
   const result = streamText({
-    model: openai('gpt-5-mini'),
+    model: openai('gpt-5'),
     system: 'You are an assistant that can edit rich text documents.',
     messages: convertToModelMessages(messages),
     tools: toolDefinitions(),

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/edit-the-document.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/edit-the-document.mdx
@@ -181,7 +181,7 @@ Apply context-aware HTML diffs to a chunk or the whole document.
   - `insert` (`string`): HTML to insert
 - `options?` (`ApplyHtmlDiffOptions`): Options for the `applyHtmlDiff` method
   - `chunkIndex?` (`number`): Target chunk index. Default: `0`
-  - `chunkSize?` (`number`): The maximum size of each chunk in number of characters. Default: `32000`
+  - `chunkSize?` (`number`): The maximum size of a string that can be passed as input to the AI model. Prevents the AI from reading too much content at once so that the context window of the AI model is not exceeded. Default: `32000`
   - `reviewOptions?` (`Omit<ReviewOptions, 'showDiff'>`): Review behavior. Note: diff previews force `showAsDiff` in compare mode
     - `mode?` (`'disabled' | 'review' | 'preview'`): Whether to review the changes before or after applying them. `'disabled'` means no review, `'review'` means review after applying, `'preview'` means preview before applying. Default: `'disabled'`
     - `displayOptions?` (`DisplayOptions<{ suggestion: Suggestion }>`): Customize how suggestions are displayed

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/execute-tool.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/execute-tool.mdx
@@ -19,7 +19,7 @@ Executes a supported tool by name and input.
 - `options` (`ExecuteToolOptions`): Configuration for tool execution
   - `toolName` (`string`): Tool to execute. Can be one of the [available tools](/content-ai/capabilities/ai-toolkit/tools/available-tools).
   - `input` (`unknown`): A JSON object that matches the input schema of the tool parameters. If no parameters are required for this tool, pass an empty object (`{}`).
-  - `chunkSize?` (`number`): The maximum size of each chunk in number of characters. Default: `32000`. This parameter is used by reading tools to control how the document is split into chunks.
+  - `chunkSize?` (`number`): The maximum size of a string that can be passed as input to the AI model. Prevents the AI from reading too much content at once so that the context window of the AI model is not exceeded. Default: `32000`. This parameter is used by reading tools to control how the document is split into chunks.
   - `reviewOptions?` (`ReviewOptions`): Control preview/review behavior
     - `mode?` (`'disabled' | 'review' | 'preview'`): Whether to review the changes before or after applying them. `'disabled'` means no review, `'review'` means review after applying, `'preview'` means preview before applying. Default: `'disabled'`
     - `showDiff?` (`boolean`): Whether to diff the documents before and after the change to display the change as a detailed diff. Default: `false`
@@ -65,7 +65,7 @@ This method has the same effect as calling the `executeTool` method, but it edit
   - `toolName` (`string`): Tool to execute. Can be one of the [available tools](/content-ai/capabilities/ai-toolkit/tools/available-tools).
   - `input` (`unknown`): A JSON object that matches the input schema of the tool parameters. If no parameters are required for this tool, pass an empty object (`{}`). If the tool has not finished streaming, this parameter should be a partial object with part of the parameters, but still a valid JSON object.
   - `hasFinished?` (`boolean`): Whether the tool has finished streaming. Default: `false`
-  - `chunkSize?` (`number`): The maximum size of each chunk in number of characters. Default: `32000`. This parameter is used by reading tools to control how the document is split into chunks.
+  - `chunkSize?` (`number`): The maximum size of a string that can be passed as input to the AI model. Prevents the AI from reading too much content at once so that the context window of the AI model is not exceeded. Default: `32000`. This parameter is used by reading tools to control how the document is split into chunks.
   - `reviewOptions?` (`ReviewOptions`): Control preview/review behavior
     - `mode?` (`'disabled' | 'review' | 'preview'`): Whether to review the changes before or after applying them. `'disabled'` means no review, `'review'` means review after applying, `'preview'` means preview before applying. Default: `'disabled'`
     - `showDiff?` (`boolean`): Whether to diff the documents before and after the change to display the change as a detailed diff. Default: `false`

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/read-the-document.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/read-the-document.mdx
@@ -220,8 +220,10 @@ Split the document into text chunks for large-content processing.
 ### Example
 
 ```ts
-// Chunk text by 1000 characters
+// Split the document into chunks of the default size
 const chunks = toolkit.getTextChunks()
+// Split the document into chunks of 1000 characters maximum
+const smallerChunks = toolkit.getTextChunks({ chunkSize: 1000 })
 ```
 
 ## `getHtmlChunks`
@@ -246,8 +248,10 @@ Split the document into HTML chunks for large-content processing.
 ### Example
 
 ```ts
-// Chunk HTML by 1000 characters
+// Split the document into chunks of the default size
 const chunks = toolkit.getHtmlChunks()
+// Split the document into chunks of 1000 characters maximum
+const smallerChunks = toolkit.getHtmlChunks({ chunkSize: 1000 })
 ```
 
 ## `getJsonChunks`
@@ -272,6 +276,8 @@ Split the document into Tiptap JSON chunks for large-content processing.
 ### Example
 
 ```ts
-// Chunk Tiptap JSON by 1000 characters
+// Split the document into chunks of the default size
 const chunks = toolkit.getJsonChunks()
+// Split the document into chunks of 1000 characters maximum
+const smallerChunks = toolkit.getJsonChunks({ chunkSize: 1000 })
 ```

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/schema-awareness.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/schema-awareness.mdx
@@ -113,7 +113,7 @@ export async function POST(req: Request) {
     await req.json()
 
   const result = streamText({
-    model: openai('gpt-5-mini'),
+    model: openai('gpt-5'),
     // Add the schema awareness string to end of the system prompt
     system: `You are an assistant that can edit rich text documents.
 ${schemaAwareness}`,

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/ai-sdk.mdx
@@ -66,12 +66,10 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [Vercel AI SD
 
 #### Parameters (`ToolDefinitionsOptions`)
 
-- `tools?`: `EnabledTools` - Enable/disable specific tools. All tools are enabled by default.
+- `tools?`: `EnabledTools` - Enable/disable specific tools by setting the value to `true` (enabled) or `false` (disabled).
   - `insertContent?`: `boolean` - Enable/disable the `insertContent` tool (default: `true`)
   - `applyDiff?`: `boolean` - Enable/disable the `applyDiff` tool (default: `true`)
-  - `readFirstChunk?`: `boolean` - Enable/disable the `readFirstChunk` tool (default: `true`)
-  - `readNextChunk?`: `boolean` - Enable/disable the `readNextChunk` tool (default: `true`)
-  - `readPreviousChunk?`: `boolean` - Enable/disable the `readPreviousChunk` tool (default: `true`)
+  - `readNodeRange?`: `boolean` - Enable/disable the `readNodeRange` tool (default: `true`)
   - `readSelection?`: `boolean` - Enable/disable the `readSelection` tool (default: `true`)
 
 #### Returns
@@ -80,7 +78,5 @@ An object containing the enabled tool definitions that can be used with the [Ver
 
 - `insertContent` - Tool for inserting HTML content at a specific position
 - `applyDiff` - Tool for applying targeted edits via diffs
-- `readFirstChunk` - Tool for reading the first chunk of the document
-- `readNextChunk` - Tool for reading the next chunk of the document
-- `readPreviousChunk` - Tool for reading the previous chunk of the document
+- `readNodeRange` - Tool for reading part of the document by specifying a range of top-level nodes
 - `readSelection` - Tool for reading the currently selected content in the editor

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/ai-sdk.mdx
@@ -26,7 +26,7 @@ import { streamText } from 'ai'
 import { toolDefinitions } from '@tiptap-pro/ai-toolkit-ai-sdk'
 
 const result = streamText({
-  model: openai('gpt-5-mini'),
+  model: openai('gpt-5'),
   tools: toolDefinitions(),
 })
 ```
@@ -40,7 +40,7 @@ import { toolDefinitions } from '@tiptap-pro/ai-toolkit-ai-sdk'
 import { z } from 'zod'
 
 const result = streamText({
-  model: openai('gpt-5-mini'),
+  model: openai('gpt-5'),
   tools: {
     // Tool definitions from the AI Toolkit
     ...toolDefinitions(),

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/available-tools.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/available-tools.mdx
@@ -50,33 +50,25 @@ Apply targeted edits via diffs to make precise changes to document content.
 ### Parameters
 
 - `diffs` (`Diff[]`): Array of diffs to apply in sequence
-  - `context` (`string`): Context string to help locate the correct position
-  - `delete` (`string`): The content to delete from the document (must match exactly)
-  - `insert` (`string`): The content to insert in place of the deleted content (can be empty for pure deletions)
+  - `context` (`string`): Context string to help locate the correct position. Must be an exact match.
+  - `delete` (`string`): The content to delete from the document. Must be an exact match.
+  - `insert` (`string`): The content to insert in place of the deleted content. It can be empty for pure deletions.
 
-## `readFirstChunk`
+## `readNodeRange`
 
-Get the first chunk of the document for efficient processing of large content.
-
-### Parameters
-
-No parameters required.
-
-## `readNextChunk`
-
-Get the next chunk of the document in sequence.
+Read part of the document by specifying a range of nodes to read. This tool allows efficient processing of large documents, so that, if the document is too large, the context window of the AI model is not exceeded. The AI can precisely jump to specific positions in the document, to see their content and edit them.
 
 ### Parameters
 
-No parameters required.
+- `nodeRange` (`string`): A string representing the range of the document to read.
 
-## `readPreviousChunk`
+If the provided node range is too large, the AI Toolkit reads the first part of it, and informs the AI of what part of the document was actually read. If the range is outside the bounds of the document, the AI Toolkit handles it gracefully and informs the AI model of the mistake.
 
-Get the previous chunk of the document to navigate backward.
+### Result
 
-### Parameters
-
-No parameters required.
+- `totalNodeCount`: The total number of top-level nodes in the document
+- `activeNodeRange`: The actual range of nodes that were read
+- `content`: The HTML content of the nodes that were read
 
 ## `readSelection`
 
@@ -85,3 +77,8 @@ Get the currently selected content in the editor.
 ### Parameters
 
 No parameters required.
+
+### Result
+
+- `selection` (`string`): The selected HTML content
+- `nodeRange`: The range of nodes that were read, so that the AI can precisely jump to the place where the selection is located.

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/langchain-js.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/langchain-js.mdx
@@ -62,12 +62,10 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [LangChain.js
 
 #### Parameters (`ToolDefinitionsOptions`)
 
-- `tools?`: `EnabledTools` - Enable/disable specific tools. All tools are enabled by default.
+- `tools?`: `EnabledTools` - Enable/disable specific tools by setting the value to `true` (enabled) or `false` (disabled).
   - `insertContent?`: `boolean` - Enable/disable the `insertContent` tool (default: `true`)
   - `applyDiff?`: `boolean` - Enable/disable the `applyDiff` tool (default: `true`)
-  - `readFirstChunk?`: `boolean` - Enable/disable the `readFirstChunk` tool (default: `true`)
-  - `readNextChunk?`: `boolean` - Enable/disable the `readNextChunk` tool (default: `true`)
-  - `readPreviousChunk?`: `boolean` - Enable/disable the `readPreviousChunk` tool (default: `true`)
+  - `readNodeRange?`: `boolean` - Enable/disable the `readNodeRange` tool (default: `true`)
   - `readSelection?`: `boolean` - Enable/disable the `readSelection` tool (default: `true`)
 
 #### Returns
@@ -76,7 +74,5 @@ An array containing the enabled tool definitions that can be used with [LangChai
 
 - `insertContent` - Tool for inserting HTML content at a specific position
 - `applyDiff` - Tool for applying targeted edits via diffs
-- `readFirstChunk` - Tool for reading the first chunk of the document
-- `readNextChunk` - Tool for reading the next chunk of the document
-- `readPreviousChunk` - Tool for reading the previous chunk of the document
+- `readNodeRange` - Tool for reading part of the document by specifying a range of top-level nodes
 - `readSelection` - Tool for reading the currently selected content in the editor

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/langchain-js.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/langchain-js.mdx
@@ -36,7 +36,7 @@ import { toolDefinitions } from '@tiptap-pro/ai-toolkit-langchain'
 import { DynamicStructuredTool } from '@langchain/core/tools'
 import { z } from 'zod'
 
-const llm = new ChatOpenAI({ model: 'gpt-4' })
+const llm = new ChatOpenAI({ model: 'gpt-5' })
 
 const customTools = [
   new DynamicStructuredTool({

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/openai.mdx
@@ -60,7 +60,7 @@ const customTools = [
 ]
 
 const response = await openai.responses.create({
-  model: 'gpt-4',
+  model: 'gpt-5',
   input: [{ role: 'user', content: 'What is the weather like and help me edit this document' }],
   tools: [...toolDefinitions(), ...customTools],
 })

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/openai.mdx
@@ -74,12 +74,10 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [OpenAI's res
 
 #### Parameters (`ToolDefinitionsOptions`)
 
-- `tools?`: `EnabledTools` - Enable/disable specific tools. All tools are enabled by default.
+- `tools?`: `EnabledTools` - Enable/disable specific tools by setting the value to `true` (enabled) or `false` (disabled).
   - `insertContent?`: `boolean` - Enable/disable the `insertContent` tool (default: `true`)
   - `applyDiff?`: `boolean` - Enable/disable the `applyDiff` tool (default: `true`)
-  - `readFirstChunk?`: `boolean` - Enable/disable the `readFirstChunk` tool (default: `true`)
-  - `readNextChunk?`: `boolean` - Enable/disable the `readNextChunk` tool (default: `true`)
-  - `readPreviousChunk?`: `boolean` - Enable/disable the `readPreviousChunk` tool (default: `true`)
+  - `readNodeRange?`: `boolean` - Enable/disable the `readNodeRange` tool (default: `true`)
   - `readSelection?`: `boolean` - Enable/disable the `readSelection` tool (default: `true`)
 
 #### Returns
@@ -88,9 +86,7 @@ An array containing the enabled tool definitions that can be used with [OpenAI's
 
 - `insertContent` - Tool for inserting HTML content at a specific position
 - `applyDiff` - Tool for applying targeted edits via diffs
-- `readFirstChunk` - Tool for reading the first chunk of the document
-- `readNextChunk` - Tool for reading the next chunk of the document
-- `readPreviousChunk` - Tool for reading the previous chunk of the document
+- `readNodeRange` - Tool for reading part of the document by specifying a range of top-level nodes
 - `readSelection` - Tool for reading the currently selected content in the editor
 
 ### `completionsApiToolDefinitions`
@@ -102,9 +98,7 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [OpenAI's com
 - `tools?`: `EnabledTools` - Enable/disable specific tools. All tools are enabled by default.
   - `insertContent?`: `boolean` - Enable/disable the `insertContent` tool (default: `true`)
   - `applyDiff?`: `boolean` - Enable/disable the `applyDiff` tool (default: `true`)
-  - `readFirstChunk?`: `boolean` - Enable/disable the `readFirstChunk` tool (default: `true`)
-  - `readNextChunk?`: `boolean` - Enable/disable the `readNextChunk` tool (default: `true`)
-  - `readPreviousChunk?`: `boolean` - Enable/disable the `readPreviousChunk` tool (default: `true`)
+  - `readNodeRange?`: `boolean` - Enable/disable the `readNodeRange` tool (default: `true`)
   - `readSelection?`: `boolean` - Enable/disable the `readSelection` tool (default: `true`)
 
 #### Returns
@@ -113,7 +107,5 @@ An array containing the enabled tool definitions that can be used with [OpenAI's
 
 - `insertContent` - Tool for inserting HTML content at a specific position
 - `applyDiff` - Tool for applying targeted edits via diffs
-- `readFirstChunk` - Tool for reading the first chunk of the document
-- `readNextChunk` - Tool for reading the next chunk of the document
-- `readPreviousChunk` - Tool for reading the previous chunk of the document
+- `readNodeRange` - Tool for reading part of the document by specifying a range of top-level nodes
 - `readSelection` - Tool for reading the currently selected content in the editor


### PR DESCRIPTION
Documentation for the advanced reading tools of the AI Toolkit

- Updates the reading tools list
- Fixes small mistakes in the AI Toolkit documentation like incorrect values and incorrect model names.
- Updates the changelog to prepare for the upcoming release.

Docs of PR https://github.com/ueberdosis/tiptap-pro/pull/428