### PR TITLE
Switch pages to public alpha

### DIFF
--- a/src/content/pages/getting-started/install.mdx
+++ b/src/content/pages/getting-started/install.mdx
@@ -1,7 +1,6 @@
 ---
 title: Install the Pages extension
 tags:
-  - type: restricted
   - type: alpha
 meta:
   title: Install Pages | Tiptap Pages Docs

--- a/src/content/pages/getting-started/overview.mdx
+++ b/src/content/pages/getting-started/overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: Pages
 tags:
-  - type: restricted
   - type: alpha
 meta:
     title: Pages | Tiptap Pages

--- a/src/content/pages/guides/collaboration-with-pages.mdx
+++ b/src/content/pages/guides/collaboration-with-pages.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Adding collaboration to Pages"
 tags:
-  - type: restricted
   - type: alpha
 meta:
   title: Collaboration with Pages | Tiptap Pages Docs

--- a/src/content/pages/guides/pagekit-usage.mdx
+++ b/src/content/pages/guides/pagekit-usage.mdx
@@ -1,7 +1,6 @@
 ---
 title: "PageKit"
 tags:
-  - type: restricted
   - type: alpha
 meta:
   title: PageKit usage | Tiptap Pages Docs

--- a/src/content/pages/guides/table-with-pages.mdx
+++ b/src/content/pages/guides/table-with-pages.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Using the TableKit extension with Pages"
 tags:
-  - type: restricted
   - type: alpha
 meta:
   title: TableKit with Pages | Tiptap Pages Docs

--- a/src/content/pages/guides/zero-to-print-ready.mdx
+++ b/src/content/pages/guides/zero-to-print-ready.mdx
@@ -1,7 +1,6 @@
 ---
 title: "From zero to print-ready: Pages & DOCX export"
 tags:
-  - type: restricted
   - type: alpha
 meta:
   title: From zero to print-ready | Tiptap Pages Docs


### PR DESCRIPTION
This pull request makes a small update to the documentation frontmatter for several guide and getting started pages. The main change is the removal of the `type: restricted` tag from the `tags` field in each file, leaving only the `type: alpha` tag.