### PR TITLE
Add explanation on how to access the parent element of the BubbleMenu in the React component

### DIFF
--- a/src/content/editor/extensions/functionality/bubble-menu.mdx
+++ b/src/content/editor/extensions/functionality/bubble-menu.mdx
@@ -45,10 +45,12 @@ Type: `HTMLElement`
 
 Default: `null`
 
+In the React version of the `Bubble Menu`, access the DOM element with the `ref` prop of the `BubbleMenu` component, by [passing a ref](https://react.dev/learn/manipulating-the-dom-with-refs) into it.
+
 ### updateDelay
 
 The `BubbleMenu` debounces the `update` method to allow the bubble menu to not be updated on every selection update. This can be controlled in milliseconds.
-The BubbleMenuPlugin will come with a default delay of 250ms. This can be deactivated, by setting the delay to `0` which deactivates the debounce.
+The `BubbleMenuPlugin` will come with a default delay of 250ms. This can be deactivated, by setting the delay to `0` which deactivates the debounce.
 
 Type: `Number`
 


### PR DESCRIPTION
Add brief explanation on how to access the parent element of the `BubbleMenu` in the React component.

This PR is a result of customer feedback.