### PR TITLE
Add guide on how to force update the position of the bubble menu

### DIFF
--- a/src/content/editor/extensions/functionality/bubble-menu.mdx
+++ b/src/content/editor/extensions/functionality/bubble-menu.mdx
@@ -189,3 +189,11 @@ new Editor({
   ],
 })
 ```
+
+### Force update the position of the bubble menu
+
+If the bubble menu changes size after the initial render, its position will not be adjusted automatically. To fix this, you can force update the position of the bubble menu by emitting an `'updatePosition'` event.
+
+```ts
+editor.commands.setMeta('bubbleMenu', 'updatePosition')
+```


### PR DESCRIPTION
Docs of PR https://github.com/ueberdosis/tiptap/pull/7005

Adds a short section to the `BubbleMenu` extension guide, where it explains how to force update the position of the bubble menu when its size changes.

This PR fixes a customer issue.