### PR TITLE
Server side Unique ID utility docs

### DIFF
--- a/src/content/editor/extensions/functionality/uniqueid.mdx
+++ b/src/content/editor/extensions/functionality/uniqueid.mdx
@@ -86,3 +86,47 @@ UniqueID.configure({
   filterTransaction: (transaction) => !isChangeOrigin(transaction),
 })
 ```
+
+## Server side Unique ID utility
+
+The `generateUniqueIds` function allows you to add unique IDs to a Tiptap document on the server side, without needing to create an `Editor` instance. This is useful for processing documents server-side or when you need to add IDs to existing content.
+
+### Parameters
+
+- **`doc`** (`JSONContent`): A Tiptap JSON document to add unique IDs to
+- **`extensions`** (`Extensions`): The extensions to use. Must include the `UniqueID` extension. To customize how the IDs are generated, you can pass options to the `UniqueID` extension.
+
+### Return type
+
+Returns a new Tiptap document (a `JSONContent` object) with unique IDs added to the nodes.
+
+### Example
+
+```js
+import { generateUniqueIds, UniqueID } from '@tiptap/extension-unique-id'
+import { StarterKit } from '@tiptap/starter-kit'
+
+const doc = {
+  type: 'doc',
+  content: [
+    { type: 'paragraph', content: [{ type: 'text', text: 'Hello, world!' }] },
+    { type: 'heading', attrs: { level: 1 }, content: [{ type: 'text', text: 'My Heading' }] },
+  ],
+}
+
+const newDoc = generateUniqueIds(doc, [
+  StarterKit,
+  UniqueID.configure({ types: ['paragraph', 'heading'] }),
+])
+
+// Result:
+// {
+//   type: 'doc',
+//   content: [
+//     { type: 'paragraph', content: [{ type: 'text', text: 'Hello, world!' }], attrs: { id: 'd4590f81-52e8-45ec-b317-2e9a805b03e3' } },
+//     { type: 'heading', content: [{ type: 'text', text: 'My Heading' }], attrs: { level: 1, id: 'c88f9b5f-7b91-442f-b4d9-ee0d04104827' } }
+//   ]
+// }
+```
+
+The function automatically picks up the configuration from the `UniqueID` extension, including options like `types`, `attributeName`, and `generateID`.


### PR DESCRIPTION
Docs of PR https://github.com/ueberdosis/tiptap/pull/6975

Adds a unique ID utility that lets you add unique IDs to a document in the server, like the UniqueID extension would do.

This PR is the result of a customer support request