### PR TITLE
AI Toolkit alpha 17 version

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 3.0.0-alpha.8
+
+### Major changes
+
+- Improve tool definitions of `readSelection` and `insertContent` tools to fix a bug where the AI inserts the content in the wrong place if the user changes the selection after the AI reads the selection. Requires a version of the AI Toolkit equal or higher than `3.0.0-alpha-17`
+
 ## 3.0.0-alpha.7
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 3.0.0-alpha.4
+
+### Major changes
+
+- Improve tool definitions of `readSelection` and `insertContent` tools to fix a bug where the AI inserts the content in the wrong place if the user changes the selection after the AI reads the selection. Requires a version of the AI Toolkit equal or higher than `3.0.0-alpha-17`
+
 ## 3.0.0-alpha.3
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 3.0.0-alpha.3
+
+### Major changes
+
+- Improve tool definitions of `readSelection` and `insertContent` tools to fix a bug where the AI inserts the content in the wrong place if the user changes the selection after the AI reads the selection. Requires a version of the AI Toolkit equal or higher than `3.0.0-alpha-17`
+
 ## 3.0.0-alpha.2
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 3.0.0-alpha.5
+
+### Major changes
+
+- Improve tool definitions of `readSelection` and `insertContent` tools to fix a bug where the AI inserts the content in the wrong place if the user changes the selection after the AI reads the selection. Requires a version of the AI Toolkit equal or higher than `3.0.0-alpha-17`
+
 ## 3.0.0-alpha.4
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,16 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.17
+
+### Major Changes
+
+- Improve tool definitions of `readSelection` and `insertContent` tools to fix a bug where the AI inserts the content in the wrong place if the user changes the selection after the AI reads the selection.
+
+### Patch Changes
+
+- Fix issue in `streamHtml` and `streamText` methods where a `ReadableStream` was not accepted as a parameter
+
 ## 3.0.0-alpha.16
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -49,6 +49,7 @@ meta:
 - Add `readNodeRange` tool. This tool allows the AI to read any range of top-level nodes in the document. It is much more flexible than the previous chunk-based reading tools.
 
 ### Minor Changes
+
 - Add `streamTool` method to stream a tool call into the editor
 
 ## 3.0.0-alpha.13

--- a/src/content/content-ai/capabilities/ai-toolkit/overview.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/overview.mdx
@@ -100,4 +100,5 @@ The AI Toolkit is split into packages and modules:
 - Tool definitions for AI providers
   - [AI SDK by Vercel](/content-ai/capabilities/ai-toolkit/tools/ai-sdk) (`@tiptap-pro/ai-toolkit-ai-sdk`)
   - [LangChain.js](/content-ai/capabilities/ai-toolkit/tools/langchain-js) (`@tiptap-pro/ai-toolkit-langchain`)
+  - [OpenAI](/content-ai/capabilities/ai-toolkit/tools/openai) (`@tiptap-pro/ai-toolkit-openai`)
   - [Other providers](/content-ai/capabilities/ai-toolkit/tools/other-providers)

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/edit-the-document.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/edit-the-document.mdx
@@ -104,7 +104,7 @@ Stream plain text content into the editor in real-time.
 
 ### Parameters
 
-- `stream` (`AsyncIterable<string | Uint8Array>`): The stream of text content. It can be any object that implements the [Async Iterable protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), such as a [ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) or a [generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_generators).
+- `stream` (`AsyncIterable<string | Uint8Array>`): The stream of text content. It can be any object that implements the [Async Iterable protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), such as a [generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_generators).
 - `options?` (`StreamTextOptions`): Options for the `streamText` method
   - `position?` (`InsertPosition`): Where to insert. [See options](#insertposition-type). Default: `'selection'`
   - `reviewOptions?` (`ReviewOptions`): Control preview/review behavior
@@ -140,7 +140,7 @@ Stream HTML content into the editor in real-time.
 
 ### Parameters
 
-- `stream` (`AsyncIterable<string | Uint8Array>`): The stream of text content. It can be any object that implements the [Async Iterable protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), such as a [ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) or a [generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_generators).
+- `stream` (`AsyncIterable<string | Uint8Array> | ReadableStream<string | Uint8Array>`): The stream of HTML content. It can be any object that implements the [Async Iterable protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), such as a [ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) or a [generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_generators).
 - `options?` (`StreamHtmlOptions`): Options for the `streamHtml` method
   - `position?` (`InsertPosition`): Where to insert. [See options](#insertposition-type). Default: `'selection'`
   - `reviewOptions?` (`ReviewOptions`): Control preview/review behavior

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/available-tools.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/available-tools.mdx
@@ -39,9 +39,6 @@ Insert HTML content at a specific position of the document.
   - `'document'`: Replace the entire document with the HTML content
   - `'documentStart'`: Insert the HTML content at the start of the document
   - `'documentEnd'`: Insert the HTML content at the end of the document
-  - `'selection'`: Replace the current selection with the HTML content
-  - `'selectionStart'`: Insert the HTML content before the selection
-  - `'selectionEnd'`: Insert the HTML content after the selection
 
 ## `applyDiff`
 
@@ -72,7 +69,7 @@ If the provided node range is too large, the AI Toolkit reads the first part of 
 
 ## `readSelection`
 
-Get the currently selected content in the editor.
+Get the currently selected content in the editor, and inform the AI model of the position of the selection.
 
 ### Parameters
 
@@ -81,4 +78,4 @@ No parameters required.
 ### Result
 
 - `selection` (`string`): The selected HTML content
-- `nodeRange`: The range of nodes that were read, so that the AI can precisely jump to the place where the selection is located.
+- `activeNodeRange`: The range of nodes where the selection is located


### PR DESCRIPTION
Docs of new AI Toolkit release

### Major Changes

- Improve tool definitions of `readSelection` and `insertContent` tools to fix a bug where the AI inserts the content in the wrong place if the user changes the selection after the AI reads the selection.

### Patch Changes

- Fix issue in `streamHtml` and `streamText` methods where a `ReadableStream` was not accepted as a parameter
