### PR TITLE
chore: Mark all ui components as not new

### DIFF
--- a/.changeset/clear-parents-hear.md
+++ b/.changeset/clear-parents-hear.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Marked all ui components as not new by updating `isNew: true` to `isNew: false` in their metadata.

--- a/package.json
+++ b/package.json
@@ -77,5 +77,5 @@
     "trailingComma": "all",
     "printWidth": 100
   },
-  "packageManager": "pnpm@10.13.1"
+  "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af"
 }

--- a/package.json
+++ b/package.json
@@ -77,5 +77,5 @@
     "trailingComma": "all",
     "printWidth": 100
   },
-  "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af"
+  "packageManager": "pnpm@10.13.1"
 }

--- a/src/content/ui-components/components/ai-ask-button.mdx
+++ b/src/content/ui-components/components/ai-ask-button.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: true
   isOpen: false
-  isNew: true
+  isNew: false
   icon: Sparkles
 tags:
   - type: start

--- a/src/content/ui-components/components/ai-menu.mdx
+++ b/src/content/ui-components/components/ai-menu.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: true
   isOpen: false
-  isNew: true
+  isNew: false
   icon: Sparkles
 tags:
   - type: start

--- a/src/content/ui-components/components/color-text-button.mdx
+++ b/src/content/ui-components/components/color-text-button.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: BaselineIcon
 tags:
   - type: start

--- a/src/content/ui-components/components/color-text-popover.mdx
+++ b/src/content/ui-components/components/color-text-popover.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: BaselineIcon
 tags:
   - type: start

--- a/src/content/ui-components/components/copy-anchor-link-button.mdx
+++ b/src/content/ui-components/components/copy-anchor-link-button.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: LinkIcon
 tags:
   - type: start

--- a/src/content/ui-components/components/copy-to-clipboard-button.mdx
+++ b/src/content/ui-components/components/copy-to-clipboard-button.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: CopyIcon
 tags:
   - type: start

--- a/src/content/ui-components/components/delete-node-button.mdx
+++ b/src/content/ui-components/components/delete-node-button.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: TrashIcon
 tags:
   - type: start

--- a/src/content/ui-components/components/drag-context-menu.mdx
+++ b/src/content/ui-components/components/drag-context-menu.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: GripVertical
 tags:
   - type: start

--- a/src/content/ui-components/components/duplicate-button.mdx
+++ b/src/content/ui-components/components/duplicate-button.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: CopyPlusIcon
 tags:
   - type: start

--- a/src/content/ui-components/components/emoji-dropdown-menu.mdx
+++ b/src/content/ui-components/components/emoji-dropdown-menu.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: SmileIcon
 tags:
   - type: start

--- a/src/content/ui-components/components/emoji-menu.mdx
+++ b/src/content/ui-components/components/emoji-menu.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: Smile
 tags:
   - type: start

--- a/src/content/ui-components/components/emoji-trigger-button.mdx
+++ b/src/content/ui-components/components/emoji-trigger-button.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: SmileIcon
 tags:
   - type: start

--- a/src/content/ui-components/components/image-align-button.mdx
+++ b/src/content/ui-components/components/image-align-button.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: AlignCenterVerticalIcon
 tags:
   - type: start

--- a/src/content/ui-components/components/improve-dropdown.mdx
+++ b/src/content/ui-components/components/improve-dropdown.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: true
   isOpen: false
-  isNew: true
+  isNew: false
   icon: AudioLinesIcon
 tags:
   - type: start

--- a/src/content/ui-components/components/mention-dropdown-menu.mdx
+++ b/src/content/ui-components/components/mention-dropdown-menu.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: AtSignIcon
 tags:
   - type: start

--- a/src/content/ui-components/components/mention-trigger-button.mdx
+++ b/src/content/ui-components/components/mention-trigger-button.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: AtSignIcon
 tags:
   - type: start

--- a/src/content/ui-components/components/move-node-button.mdx
+++ b/src/content/ui-components/components/move-node-button.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: AlignTopIcon
 tags:
   - type: start

--- a/src/content/ui-components/components/reset-all-formatting-button.mdx
+++ b/src/content/ui-components/components/reset-all-formatting-button.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: RotateCcwIcon
 tags:
   - type: start

--- a/src/content/ui-components/components/slash-command-trigger-button.mdx
+++ b/src/content/ui-components/components/slash-command-trigger-button.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: SlashIcon
 tags:
   - type: start

--- a/src/content/ui-components/components/slash-dropdown-menu.mdx
+++ b/src/content/ui-components/components/slash-dropdown-menu.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: SlashIcon
 tags:
   - type: start

--- a/src/content/ui-components/components/text-button.mdx
+++ b/src/content/ui-components/components/text-button.mdx
@@ -11,7 +11,7 @@ component:
   isFree: true
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: TextQuote
 tags:
   - type: start

--- a/src/content/ui-components/components/turn-into-dropdown.mdx
+++ b/src/content/ui-components/components/turn-into-dropdown.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: ArrowUpDown
 tags:
   - type: start

--- a/src/content/ui-components/node-components/blockquote-node.mdx
+++ b/src/content/ui-components/node-components/blockquote-node.mdx
@@ -11,7 +11,7 @@ component:
   isFree: true
   isCloud: false
   isOpen: true
-  isNew: true
+  isNew: false
   icon: QuoteIcon
 ---
 

--- a/src/content/ui-components/node-components/heading-node.mdx
+++ b/src/content/ui-components/node-components/heading-node.mdx
@@ -11,7 +11,7 @@ component:
   isFree: true
   isCloud: false
   isOpen: true
-  isNew: true
+  isNew: false
   icon: HeadingIcon
 ---
 

--- a/src/content/ui-components/node-components/horizontal-rule-node.mdx
+++ b/src/content/ui-components/node-components/horizontal-rule-node.mdx
@@ -11,7 +11,7 @@ component:
   isFree: true
   isCloud: false
   isOpen: true
-  isNew: true
+  isNew: false
   icon: DivideIcon
 ---
 

--- a/src/content/ui-components/node-components/image-node-pro.mdx
+++ b/src/content/ui-components/node-components/image-node-pro.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: ImageIcon
 tags:
   - type: start

--- a/src/content/ui-components/primitives/avatar.mdx
+++ b/src/content/ui-components/primitives/avatar.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: UserIcon
 ---
 

--- a/src/content/ui-components/primitives/badge.mdx
+++ b/src/content/ui-components/primitives/badge.mdx
@@ -11,7 +11,7 @@ component:
   isFree: true
   isCloud: false
   isOpen: true
-  isNew: true
+  isNew: false
   icon: BadgeIcon
 ---
 

--- a/src/content/ui-components/primitives/card.mdx
+++ b/src/content/ui-components/primitives/card.mdx
@@ -11,7 +11,7 @@ component:
   isFree: true
   isCloud: false
   isOpen: true
-  isNew: true
+  isNew: false
   icon: LayoutIcon
 ---
 

--- a/src/content/ui-components/primitives/combobox.mdx
+++ b/src/content/ui-components/primitives/combobox.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: SearchIcon
 ---
 

--- a/src/content/ui-components/primitives/input.mdx
+++ b/src/content/ui-components/primitives/input.mdx
@@ -11,7 +11,7 @@ component:
   isFree: true
   isCloud: false
   isOpen: true
-  isNew: true
+  isNew: false
   icon: TextIcon
 ---
 

--- a/src/content/ui-components/primitives/label.mdx
+++ b/src/content/ui-components/primitives/label.mdx
@@ -11,7 +11,7 @@ component:
   isFree: true
   isCloud: false
   isOpen: true
-  isNew: true
+  isNew: false
   icon: TagIcon
 ---
 

--- a/src/content/ui-components/primitives/menu.mdx
+++ b/src/content/ui-components/primitives/menu.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: MenuIcon
 ---
 

--- a/src/content/ui-components/primitives/textarea-autosize.mdx
+++ b/src/content/ui-components/primitives/textarea-autosize.mdx
@@ -11,7 +11,7 @@ component:
   isFree: true
   isCloud: false
   isOpen: true
-  isNew: true
+  isNew: false
   icon: TextIcon
 ---
 

--- a/src/content/ui-components/utils-components/floating-element.mdx
+++ b/src/content/ui-components/utils-components/floating-element.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: ArrowUpRightIcon
 ---
 

--- a/src/content/ui-components/utils-components/suggestion-menu.mdx
+++ b/src/content/ui-components/utils-components/suggestion-menu.mdx
@@ -11,7 +11,7 @@ component:
   isFree: false
   isCloud: false
   isOpen: false
-  isNew: true
+  isNew: false
   icon: LightBulbIcon
 ---
 


### PR DESCRIPTION
## Summary
This PR updates all ui component metadata by setting `isNew: false` (previously `isNew: true`).

## Motivation
The `isNew` flag is only intended for recently released components. Since these components are no longer considered new, because of the upcoming table components

## Changes
- Updated `isNew: true` → `isNew: false` across all component metadata files.
