### PR TITLE
docs: add documentation for table ui components

### DIFF
--- a/.changeset/whole-dryers-live.md
+++ b/.changeset/whole-dryers-live.md
@@ -1,0 +1,21 @@
+---
+'tiptap-docs': patch
+---
+
+Add documentation for table ui components
+
+- Add docs for
+    - table add row/column button
+    - table align cell button
+    - table cell handle menu
+    - table clear row column content button
+    - table delete row/column button
+    - table duplicate row/column button
+    - table extend row/column button
+    - table fit to width button
+    - table handle menu
+    - table handle
+    - table header row/column button
+    - table move row/column button
+    - table selection overlay
+    - table sort row/column button

--- a/src/content/ui-components/components/table-add-row-column-button.mdx
+++ b/src/content/ui-components/components/table-add-row-column-button.mdx
@@ -1,0 +1,591 @@
+---
+title: Table Add Row/Column Button
+meta:
+  title: Table Add Row/Column Button | Tiptap UI Components
+  description: A button component and hook for adding table rows and columns in Tiptap editors, with flexible positioning options for inserting rows and columns.
+  category: UI Components
+component:
+  name: Table Add Row/Column Button
+  description: A prebuilt button component and hook for adding rows above/below and columns left/right.
+  type: component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: TableIcon
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+A button component and custom hook for adding table rows and columns in Tiptap editors. Supports inserting rows above/below and columns left/right with intelligent validation and selection management.
+
+<CodeDemo
+  isScrollable
+  src="https://template.tiptap.dev/preview/tiptap-ui/table-add-row-column-button"
+/>
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add table-add-row-column-button
+```
+
+## Components
+
+### `<TableAddRowColumnButton />`
+
+A prebuilt button component for triggering row/column addition operations.
+
+#### Usage
+
+```tsx
+import { TableAddRowColumnButton } from '@/registry/tiptap-ui/table-add-row-column-button'
+
+function MyAddButton() {
+  return <TableAddRowColumnButton editor={editor} index={0} orientation="row" side="above" />
+}
+```
+
+### Props
+
+| Name                  | Type                 | Default      | Description                                                                           |
+| --------------------- | -------------------- | ------------ | ------------------------------------------------------------------------------------- |
+| `editor`              | `Editor \| null`     | `undefined`  | The Tiptap editor instance                                                            |
+| `index`               | `number`             | `undefined`  | The index of the row or column to add relative to. If omitted, uses current selection |
+| `orientation`         | `Orientation`        | `undefined`  | Whether adding a "row" or "column". If omitted, uses current selection                |
+| `tablePos`            | `number`             | `undefined`  | The position of the table in the document                                             |
+| `side`                | `RowSide \| ColSide` | **required** | The side to add on: "above"/"below" for rows, "left"/"right" for columns              |
+| `hideWhenUnavailable` | `boolean`            | `false`      | Hide the button when addition isn't currently possible                                |
+| `onAdded`             | `() => void`         | `undefined`  | Callback function called after a successful addition                                  |
+| `text`                | `string`             | `undefined`  | Optional text to display alongside the icon                                           |
+| `...buttonProps`      | `ButtonProps`        | -            | All other props from the base Button component                                        |
+
+## Hook
+
+### `useTableAddRowColumn(config)`
+
+For custom button implementations, use the hook directly:
+
+#### Usage
+
+```tsx
+import { useTableAddRowColumn } from '@/registry/tiptap-ui/table-add-row-column-button'
+
+function CustomAddButton() {
+  const { isVisible, handleAdd, label, canAddRowColumn, Icon } = useTableAddRowColumn({
+    side: 'above',
+    hideWhenUnavailable: true,
+  })
+
+  if (!isVisible) return null
+
+  return (
+    <button onClick={handleAdd} disabled={!canAddRowColumn}>
+      <Icon />
+      {label}
+    </button>
+  )
+}
+```
+
+### Hook Configuration
+
+The `UseTableAddRowColumnConfig` interface supports the following options:
+
+| Name                  | Type                 | Default      | Description                                                                           |
+| --------------------- | -------------------- | ------------ | ------------------------------------------------------------------------------------- |
+| `editor`              | `Editor \| null`     | `undefined`  | The Tiptap editor instance. Uses context if omitted                                   |
+| `index`               | `number`             | `undefined`  | The index of the row or column to add relative to. If omitted, uses current selection |
+| `orientation`         | `Orientation`        | `undefined`  | Whether adding a "row" or "column". If omitted, uses current selection                |
+| `tablePos`            | `number`             | `undefined`  | The position of the table in the document                                             |
+| `side`                | `RowSide \| ColSide` | **required** | The side to add on: "above"/"below" for rows, "left"/"right" for columns              |
+| `hideWhenUnavailable` | `boolean`            | `false`      | Hide when addition isn't currently possible                                           |
+| `onAdded`             | `() => void`         | `undefined`  | Callback function called after a successful addition                                  |
+
+### Hook Return Values
+
+| Name              | Type                  | Description                                                |
+| ----------------- | --------------------- | ---------------------------------------------------------- |
+| `isVisible`       | `boolean`             | Whether the button should be shown                         |
+| `handleAdd`       | `() => void`          | Function to execute the addition operation                 |
+| `label`           | `string`              | Accessible label for the button (e.g., "Insert row above") |
+| `canAddRowColumn` | `boolean`             | Whether addition is currently possible                     |
+| `Icon`            | `React.ComponentType` | The appropriate icon component for the addition side       |
+
+## Usage Examples
+
+### Standalone Button
+
+```tsx
+'use client'
+
+import { EditorContent, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { TableAddRowColumnButton } from '@/registry/tiptap-ui/table-add-row-column-button'
+
+export const StandaloneExample = () => {
+  const editor = useEditor({
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Name</strong></p></th>
+            <th><p><strong>Age</strong></p></th>
+            <th><p><strong>City</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Alice</p></td>
+            <td><p>30</p></td>
+            <td><p>New York</p></td>
+          </tr>
+          <tr>
+            <td><p>Bob</p></td>
+            <td><p>25</p></td>
+            <td><p>London</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <div style={{ marginTop: 10 }}>
+        <TableAddRowColumnButton
+          editor={editor}
+          index={1}
+          orientation="row"
+          side="above"
+          text="Insert Row Above"
+        />
+        <TableAddRowColumnButton
+          editor={editor}
+          index={1}
+          orientation="row"
+          side="below"
+          text="Insert Row Below"
+        />
+        <TableAddRowColumnButton
+          editor={editor}
+          index={1}
+          orientation="column"
+          side="left"
+          text="Insert Column Left"
+        />
+        <TableAddRowColumnButton
+          editor={editor}
+          index={1}
+          orientation="column"
+          side="right"
+          text="Insert Column Right"
+        />
+      </div>
+    </div>
+  )
+}
+```
+
+### With Table Handle Integration
+
+```tsx
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { useTableAddRowColumn } from '@/registry/tiptap-ui/table-add-row-column-button'
+import { TableHandle } from '@/registry/tiptap-ui/table-handle'
+import type { TableHandleButtonProps } from '@/registry/tiptap-ui/table-handle'
+import { Button } from '@/registry/tiptap-ui-primitive/button'
+import {
+  Menu,
+  MenuButton,
+  MenuContent,
+  MenuGroup,
+  MenuItem,
+} from '@/registry/tiptap-ui-primitive/menu'
+import { Combobox, ComboboxList } from '@/registry/tiptap-ui-primitive/combobox'
+import { MoreVerticalIcon } from '@/registry/tiptap-icons/more-vertical-icon'
+import type { Orientation } from '@/registry/lib/tiptap-table-utils'
+
+const MENU_PLACEMENT_MAP: Record<Orientation, React.ComponentProps<typeof Menu>['placement']> = {
+  row: 'top-start',
+  column: 'bottom-start',
+}
+
+export const TableHandleIntegrationExample = () => {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <h2>Table Add Row/Column Demo</h2>
+      <p>Hover over the table to see handle buttons. Click the menu to access addition options.</p>
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Country</strong></p></th>
+            <th><p><strong>Capital</strong></p></th>
+            <th><p><strong>Language</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Spain</p></td>
+            <td><p>Madrid</p></td>
+            <td><p>Spanish</p></td>
+          </tr>
+          <tr>
+            <td><p>Germany</p></td>
+            <td><p>Berlin</p></td>
+            <td><p>German</p></td>
+          </tr>
+          <tr>
+            <td><p>Indonesia</p></td>
+            <td><p>Jakarta</p></td>
+            <td><p>Indonesian</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <EditorContent editor={editor} className="control-showcase" />
+      <TableHandle editor={editor} rowButton={AddMenu} columnButton={AddMenu} />
+    </EditorContext.Provider>
+  )
+}
+
+function AddMenu(props: TableHandleButtonProps) {
+  const { editor, index, tablePos, orientation, onToggleOtherHandle } = props
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  const addAbove = useTableAddRowColumn({
+    index,
+    tablePos,
+    orientation: 'row',
+    side: 'above',
+    hideWhenUnavailable: true,
+  })
+
+  const addBelow = useTableAddRowColumn({
+    index,
+    tablePos,
+    orientation: 'row',
+    side: 'below',
+    hideWhenUnavailable: true,
+  })
+
+  const addLeft = useTableAddRowColumn({
+    index,
+    tablePos,
+    orientation: 'column',
+    side: 'left',
+    hideWhenUnavailable: true,
+  })
+
+  const addRight = useTableAddRowColumn({
+    index,
+    tablePos,
+    orientation: 'column',
+    side: 'right',
+    hideWhenUnavailable: true,
+  })
+
+  const addActions = useMemo(
+    () => ({
+      addAbove,
+      addBelow,
+      addLeft,
+      addRight,
+    }),
+    [addAbove, addBelow, addLeft, addRight],
+  )
+
+  const getAddItems = useCallback(() => {
+    const items: Array<{
+      icon: React.ComponentType<any>
+      label: string
+      disabled: boolean
+      onClick: () => void
+    }> = []
+
+    if (orientation === 'row') {
+      if (addActions.addAbove.isVisible) {
+        items.push({
+          icon: addActions.addAbove.Icon,
+          label: addActions.addAbove.label,
+          disabled: !addActions.addAbove.canAddRowColumn,
+          onClick: addActions.addAbove.handleAdd,
+        })
+      }
+      if (addActions.addBelow.isVisible) {
+        items.push({
+          icon: addActions.addBelow.Icon,
+          label: addActions.addBelow.label,
+          disabled: !addActions.addBelow.canAddRowColumn,
+          onClick: addActions.addBelow.handleAdd,
+        })
+      }
+    } else {
+      if (addActions.addLeft.isVisible) {
+        items.push({
+          icon: addActions.addLeft.Icon,
+          label: addActions.addLeft.label,
+          disabled: !addActions.addLeft.canAddRowColumn,
+          onClick: addActions.addLeft.handleAdd,
+        })
+      }
+      if (addActions.addRight.isVisible) {
+        items.push({
+          icon: addActions.addRight.Icon,
+          label: addActions.addRight.label,
+          disabled: !addActions.addRight.canAddRowColumn,
+          onClick: addActions.addRight.handleAdd,
+        })
+      }
+    }
+
+    return items
+  }, [orientation, addActions])
+
+  const menuPlacement = useMemo(() => MENU_PLACEMENT_MAP[orientation], [orientation])
+
+  const handleMenuToggle = useCallback(
+    (isOpen: boolean) => {
+      setIsMenuOpen(isOpen)
+
+      if (isOpen) {
+        editor.commands.freezeHandles()
+        onToggleOtherHandle?.(false)
+      } else {
+        editor.commands.unfreezeHandles()
+        onToggleOtherHandle?.(true)
+      }
+    },
+    [editor, onToggleOtherHandle],
+  )
+
+  return (
+    <Menu
+      open={isMenuOpen}
+      onOpenChange={handleMenuToggle}
+      placement={menuPlacement}
+      trigger={
+        <MenuButton
+          className={`tiptap-table-handle-menu ${isMenuOpen ? 'menu-opened' : ''} ${orientation}`}
+        >
+          <MoreVerticalIcon className="tiptap-button-icon" />
+        </MenuButton>
+      }
+    >
+      <MenuContent autoFocusOnShow modal>
+        <Combobox style={{ position: 'absolute', left: '-9999px' }} />
+        <ComboboxList>
+          <MenuGroup>
+            {getAddItems().map((item) => (
+              <MenuItem
+                key={item.label}
+                onClick={item.onClick}
+                disabled={item.disabled}
+                render={
+                  <Button data-style="ghost" data-active-state="off">
+                    <item.icon className="tiptap-button-icon" />
+                    <span>{item.label}</span>
+                  </Button>
+                }
+              />
+            ))}
+          </MenuGroup>
+        </ComboboxList>
+      </MenuContent>
+    </Menu>
+  )
+}
+```
+
+### Using Hook Directly
+
+```tsx
+'use client'
+
+import { useEditor } from '@tiptap/react'
+import { useTableAddRowColumn } from '@/registry/tiptap-ui/table-add-row-column-button'
+
+export const HookExample = () => {
+  const editor = useEditor({
+    // ... editor config
+  })
+
+  const addAbove = useTableAddRowColumn({
+    editor,
+    orientation: 'row',
+    side: 'above',
+    hideWhenUnavailable: true,
+    onAdded: () => console.log('Row added above!'),
+  })
+
+  const addBelow = useTableAddRowColumn({
+    editor,
+    orientation: 'row',
+    side: 'below',
+    hideWhenUnavailable: true,
+  })
+
+  const addLeft = useTableAddRowColumn({
+    editor,
+    orientation: 'column',
+    side: 'left',
+    hideWhenUnavailable: true,
+  })
+
+  const addRight = useTableAddRowColumn({
+    editor,
+    orientation: 'column',
+    side: 'right',
+    hideWhenUnavailable: true,
+  })
+
+  return (
+    <div>
+      {addAbove.isVisible && (
+        <button
+          onClick={addAbove.handleAdd}
+          disabled={!addAbove.canAddRowColumn}
+          aria-label={addAbove.label}
+        >
+          <addAbove.Icon />
+          {addAbove.label}
+        </button>
+      )}
+      {addBelow.isVisible && (
+        <button
+          onClick={addBelow.handleAdd}
+          disabled={!addBelow.canAddRowColumn}
+          aria-label={addBelow.label}
+        >
+          <addBelow.Icon />
+          {addBelow.label}
+        </button>
+      )}
+      {addLeft.isVisible && (
+        <button
+          onClick={addLeft.handleAdd}
+          disabled={!addLeft.canAddRowColumn}
+          aria-label={addLeft.label}
+        >
+          <addLeft.Icon />
+          {addLeft.label}
+        </button>
+      )}
+      {addRight.isVisible && (
+        <button
+          onClick={addRight.handleAdd}
+          disabled={!addRight.canAddRowColumn}
+          aria-label={addRight.label}
+        >
+          <addRight.Icon />
+          {addRight.label}
+        </button>
+      )}
+    </div>
+  )
+}
+```
+
+## Behavior
+
+### Side and Orientation Validation
+
+The component validates that sides are compatible with orientations:
+
+- **Rows** can be added **above** or **below**
+- **Columns** can be added **left** or **right**
+
+### Add Operation
+
+The add operation:
+
+1. **Validates the operation** - Checks if the addition is valid in the current state
+2. **Determines the target position** - Based on the side parameter:
+   - `above`: Inserts a new row above the current index (new row takes the same index)
+   - `below`: Inserts a new row below the current index (new row is at index + 1)
+   - `left`: Inserts a new column to the left (new column takes the same index)
+   - `right`: Inserts a new column to the right (new column is at index + 1)
+3. **Executes the addition** - Uses ProseMirror's `addRowBefore`, `addRowAfter`, `addColumnBefore`, or `addColumnAfter` command
+4. **Updates selection** - Selects the newly added row/column after the operation
+
+### Selection Handling
+
+The component handles two types of selections:
+
+1. **CellSelection** - When multiple cells are selected, adds relative to the selected range
+2. **Regular selection** - When cursor is in a single cell, adds relative to that row/column
+
+For regular selections, the component:
+
+- Creates a temporary cell selection for the target row/column
+- Executes the add operation
+- Updates selection to the newly added position
+
+### New Index Calculation
+
+After a successful addition, the component calculates the new index:
+
+- **Above/Left**: New index equals the original index (original content shifts)
+- **Below/Right**: New index equals original index + 1
+
+This ensures the selection correctly follows the newly added content.
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` - Core Tiptap React integration
+- `@tiptap/pm/tables` - ProseMirror table utilities (CellSelection, addRowBefore, addRowAfter, addColumnBefore, addColumnAfter)
+- `@tiptap/pm/state` - ProseMirror state management (Transaction)
+- `react` - React framework
+
+### Required Extensions
+
+- `table` - Table node extension (TableKit)
+
+### Required Components (for full example)
+
+- `Button` (UI primitive) - Base button component
+- `Menu`, `MenuButton`, `MenuContent`, `MenuItem` (UI primitives) - Menu components
+- `TableHandle` - For hover-based table manipulation
+
+### Referenced Utilities
+
+- `useTiptapEditor` (hook) - Custom hook for editor instance management
+- `tiptap-table-utils` (lib) - Utility functions:
+  - `getTable` - Get table node information
+  - `getTableSelectionType` - Determine selection type
+  - `selectCellsByCoords` - Select cells by coordinates
+  - `updateSelectionAfterAction` - Update selection after table operations
+
+### Icons
+
+- `AddRowTopIcon` - Icon for adding row above
+- `AddRowBottomIcon` - Icon for adding row below
+- `AddColLeftIcon` - Icon for adding column left
+- `AddColRightIcon` - Icon for adding column right
+
+## Related Components
+
+- **Table Handle** - For hover-based row/column manipulation
+- **Table Move Row/Column Button** - For moving rows and columns
+- **Table Delete Row/Column Button** - For deleting rows and columns
+- **Table Duplicate Row/Column Button** - For duplicating rows and columns
+- **Table Node (TableKit)** - The core table node extension
+- **Table Handle Extension** - Extension for context detection

--- a/src/content/ui-components/components/table-add-row-column-button.mdx
+++ b/src/content/ui-components/components/table-add-row-column-button.mdx
@@ -583,9 +583,9 @@ This ensures the selection correctly follows the newly added content.
 
 ## Related Components
 
-- **Table Handle** - For hover-based row/column manipulation
-- **Table Move Row/Column Button** - For moving rows and columns
-- **Table Delete Row/Column Button** - For deleting rows and columns
-- **Table Duplicate Row/Column Button** - For duplicating rows and columns
-- **Table Node (TableKit)** - The core table node extension
+- **[Table Handle](/ui-components/components/table-handle)** - For hover-based row/column manipulation
+- **[Table Move Row/Column Button](/ui-components/components/table-move-row-column-button)** - For moving rows and columns
+- **[Table Delete Row/Column Button](/ui-components/components/table-delete-row-column-button)** - For deleting rows and columns
+- **[Table Duplicate Row/Column Button](/ui-components/components/table-duplicate-row-column-button)** - For duplicating rows and columns
+- **[Table Node (TableKit)](/ui-components/node-components/table-node)** - The core table node extension
 - **Table Handle Extension** - Extension for context detection

--- a/src/content/ui-components/components/table-align-cell-button.mdx
+++ b/src/content/ui-components/components/table-align-cell-button.mdx
@@ -1,0 +1,430 @@
+---
+title: Table Align Cell Button
+meta:
+  title: Table Align Cell Button | Tiptap UI Components
+  description: A button component and hook for aligning table cells in Tiptap editors, supporting both text and vertical alignment options.
+  category: UI Components
+component:
+  name: Table Align Cell Button
+  description: A prebuilt button component and hook for aligning table cells with text and vertical alignment options.
+  type: component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: TableIcon
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+A button component and custom hook for aligning table cells in Tiptap editors. Supports both text alignment (left, center, right, justify) and vertical alignment (top, middle, bottom) for individual cells or entire rows/columns.
+
+<CodeDemo
+  isScrollable
+  src="https://template.tiptap.dev/preview/tiptap-ui/table-align-cell-button"
+/>
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add table-align-cell-button
+```
+
+## Components
+
+### `<TableAlignCellButton />`
+
+A prebuilt button component for triggering cell alignment operations.
+
+#### Usage
+
+```tsx
+import { TableAlignCellButton } from '@/registry/tiptap-ui/table-align-cell-button'
+
+function MyAlignButton() {
+  return <TableAlignCellButton editor={editor} alignmentType="text" alignment="center" />
+}
+```
+
+### Props
+
+| Name                  | Type                                 | Default      | Description                                                                       |
+| --------------------- | ------------------------------------ | ------------ | --------------------------------------------------------------------------------- |
+| `editor`              | `Editor \| null`                     | `undefined`  | The Tiptap editor instance                                                        |
+| `alignmentType`       | `AlignmentType`                      | **required** | The type of alignment: "text" or "vertical"                                       |
+| `alignment`           | `TextAlignment \| VerticalAlignment` | **required** | The alignment value: "left"/"center"/"right"/"justify" or "top"/"middle"/"bottom" |
+| `index`               | `number`                             | `undefined`  | The index of the row or column to align. If omitted, aligns current selection     |
+| `orientation`         | `Orientation`                        | `undefined`  | Whether aligning a "row" or "column". Required when index is provided             |
+| `hideWhenUnavailable` | `boolean`                            | `false`      | Hide the button when alignment isn't currently possible                           |
+| `onAligned`           | `(alignment) => void`                | `undefined`  | Callback function called after successful alignment                               |
+| `text`                | `string`                             | `undefined`  | Optional text to display alongside the icon                                       |
+| `...buttonProps`      | `ButtonProps`                        | -            | All other props from the base Button component                                    |
+
+## Hook
+
+### `useTableAlignCell(config)`
+
+For custom button implementations, use the hook directly:
+
+#### Usage
+
+```tsx
+import { useTableAlignCell } from '@/registry/tiptap-ui/table-align-cell-button'
+
+function CustomAlignButton() {
+  const { isVisible, handleAlign, label, canAlignCell, Icon, isActive } = useTableAlignCell({
+    alignmentType: 'text',
+    alignment: 'center',
+    hideWhenUnavailable: true,
+  })
+
+  if (!isVisible) return null
+
+  return (
+    <button onClick={handleAlign} disabled={!canAlignCell} aria-pressed={isActive}>
+      <Icon />
+      {label}
+    </button>
+  )
+}
+```
+
+### Hook Configuration
+
+The `UseTableAlignCellConfig` interface supports the following options:
+
+| Name                  | Type                                 | Default      | Description                                                           |
+| --------------------- | ------------------------------------ | ------------ | --------------------------------------------------------------------- |
+| `editor`              | `Editor \| null`                     | `undefined`  | The Tiptap editor instance. Uses context if omitted                   |
+| `alignmentType`       | `AlignmentType`                      | **required** | The type of alignment: "text" or "vertical"                           |
+| `alignment`           | `TextAlignment \| VerticalAlignment` | **required** | The alignment value to set                                            |
+| `index`               | `number`                             | `undefined`  | Optional index of the row or column to align                          |
+| `orientation`         | `Orientation`                        | `undefined`  | Whether aligning a "row" or "column". Required when index is provided |
+| `hideWhenUnavailable` | `boolean`                            | `false`      | Hide when alignment isn't currently possible                          |
+| `onAligned`           | `(alignment) => void`                | `undefined`  | Callback function called after successful alignment                   |
+
+### Hook Return Values
+
+| Name               | Type                   | Description                                            |
+| ------------------ | ---------------------- | ------------------------------------------------------ |
+| `isVisible`        | `boolean`              | Whether the button should be shown                     |
+| `handleAlign`      | `() => void`           | Function to execute the alignment operation            |
+| `label`            | `string`               | Accessible label for the button (e.g., "Align center") |
+| `canAlignCell`     | `() => boolean`        | Function that returns whether alignment is possible    |
+| `Icon`             | `React.ComponentType`  | The appropriate icon component for the alignment type  |
+| `isActive`         | `boolean`              | Whether this alignment is currently active             |
+| `currentAlignment` | `() => string \| null` | Function that returns the current alignment value      |
+
+## Usage Examples
+
+### Standalone Button
+
+```tsx
+'use client'
+
+import { EditorContent, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableAlignCellButton } from '@/registry/tiptap-ui/table-align-cell-button'
+
+export const StandaloneExample = () => {
+  const editor = useEditor({
+    extensions: [StarterKit, TableKit],
+    content: `
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Name</strong></p></th>
+            <th><p><strong>Age</strong></p></th>
+            <th><p><strong>City</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Alice</p></td>
+            <td><p>30</p></td>
+            <td><p>New York</p></td>
+          </tr>
+          <tr>
+            <td><p>Bob</p></td>
+            <td><p>25</p></td>
+            <td><p>London</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <div style={{ marginTop: 10 }}>
+        <h4>Text Alignment</h4>
+        <TableAlignCellButton editor={editor} alignmentType="text" alignment="left" text="Left" />
+        <TableAlignCellButton
+          editor={editor}
+          alignmentType="text"
+          alignment="center"
+          text="Center"
+        />
+        <TableAlignCellButton editor={editor} alignmentType="text" alignment="right" text="Right" />
+        <TableAlignCellButton
+          editor={editor}
+          alignmentType="text"
+          alignment="justify"
+          text="Justify"
+        />
+
+        <h4>Vertical Alignment</h4>
+        <TableAlignCellButton editor={editor} alignmentType="vertical" alignment="top" text="Top" />
+        <TableAlignCellButton
+          editor={editor}
+          alignmentType="vertical"
+          alignment="middle"
+          text="Middle"
+        />
+        <TableAlignCellButton
+          editor={editor}
+          alignmentType="vertical"
+          alignment="bottom"
+          text="Bottom"
+        />
+      </div>
+    </div>
+  )
+}
+```
+
+### Align Entire Row or Column
+
+```tsx
+'use client'
+
+import { EditorContent, useEditor } from '@tiptap/react'
+import { TableAlignCellButton } from '@/registry/tiptap-ui/table-align-cell-button'
+
+export const RowColumnAlignExample = () => {
+  const editor = useEditor({
+    // ... editor config
+  })
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <div>
+        {/* Align all cells in row 0 to center */}
+        <TableAlignCellButton
+          editor={editor}
+          alignmentType="text"
+          alignment="center"
+          index={0}
+          orientation="row"
+          text="Center Row 0"
+        />
+
+        {/* Align all cells in column 1 to middle (vertically) */}
+        <TableAlignCellButton
+          editor={editor}
+          alignmentType="vertical"
+          alignment="middle"
+          index={1}
+          orientation="column"
+          text="Middle Column 1"
+        />
+      </div>
+    </div>
+  )
+}
+```
+
+### Complete Alignment Menu
+
+```tsx
+'use client'
+
+import { useCallback } from 'react'
+import { useTableAlignCell } from '@/registry/tiptap-ui/table-align-cell-button'
+import type { TextAlignment, VerticalAlignment } from '@/registry/tiptap-ui/table-align-cell-button'
+
+function AlignmentMenu() {
+  const textAlignments: TextAlignment[] = ['left', 'center', 'right', 'justify']
+  const verticalAlignments: VerticalAlignment[] = ['top', 'middle', 'bottom']
+
+  return (
+    <div>
+      <div>
+        <h4>Text Alignment</h4>
+        <div role="toolbar" aria-label="Text alignment">
+          {textAlignments.map((alignment) => {
+            const { isVisible, handleAlign, canAlignCell, isActive, Icon, label } =
+              useTableAlignCell({
+                alignmentType: 'text',
+                alignment,
+                hideWhenUnavailable: true,
+                onAligned: (newAlignment) => console.log(`Text aligned to: ${newAlignment}`),
+              })
+
+            if (!isVisible) return null
+
+            return (
+              <button
+                key={alignment}
+                onClick={handleAlign}
+                disabled={!canAlignCell()}
+                aria-pressed={isActive}
+                aria-label={label}
+              >
+                <Icon />
+                {label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div>
+        <h4>Vertical Alignment</h4>
+        <div role="toolbar" aria-label="Vertical alignment">
+          {verticalAlignments.map((alignment) => {
+            const { isVisible, handleAlign, canAlignCell, isActive, Icon, label } =
+              useTableAlignCell({
+                alignmentType: 'vertical',
+                alignment,
+                hideWhenUnavailable: true,
+              })
+
+            if (!isVisible) return null
+
+            return (
+              <button
+                key={alignment}
+                onClick={handleAlign}
+                disabled={!canAlignCell()}
+                aria-pressed={isActive}
+                aria-label={label}
+              >
+                <Icon />
+                {label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+## Behavior
+
+### Alignment Types
+
+The component supports two types of alignment:
+
+#### Text Alignment
+
+- **left**: Aligns text to the left (default)
+- **center**: Centers text horizontally
+- **right**: Aligns text to the right
+- **justify**: Justifies text (distributes evenly)
+
+#### Vertical Alignment
+
+- **top**: Aligns content to the top of the cell (default)
+- **middle**: Centers content vertically
+- **bottom**: Aligns content to the bottom of the cell
+
+### Alignment Operation
+
+The align operation works differently based on scope:
+
+#### Single Cell/Selection Alignment
+
+When no `index` or `orientation` is provided:
+
+1. **Validates the operation** - Checks if cursor is in a table cell or header
+2. **Sets cell attribute** - Uses `setCellAttribute` command:
+   - For text: Sets `nodeTextAlign` attribute
+   - For vertical: Sets `nodeVerticalAlign` attribute
+3. **Applies to selection** - Works on currently selected cell(s)
+
+#### Row/Column Alignment
+
+When `index` and `orientation` are provided:
+
+1. **Retrieves cells** - Gets all cells in the specified row or column
+2. **Handles merged cells** - Tracks unique cells to avoid processing the same merged cell multiple times
+3. **Creates transaction** - Builds a transaction to update all cells
+4. **Processes in reverse** - Updates cells from end to beginning to maintain correct positions
+5. **Updates attributes** - Replaces each cell node with updated alignment attributes
+6. **Dispatches changes** - Applies all changes in a single transaction
+
+### Active State
+
+The component tracks whether the current alignment is active:
+
+- Checks the `nodeTextAlign` or `nodeVerticalAlign` attribute of the active cell
+- Returns `true` if the cell's alignment matches the button's alignment
+- For row/column alignment, checks the first cell's alignment
+- Defaults to "left" for text and "top" for vertical if no alignment is set
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` - Core Tiptap React integration
+- `react` - React framework
+
+### Required Extensions
+
+- `table` - Table node extension (TableKit) with cell attribute support
+
+### Required Components (for full example)
+
+- `Button` (UI primitive) - Base button component
+
+### Referenced Utilities
+
+- `useTiptapEditor` (hook) - Custom hook for editor instance management
+- `tiptap-table-utils` (lib) - Utility functions:
+  - `getTable` - Get table node information
+  - `getRowOrColumnCells` - Retrieve all cells in a row or column
+
+### Icons
+
+- **Text Alignment**:
+  - `AlignLeftIcon` - Left alignment icon
+  - `AlignCenterIcon` - Center alignment icon
+  - `AlignRightIcon` - Right alignment icon
+  - `AlignJustifyIcon` - Justify alignment icon
+- **Vertical Alignment**:
+  - `AlignTopIcon` - Top alignment icon
+  - `AlignMiddleIcon` - Middle alignment icon
+  - `AlignBottomIcon` - Bottom alignment icon
+
+## Cell Attributes
+
+The component modifies the following cell attributes:
+
+### Text Alignment
+
+- **Attribute**: `nodeTextAlign`
+- **Values**: `"left"` | `"center"` | `"right"` | `"justify"`
+- **Default**: `"left"`
+
+### Vertical Alignment
+
+- **Attribute**: `nodeVerticalAlign`
+- **Values**: `"top"` | `"middle"` | `"bottom"`
+- **Default**: `"top"`
+
+These attributes are stored directly on `tableCell` and `tableHeader` nodes and control the CSS styling of the cell content.
+
+## Related Components
+
+- **Table Handle** - For hover-based cell manipulation
+- **Table Cell Background Color** - For styling cell backgrounds
+- **Table Node (TableKit)** - The core table node extension with cell attribute support
+- **Table Handle Extension** - Extension for context detection

--- a/src/content/ui-components/components/table-align-cell-button.mdx
+++ b/src/content/ui-components/components/table-align-cell-button.mdx
@@ -424,7 +424,7 @@ These attributes are stored directly on `tableCell` and `tableHeader` nodes and 
 
 ## Related Components
 
-- **Table Handle** - For hover-based cell manipulation
+- **[Table Handle](/ui-components/components/table-handle)** - For hover-based cell manipulation
 - **Table Cell Background Color** - For styling cell backgrounds
-- **Table Node (TableKit)** - The core table node extension with cell attribute support
+- **[Table Node (TableKit)](/ui-components/node-components/table-node)** - The core table node extension with cell attribute support
 - **Table Handle Extension** - Extension for context detection

--- a/src/content/ui-components/components/table-cell-handle-menu.mdx
+++ b/src/content/ui-components/components/table-cell-handle-menu.mdx
@@ -1,0 +1,332 @@
+---
+title: Table Cell Handle Menu
+meta:
+  title: Table Cell Handle Menu | Tiptap UI Components
+  description: A contextual menu component for table cells in Tiptap editors, providing quick access to cell operations like merge, split, align, color, and clear.
+  category: UI Components
+component:
+  name: Table Cell Handle Menu
+  description: A prebuilt contextual menu for table cell operations with expandable button trigger.
+  type: component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: TableIcon
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+A contextual menu component for table cell operations in Tiptap editors. Provides quick access to common cell actions including merge/split, alignment, background color, and content clearing through an expandable button interface.
+
+<CodeDemo isScrollable src="https://template.tiptap.dev/preview/tiptap-ui/table-cell-handle-menu" />
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add table-cell-handle-menu
+```
+
+## Components
+
+### `<TableCellHandleMenu />`
+
+A prebuilt contextual menu component that appears within table cells, providing access to cell-specific operations.
+
+#### Usage
+
+```tsx
+import { TableCellHandleMenu } from '@/registry/tiptap-ui/table-cell-handle-menu'
+
+function MyTableEditor() {
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <TableCellHandleMenu editor={editor} />
+    </div>
+  )
+}
+```
+
+### Props
+
+| Name           | Type                        | Default     | Description                                           |
+| -------------- | --------------------------- | ----------- | ----------------------------------------------------- |
+| `editor`       | `Editor \| null`            | `undefined` | The Tiptap editor instance. Uses context if omitted   |
+| `onOpenChange` | `(isOpen: boolean) => void` | `undefined` | Callback function called when menu open state changes |
+
+## Sub-Components
+
+### `<TableActionMenu />`
+
+The internal menu content component that can be used independently or customized.
+
+```tsx
+import { TableActionMenu } from '@/registry/tiptap-ui/table-cell-handle-menu'
+
+function CustomMenu() {
+  return (
+    <Menu>
+      <TableActionMenu onClose={() => console.log('Menu closed')} />
+    </Menu>
+  )
+}
+```
+
+## Usage Examples
+
+### Basic Implementation
+
+```tsx
+'use client'
+
+import { EditorContent, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableCellHandleMenu } from '@/registry/tiptap-ui/table-cell-handle-menu'
+
+export const BasicExample = () => {
+  const editor = useEditor({
+    extensions: [StarterKit, TableKit],
+    content: `
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Name</strong></p></th>
+            <th><p><strong>Role</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Alice</p></td>
+            <td><p>Developer</p></td>
+          </tr>
+          <tr>
+            <td><p>Bob</p></td>
+            <td><p>Designer</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <TableCellHandleMenu editor={editor} />
+    </div>
+  )
+}
+```
+
+### With State Tracking
+
+```tsx
+'use client'
+
+import { useState } from 'react'
+import { EditorContent, useEditor } from '@tiptap/react'
+import { TableCellHandleMenu } from '@/registry/tiptap-ui/table-cell-handle-menu'
+
+export const StateTrackingExample = () => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  const editor = useEditor({
+    // ... editor config
+  })
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <TableCellHandleMenu
+        editor={editor}
+        onOpenChange={(isOpen) => {
+          setIsMenuOpen(isOpen)
+          console.log('Menu is now:', isOpen ? 'open' : 'closed')
+        }}
+      />
+      {isMenuOpen && <div>Menu is currently open</div>}
+    </div>
+  )
+}
+```
+
+### Complete Table Editor Setup
+
+```tsx
+'use client'
+
+import { EditorContent, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { TableCellHandleMenu } from '@/registry/tiptap-ui/table-cell-handle-menu'
+import { TableHandle } from '@/registry/tiptap-ui/table-handle'
+import { TableSelectionOverlay } from '@/registry/tiptap-ui/table-selection-overlay'
+
+export const CompleteTableEditor = () => {
+  const editor = useEditor({
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <h2>Complete Table Editor</h2>
+      <p>This example includes all table UI components working together.</p>
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Product</strong></p></th>
+            <th><p><strong>Price</strong></p></th>
+            <th><p><strong>Stock</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Widget A</p></td>
+            <td><p>$29.99</p></td>
+            <td><p>150</p></td>
+          </tr>
+          <tr>
+            <td><p>Widget B</p></td>
+            <td><p>$39.99</p></td>
+            <td><p>87</p></td>
+          </tr>
+          <tr>
+            <td><p>Widget C</p></td>
+            <td><p>$49.99</p></td>
+            <td><p>203</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <TableCellHandleMenu editor={editor} />
+      <TableHandle editor={editor} />
+      <TableSelectionOverlay editor={editor} />
+    </div>
+  )
+}
+```
+
+## Behavior
+
+### Menu Trigger
+
+The component renders an expandable button within table cells:
+
+- **Initial State**: Small circular dot indicator
+- **Hover State**: Expands to show grip icon
+- **Active State**: Highlighted with brand color when menu is open
+
+### Menu Positioning
+
+- **Placement**: Bottom-start relative to the trigger button
+- **Position**: Top-right corner of the active table cell
+- **Offset**: `-8px` from the right edge for visual alignment
+
+### Available Actions
+
+The menu dynamically shows available actions based on cell state:
+
+#### Merge/Split Group (conditional)
+
+- **Merge Cells**: Combines selected adjacent cells (shown when multiple cells are selected)
+- **Split Cell**: Divides a merged cell back into separate cells (shown when cell has colspan/rowspan > 1)
+
+#### Color & Alignment Group
+
+- **Color Menu**: Set cell background color
+- **Table Align Menu**: Configure text and vertical alignment
+- **Clear Content**: Remove cell content and optionally reset attributes
+
+### Action Availability
+
+Actions are intelligently shown/hidden based on:
+
+- **Current selection** - Single cell vs. multiple cells
+- **Cell state** - Merged vs. unmerged
+- **Cell content** - Empty vs. filled
+- **Editor state** - Editable vs. read-only
+
+### Handle Freezing
+
+When the menu opens:
+
+1. **Freezes table handles** - Prevents row/column handles from interfering
+2. **Maintains selection** - Keeps current cell selection active
+3. **Unfreezes on close** - Restores normal handle behavior when menu closes
+
+## Menu Content
+
+### Structure
+
+```tsx
+<MenuContent>
+  {/* Conditional Merge/Split Group */}
+  {hasMergeOrSplit && (
+    <MenuGroup>
+      <MenuItem>Merge cells</MenuItem>
+      <MenuItem>Split cell</MenuItem>
+      <Separator />
+    </MenuGroup>
+  )}
+
+  {/* Main Actions Group */}
+  <MenuGroup>
+    <ColorMenu /> {/* Background color picker */}
+    <TableAlignMenu /> {/* Text & vertical alignment */}
+    <MenuItem>Clear cell</MenuItem>
+  </MenuGroup>
+</MenuContent>
+```
+
+### Integrated Components
+
+The menu integrates several sub-components:
+
+1. **ColorMenu**: Color picker for cell background
+2. **TableAlignMenu**: Text and vertical alignment options
+3. **Merge/Split Actions**: Cell structure operations
+4. **Clear Action**: Content and attribute removal
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` - Core Tiptap React integration
+- `react` - React framework
+
+### Required Extensions
+
+- `table` - Table node extension (TableKit)
+
+### Required Components
+
+- `Button` (UI primitive) - Base button component
+- `Menu`, `MenuButton`, `MenuContent`, `MenuItem` (UI primitives) - Menu components
+- `Combobox`, `ComboboxList` (UI primitives) - For menu navigation
+- `Separator` (UI primitive) - Visual separator between groups
+- `ColorMenu` - Background color picker menu
+- `TableAlignMenu` - Alignment options menu
+
+### Referenced Hooks
+
+- `useTiptapEditor` (hook) - Custom hook for editor instance management
+- `useTableMergeSplitCell` - Hook for merge/split cell operations
+- `useTableClearRowColumnContent` - Hook for clearing cell content
+
+### Icons
+
+- `Grip4Icon` - Four-dot grip icon for the menu trigger
+
+## Related Components
+
+- **Table Handle** - For row/column manipulation handles
+- **Table Align Menu** - Integrated alignment submenu
+- **Color Menu** - Integrated color picker submenu
+- **Table Merge/Split Cell Button** - Merge and split operations
+- **Table Clear Row/Column Content Button** - Content clearing operations
+- **Table Node (TableKit)** - The core table node extension
+- **Table Selection Overlay** - Visual selection indicator

--- a/src/content/ui-components/components/table-cell-handle-menu.mdx
+++ b/src/content/ui-components/components/table-cell-handle-menu.mdx
@@ -323,10 +323,10 @@ The menu integrates several sub-components:
 
 ## Related Components
 
-- **Table Handle** - For row/column manipulation handles
+- **[Table Handle](/ui-components/components/table-handle)** - For row/column manipulation handles
 - **Table Align Menu** - Integrated alignment submenu
 - **Color Menu** - Integrated color picker submenu
-- **Table Merge/Split Cell Button** - Merge and split operations
-- **Table Clear Row/Column Content Button** - Content clearing operations
-- **Table Node (TableKit)** - The core table node extension
-- **Table Selection Overlay** - Visual selection indicator
+- **[Table Merge/Split Cell Button](/ui-components/components/table-merge-split-cell-button)** - Merge and split operations
+- **[Table Clear Row/Column Content Button](/ui-components/components/table-clear-row-column-content-button)** - Content clearing operations
+- **[Table Node (TableKit)](/ui-components/node-components/table-node)** - The core table node extension
+- **[Table Selection Overlay](/ui-components/components/table-selection-overlay)** - Visual selection indicator

--- a/src/content/ui-components/components/table-clear-row-column-content-button.mdx
+++ b/src/content/ui-components/components/table-clear-row-column-content-button.mdx
@@ -454,8 +454,8 @@ When `hideWhenUnavailable` is true, the button hides when these conditions aren'
 
 ## Related Components
 
-- **Table Handle** - For row/column manipulation handles
-- **Table Delete Row/Column Button** - For deleting entire rows/columns
-- **Table Merge/Split Cell Button** - For cell structure operations
-- **Table Cell Handle Menu** - Contextual menu that includes clear action
-- **Table Node (TableKit)** - The core table node extension
+- **[Table Handle](/ui-components/components/table-handle)** - For row/column manipulation handles
+- **[Table Delete Row/Column Button](/ui-components/components/table-delete-row-column-button)** - For deleting entire rows/columns
+- **[Table Merge/Split Cell Button](/ui-components/components/table-merge-split-cell-button)** - For cell structure operations
+- **[Table Cell Handle Menu](/ui-components/components/table-cell-handle-menu)** - Contextual menu that includes clear action
+- **[Table Node (TableKit)](/ui-components/node-components/table-node)** - The core table node extension

--- a/src/content/ui-components/components/table-clear-row-column-content-button.mdx
+++ b/src/content/ui-components/components/table-clear-row-column-content-button.mdx
@@ -1,0 +1,461 @@
+---
+title: Table Clear Row/Column Content Button
+meta:
+  title: Table Clear Row/Column Content Button | Tiptap UI Components
+  description: A button component and hook for clearing table row, column, or cell content in Tiptap editors, with optional attribute reset functionality.
+  category: UI Components
+component:
+  name: Table Clear Row/Column Content Button
+  description: A prebuilt button component and hook for clearing content from table rows, columns, or selected cells.
+  type: component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: TableIcon
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+A button component and custom hook for clearing content from table rows, columns, or individual cells in Tiptap editors. Supports optional attribute reset to restore default cell styling when clearing content.
+
+<CodeDemo
+  isScrollable
+  src="https://template.tiptap.dev/preview/tiptap-ui/table-clear-row-column-content-button"
+/>
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add table-clear-row-column-content-button
+```
+
+## Components
+
+### `<TableClearRowColumnContentButton />`
+
+A prebuilt button component for triggering content clearing operations.
+
+#### Usage
+
+```tsx
+import { TableClearRowColumnContentButton } from '@/registry/tiptap-ui/table-clear-row-column-content-button'
+
+function MyClearButton() {
+  return <TableClearRowColumnContentButton editor={editor} index={0} orientation="row" />
+}
+```
+
+### Props
+
+| Name                  | Type             | Default     | Description                                                                   |
+| --------------------- | ---------------- | ----------- | ----------------------------------------------------------------------------- |
+| `editor`              | `Editor \| null` | `undefined` | The Tiptap editor instance                                                    |
+| `index`               | `number`         | `undefined` | The index of the row or column to clear. If omitted, clears current selection |
+| `orientation`         | `Orientation`    | `undefined` | Whether clearing a "row" or "column". If omitted, clears current selection    |
+| `tablePos`            | `number`         | `undefined` | The position of the table in the document                                     |
+| `hideWhenUnavailable` | `boolean`        | `false`     | Hide the button when clearing isn't currently possible                        |
+| `resetAttrs`          | `boolean`        | `false`     | Whether to reset cell attributes when clearing content                        |
+| `onCleared`           | `() => void`     | `undefined` | Callback function called after a successful clear                             |
+| `text`                | `string`         | `undefined` | Optional text to display alongside the icon                                   |
+| `...buttonProps`      | `ButtonProps`    | -           | All other props from the base Button component                                |
+
+## Hook
+
+### `useTableClearRowColumnContent(config)`
+
+For custom button implementations, use the hook directly:
+
+#### Usage
+
+```tsx
+import { useTableClearRowColumnContent } from '@/registry/tiptap-ui/table-clear-row-column-content-button'
+
+function CustomClearButton() {
+  const { isVisible, handleClear, label, canClearRowColumnContent, Icon } =
+    useTableClearRowColumnContent({
+      resetAttrs: true,
+      hideWhenUnavailable: true,
+    })
+
+  if (!isVisible) return null
+
+  return (
+    <button onClick={handleClear} disabled={!canClearRowColumnContent}>
+      <Icon />
+      {label}
+    </button>
+  )
+}
+```
+
+### Hook Configuration
+
+The `UseTableClearRowColumnContentConfig` interface supports the following options:
+
+| Name                  | Type             | Default     | Description                                                                   |
+| --------------------- | ---------------- | ----------- | ----------------------------------------------------------------------------- |
+| `editor`              | `Editor \| null` | `undefined` | The Tiptap editor instance. Uses context if omitted                           |
+| `index`               | `number`         | `undefined` | The index of the row or column to clear. If omitted, clears current selection |
+| `orientation`         | `Orientation`    | `undefined` | Whether clearing a "row" or "column". If omitted, clears current selection    |
+| `tablePos`            | `number`         | `undefined` | The position of the table in the document                                     |
+| `hideWhenUnavailable` | `boolean`        | `false`     | Hide when clearing isn't currently possible                                   |
+| `resetAttrs`          | `boolean`        | `false`     | Whether to reset cell attributes when clearing                                |
+| `onCleared`           | `() => void`     | `undefined` | Callback function called after successful clear                               |
+
+### Hook Return Values
+
+| Name                       | Type                  | Description                                                  |
+| -------------------------- | --------------------- | ------------------------------------------------------------ |
+| `isVisible`                | `boolean`             | Whether the button should be shown                           |
+| `handleClear`              | `() => void`          | Function to execute the clear operation                      |
+| `label`                    | `string`              | Accessible label for the button (e.g., "Clear row contents") |
+| `canClearRowColumnContent` | `boolean`             | Whether clearing is currently possible                       |
+| `Icon`                     | `React.ComponentType` | The icon component (SquareXIcon)                             |
+
+## Usage Examples
+
+### Standalone Button
+
+```tsx
+'use client'
+
+import { EditorContent, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableClearRowColumnContentButton } from '@/registry/tiptap-ui/table-clear-row-column-content-button'
+
+export const StandaloneExample = () => {
+  const editor = useEditor({
+    extensions: [StarterKit, TableKit],
+    content: `
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Name</strong></p></th>
+            <th><p><strong>Email</strong></p></th>
+            <th><p><strong>Role</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Alice</p></td>
+            <td><p>alice@example.com</p></td>
+            <td><p>Developer</p></td>
+          </tr>
+          <tr>
+            <td><p>Bob</p></td>
+            <td><p>bob@example.com</p></td>
+            <td><p>Designer</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <div style={{ marginTop: 10 }}>
+        <TableClearRowColumnContentButton
+          editor={editor}
+          index={1}
+          orientation="row"
+          text="Clear Row 1"
+        />
+        <TableClearRowColumnContentButton
+          editor={editor}
+          index={1}
+          orientation="column"
+          resetAttrs={true}
+          text="Clear Column 1 & Reset Styles"
+        />
+      </div>
+    </div>
+  )
+}
+```
+
+### With Table Handle Integration
+
+```tsx
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { useTableClearRowColumnContent } from '@/registry/tiptap-ui/table-clear-row-column-content-button'
+import { TableHandle } from '@/registry/tiptap-ui/table-handle'
+import type { TableHandleButtonProps } from '@/registry/tiptap-ui/table-handle'
+import { Button } from '@/registry/tiptap-ui-primitive/button'
+import {
+  Menu,
+  MenuButton,
+  MenuContent,
+  MenuGroup,
+  MenuItem,
+} from '@/registry/tiptap-ui-primitive/menu'
+import { Combobox, ComboboxList } from '@/registry/tiptap-ui-primitive/combobox'
+import { MoreVerticalIcon } from '@/registry/tiptap-icons/more-vertical-icon'
+import type { Orientation } from '@/registry/lib/tiptap-table-utils'
+
+const MENU_PLACEMENT_MAP: Record<Orientation, React.ComponentProps<typeof Menu>['placement']> = {
+  row: 'top-start',
+  column: 'bottom-start',
+}
+
+export const TableHandleIntegrationExample = () => {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <h2>Table Clear Content Demo</h2>
+      <p>Hover over the table to see handle buttons. Click the menu to clear row or column content.</p>
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Product</strong></p></th>
+            <th><p><strong>Price</strong></p></th>
+            <th><p><strong>Stock</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Widget A</p></td>
+            <td><p>$29.99</p></td>
+            <td><p>150</p></td>
+          </tr>
+          <tr>
+            <td><p>Widget B</p></td>
+            <td><p>$39.99</p></td>
+            <td><p>87</p></td>
+          </tr>
+          <tr>
+            <td><p>Widget C</p></td>
+            <td><p>$49.99</p></td>
+            <td><p>203</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <EditorContent editor={editor} className="control-showcase" />
+      <TableHandle editor={editor} rowButton={ClearMenu} columnButton={ClearMenu} />
+    </EditorContext.Provider>
+  )
+}
+
+function ClearMenu(props: TableHandleButtonProps) {
+  const { editor, index, tablePos, orientation, onToggleOtherHandle } = props
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  const clearContentAction = useTableClearRowColumnContent({
+    index,
+    orientation,
+    tablePos,
+    resetAttrs: true,
+    hideWhenUnavailable: true,
+  })
+
+  const menuPlacement = useMemo(() => MENU_PLACEMENT_MAP[orientation], [orientation])
+
+  const handleMenuToggle = useCallback(
+    (isOpen: boolean) => {
+      setIsMenuOpen(isOpen)
+
+      if (isOpen) {
+        editor.commands.freezeHandles()
+        onToggleOtherHandle?.(false)
+      } else {
+        editor.commands.unfreezeHandles()
+        onToggleOtherHandle?.(true)
+      }
+    },
+    [editor, onToggleOtherHandle],
+  )
+
+  return (
+    <Menu
+      open={isMenuOpen}
+      onOpenChange={handleMenuToggle}
+      placement={menuPlacement}
+      trigger={
+        <MenuButton
+          className={`tiptap-table-handle-menu ${isMenuOpen ? 'menu-opened' : ''} ${orientation}`}
+        >
+          <MoreVerticalIcon className="tiptap-button-icon" />
+        </MenuButton>
+      }
+    >
+      <MenuContent autoFocusOnShow modal>
+        <Combobox style={{ position: 'absolute', left: '-9999px' }} />
+        <ComboboxList>
+          <MenuGroup>
+            <MenuItem
+              render={
+                <Button data-style="ghost" data-active-state="off">
+                  <clearContentAction.Icon className="tiptap-button-icon" />
+                  <span className="tiptap-button-text">{clearContentAction.label}</span>
+                </Button>
+              }
+              onClick={clearContentAction.handleClear}
+              disabled={!clearContentAction.canClearRowColumnContent}
+            />
+          </MenuGroup>
+        </ComboboxList>
+      </MenuContent>
+    </Menu>
+  )
+}
+```
+
+### With Attribute Reset
+
+```tsx
+'use client'
+
+import { useState } from 'react'
+import { useTableClearRowColumnContent } from '@/registry/tiptap-ui/table-clear-row-column-content-button'
+
+export const AttributeResetExample = () => {
+  const [resetAttrs, setResetAttrs] = useState(false)
+
+  const { handleClear, label, Icon } = useTableClearRowColumnContent({
+    index: 0,
+    orientation: 'row',
+    resetAttrs,
+    onCleared: () => {
+      console.log(`Row cleared with resetAttrs: ${resetAttrs}`)
+    },
+  })
+
+  return (
+    <div>
+      <label>
+        <input
+          type="checkbox"
+          checked={resetAttrs}
+          onChange={(e) => setResetAttrs(e.target.checked)}
+        />
+        Reset cell attributes (background color, alignment)
+      </label>
+      <button onClick={handleClear}>
+        <Icon />
+        {label}
+      </button>
+    </div>
+  )
+}
+```
+
+## Behavior
+
+### Clear Operation Modes
+
+The component operates in three modes based on parameters:
+
+#### 1. Clear Specific Row/Column
+
+When `index` and `orientation` are provided:
+
+- Clears all cells in the specified row or column
+- Processes cells in reverse order to maintain correct positions
+- Optionally resets cell attributes to defaults
+
+#### 2. Clear Selected Cells
+
+When no `index` or `orientation` is provided:
+
+- Clears content from currently selected cell(s)
+- Works with both single cell and multi-cell selections (CellSelection)
+- Respects the current selection state
+
+#### 3. Smart Clear
+
+The hook automatically determines the appropriate mode:
+
+- Uses `index` and `orientation` if provided
+- Falls back to current selection otherwise
+- Intelligently adapts to the editing context
+
+### Attribute Reset
+
+When `resetAttrs` is set to `true`, the following attributes are reset to defaults:
+
+```typescript
+{
+  backgroundColor: null,      // Removes background color
+  nodeVerticalAlign: null,    // Resets to default vertical alignment
+  nodeTextAlign: null,        // Resets to default text alignment
+}
+```
+
+This is useful for:
+
+- Removing custom styling when clearing content
+- Resetting cells to their default appearance
+- Bulk style cleanup operations
+
+### Empty Cell Detection
+
+The component intelligently detects whether cells have content:
+
+- **Non-empty cells**: Have text content or child nodes
+- **Empty cells**: Contain only empty paragraph nodes or no content
+- Only non-empty cells are processed during clear operations
+
+### Availability Check
+
+The button determines availability based on:
+
+- **Editor state** - Editor must be editable
+- **Required extensions** - Table extension must be available
+- **Cell content** - At least one cell must have content to clear
+- **Selection validity** - Cursor must be in a table cell or valid selection exists
+
+When `hideWhenUnavailable` is true, the button hides when these conditions aren't met.
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` - Core Tiptap React integration
+- `@tiptap/pm/tables` - ProseMirror table utilities (CellSelection, deleteCellSelection, cellAround)
+- `react` - React framework
+
+### Required Extensions
+
+- `table` - Table node extension (TableKit)
+
+### Required Components (for full example)
+
+- `Button` (UI primitive) - Base button component
+- `Menu`, `MenuButton`, `MenuContent`, `MenuItem` (UI primitives) - Menu components
+- `TableHandle` - For hover-based table manipulation
+
+### Referenced Utilities
+
+- `useTiptapEditor` (hook) - Custom hook for editor instance management
+- `tiptap-table-utils` (lib) - Utility functions:
+  - `getTable` - Get table node information
+  - `getTableSelectionType` - Determine selection type
+  - `getRowOrColumnCells` - Retrieve cells in a row or column
+  - `setCellAttr` - Set cell attributes
+  - `isCellEmpty` - Check if a cell has content
+
+### Icons
+
+- `SquareXIcon` - X mark in square icon for the clear action
+
+## Related Components
+
+- **Table Handle** - For row/column manipulation handles
+- **Table Delete Row/Column Button** - For deleting entire rows/columns
+- **Table Merge/Split Cell Button** - For cell structure operations
+- **Table Cell Handle Menu** - Contextual menu that includes clear action
+- **Table Node (TableKit)** - The core table node extension

--- a/src/content/ui-components/components/table-delete-row-column-button.mdx
+++ b/src/content/ui-components/components/table-delete-row-column-button.mdx
@@ -425,11 +425,11 @@ For regular selections, the component:
 
 ## Related Components
 
-- **Table Handle** - For hover-based row/column manipulation
-- **Table Move Row/Column Button** - For moving rows and columns
-- **Table Duplicate Row/Column Button** - For duplicating rows and columns
-- **Table Add Row/Column Button** - For adding new rows and columns
-- **Table Clear Row/Column Content Button** - For clearing content without deletion
-- **Table Sort Row/Column Button** - For sorting rows and columns
-- **Table Node (TableKit)** - The core table node extension
+- **[Table Handle](/ui-components/components/table-handle)** - For hover-based row/column manipulation
+- **[Table Move Row/Column Button](/ui-components/components/table-move-row-column-button)** - For moving rows and columns
+- **[Table Duplicate Row/Column Button](/ui-components/components/table-duplicate-row-column-button)** - For duplicating rows and columns
+- **[Table Add Row/Column Button](/ui-components/components/table-add-row-column-button)** - For adding new rows and columns
+- **[Table Clear Row/Column Content Button](/ui-components/components/table-clear-row-column-content-button)** - For clearing content without deletion
+- **[Table Sort Row/Column Button](/ui-components/components/table-sort-row-column-button)** - For sorting rows and columns
+- **[Table Node (TableKit)](/ui-components/node-components/table-node)** - The core table node extension
 - **Table Handle Extension** - Required extension for context detection

--- a/src/content/ui-components/components/table-delete-row-column-button.mdx
+++ b/src/content/ui-components/components/table-delete-row-column-button.mdx
@@ -1,0 +1,435 @@
+---
+title: Table Delete Row/Column Button
+meta:
+  title: Table Delete Row/Column Button | Tiptap UI Components
+  description: A button component and hook for deleting table rows and columns in Tiptap editors, with intelligent validation to prevent structural issues.
+  category: UI Components
+component:
+  name: Table Delete Row/Column Button
+  description: A prebuilt button component and hook for deleting table rows and columns.
+  type: component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: TableIcon
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+A button component and custom hook for deleting table rows and columns in Tiptap editors. Supports row and column deletion with intelligent validation to ensure table structure integrity.
+
+<CodeDemo
+  isScrollable
+  src="https://template.tiptap.dev/preview/tiptap-ui/table-delete-row-column-button"
+/>
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add table-delete-row-column-button
+```
+
+## Components
+
+### `<TableDeleteRowColumnButton />`
+
+A prebuilt button component for triggering row/column deletion operations.
+
+#### Usage
+
+```tsx
+import { TableDeleteRowColumnButton } from '@/registry/tiptap-ui/table-delete-row-column-button'
+
+function MyDeleteButton() {
+  return <TableDeleteRowColumnButton editor={editor} index={0} orientation="row" />
+}
+```
+
+### Props
+
+| Name                  | Type             | Default     | Description                                                                  |
+| --------------------- | ---------------- | ----------- | ---------------------------------------------------------------------------- |
+| `editor`              | `Editor \| null` | `undefined` | The Tiptap editor instance                                                   |
+| `index`               | `number`         | `undefined` | The index of the row or column to delete. If omitted, uses current selection |
+| `orientation`         | `Orientation`    | `undefined` | Whether deleting a "row" or "column". Uses context if omitted                |
+| `tablePos`            | `number`         | `undefined` | The position of the table in the document                                    |
+| `hideWhenUnavailable` | `boolean`        | `false`     | Hide the button when deletion isn't currently possible                       |
+| `onDeleted`           | `() => void`     | `undefined` | Callback function called after a successful deletion                         |
+| `text`                | `string`         | `undefined` | Optional text to display alongside the icon                                  |
+| `...buttonProps`      | `ButtonProps`    | -           | All other props from the base Button component                               |
+
+## Hook
+
+### `useTableDeleteRowColumn(config)`
+
+For custom button implementations, use the hook directly:
+
+#### Usage
+
+```tsx
+import { useTableDeleteRowColumn } from '@/registry/tiptap-ui/table-delete-row-column-button'
+
+function CustomDeleteButton() {
+  const { isVisible, handleDelete, label, canDeleteRowColumn, Icon } = useTableDeleteRowColumn({
+    orientation: 'row',
+    hideWhenUnavailable: true,
+  })
+
+  if (!isVisible) return null
+
+  return (
+    <button onClick={handleDelete} disabled={!canDeleteRowColumn}>
+      <Icon />
+      {label}
+    </button>
+  )
+}
+```
+
+### Hook Configuration
+
+The `UseTableDeleteRowColumnConfig` interface supports the following options:
+
+| Name                  | Type             | Default     | Description                                                                  |
+| --------------------- | ---------------- | ----------- | ---------------------------------------------------------------------------- |
+| `editor`              | `Editor \| null` | `undefined` | The Tiptap editor instance. Uses context if omitted                          |
+| `index`               | `number`         | `undefined` | The index of the row or column to delete. If omitted, uses current selection |
+| `orientation`         | `Orientation`    | `undefined` | Whether deleting a "row" or "column". If omitted, uses current selection     |
+| `tablePos`            | `number`         | `undefined` | The position of the table in the document                                    |
+| `hideWhenUnavailable` | `boolean`        | `false`     | Hide when deletion isn't currently possible                                  |
+| `onDeleted`           | `() => void`     | `undefined` | Callback function called after a successful deletion                         |
+
+### Hook Return Values
+
+| Name                 | Type                  | Description                                          |
+| -------------------- | --------------------- | ---------------------------------------------------- |
+| `isVisible`          | `boolean`             | Whether the button should be shown                   |
+| `handleDelete`       | `() => void`          | Function to execute the deletion operation           |
+| `label`              | `string`              | Accessible label for the button (e.g., "Delete row") |
+| `canDeleteRowColumn` | `boolean`             | Whether deletion is currently possible               |
+| `Icon`               | `React.ComponentType` | The trash icon component for the delete action       |
+
+## Usage Examples
+
+### Standalone Button
+
+```tsx
+'use client'
+
+import { EditorContent, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { TableDeleteRowColumnButton } from '@/registry/tiptap-ui/table-delete-row-column-button'
+
+export const StandaloneExample = () => {
+  const editor = useEditor({
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Name</strong></p></th>
+            <th><p><strong>Age</strong></p></th>
+            <th><p><strong>City</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Alice</p></td>
+            <td><p>30</p></td>
+            <td><p>New York</p></td>
+          </tr>
+          <tr>
+            <td><p>Bob</p></td>
+            <td><p>25</p></td>
+            <td><p>London</p></td>
+          </tr>
+          <tr>
+            <td><p>Carol</p></td>
+            <td><p>35</p></td>
+            <td><p>Tokyo</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <div style={{ marginTop: 10 }}>
+        <TableDeleteRowColumnButton
+          editor={editor}
+          index={1}
+          orientation="row"
+          text="Delete Row 1"
+        />
+        <TableDeleteRowColumnButton
+          editor={editor}
+          index={1}
+          orientation="column"
+          text="Delete Column 1"
+        />
+      </div>
+    </div>
+  )
+}
+```
+
+### With Table Handle Integration
+
+```tsx
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { useTableDeleteRowColumn } from '@/registry/tiptap-ui/table-delete-row-column-button'
+import { TableHandle } from '@/registry/tiptap-ui/table-handle'
+import type { TableHandleButtonProps } from '@/registry/tiptap-ui/table-handle'
+import { Button } from '@/registry/tiptap-ui-primitive/button'
+import {
+  Menu,
+  MenuButton,
+  MenuContent,
+  MenuGroup,
+  MenuItem,
+} from '@/registry/tiptap-ui-primitive/menu'
+import { Combobox, ComboboxList } from '@/registry/tiptap-ui-primitive/combobox'
+import { MoreVerticalIcon } from '@/registry/tiptap-icons/more-vertical-icon'
+import type { Orientation } from '@/registry/lib/tiptap-table-utils'
+import { cn, SR_ONLY } from '@/registry/lib/tiptap-utils'
+
+const MENU_PLACEMENT_MAP: Record<Orientation, React.ComponentProps<typeof Menu>['placement']> = {
+  row: 'top-start',
+  column: 'bottom-start',
+}
+
+export const TableHandleIntegrationExample = () => {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <h2>Table Delete Row/Column Demo</h2>
+      <p>
+        Hover over the table to see handle buttons. Click the menu to delete rows and columns. 
+        Note that deletion cannot be undone.
+      </p>
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Country</strong></p></th>
+            <th><p><strong>Capital</strong></p></th>
+            <th><p><strong>Language</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Spain</p></td>
+            <td><p>Madrid</p></td>
+            <td><p>Spanish</p></td>
+          </tr>
+          <tr>
+            <td><p>Germany</p></td>
+            <td><p>Berlin</p></td>
+            <td><p>German</p></td>
+          </tr>
+          <tr>
+            <td><p>Indonesia</p></td>
+            <td><p>Jakarta</p></td>
+            <td><p>Indonesian</p></td>
+          </tr>
+          <tr>
+            <td><p>Netherlands</p></td>
+            <td><p>Amsterdam</p></td>
+            <td><p>Dutch</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <EditorContent editor={editor} className="control-showcase" />
+      <TableHandle editor={editor} rowButton={DeleteMenu} columnButton={DeleteMenu} />
+    </EditorContext.Provider>
+  )
+}
+
+function DeleteMenu(props: TableHandleButtonProps) {
+  const { editor, index, tablePos, orientation, onToggleOtherHandle } = props
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  const deleteAction = useTableDeleteRowColumn({
+    index,
+    tablePos,
+    orientation,
+    hideWhenUnavailable: false,
+    onDeleted: () => console.log('Deleted!'),
+  })
+
+  const menuPlacement = useMemo(() => MENU_PLACEMENT_MAP[orientation], [orientation])
+
+  const handleMenuToggle = useCallback(
+    (isOpen: boolean) => {
+      setIsMenuOpen(isOpen)
+
+      if (isOpen) {
+        editor.commands.freezeHandles()
+        onToggleOtherHandle?.(false)
+      } else {
+        editor.commands.unfreezeHandles()
+        onToggleOtherHandle?.(true)
+      }
+    },
+    [editor, onToggleOtherHandle],
+  )
+
+  return (
+    <Menu
+      open={isMenuOpen}
+      onOpenChange={handleMenuToggle}
+      placement={menuPlacement}
+      trigger={
+        <MenuButton
+          className={cn('tiptap-table-handle-menu', isMenuOpen && 'menu-opened', orientation)}
+        >
+          <MoreVerticalIcon className="tiptap-button-icon" />
+        </MenuButton>
+      }
+    >
+      <MenuContent autoFocusOnShow modal>
+        <Combobox style={SR_ONLY} />
+        <ComboboxList>
+          <MenuGroup>
+            <MenuItem
+              render={<Button data-style="ghost" data-active-state="off" />}
+              onClick={deleteAction.handleDelete}
+              disabled={!deleteAction.canDeleteRowColumn}
+            >
+              <deleteAction.Icon className="tiptap-button-icon" />
+              <span className="tiptap-button-text">{deleteAction.label}</span>
+            </MenuItem>
+          </MenuGroup>
+        </ComboboxList>
+      </MenuContent>
+    </Menu>
+  )
+}
+```
+
+### Using Hook with Custom Button
+
+```tsx
+'use client'
+
+import { useTableDeleteRowColumn } from '@/registry/tiptap-ui/table-delete-row-column-button'
+
+function CustomDeleteControls() {
+  const deleteRow = useTableDeleteRowColumn({
+    orientation: 'row',
+    hideWhenUnavailable: true,
+    onDeleted: () => console.log('Row deleted!'),
+  })
+
+  const deleteColumn = useTableDeleteRowColumn({
+    orientation: 'column',
+    hideWhenUnavailable: true,
+  })
+
+  return (
+    <div>
+      {deleteRow.isVisible && (
+        <button
+          onClick={deleteRow.handleDelete}
+          disabled={!deleteRow.canDeleteRowColumn}
+          aria-label={deleteRow.label}
+        >
+          <deleteRow.Icon />
+          {deleteRow.label}
+        </button>
+      )}
+      {deleteColumn.isVisible && (
+        <button
+          onClick={deleteColumn.handleDelete}
+          disabled={!deleteColumn.canDeleteRowColumn}
+          aria-label={deleteColumn.label}
+        >
+          <deleteColumn.Icon />
+          {deleteColumn.label}
+        </button>
+      )}
+    </div>
+  )
+}
+```
+
+## Behavior
+
+### Delete Operation
+
+The delete operation:
+
+1. **Validates the deletion** - Checks if the table has the target row/column and the table structure allows deletion
+2. **Determines target** - Uses the current selection or specified index to identify what to delete
+3. **Executes the deletion** - Uses ProseMirror's `deleteRow` or `deleteColumn` command
+4. **Maintains selection** - Updates selection to remain within the table after deletion
+
+### Selection Handling
+
+The component handles two types of selections:
+
+1. **CellSelection** - When multiple cells are selected, deletes the selected rows/columns
+2. **Regular selection** - When cursor is in a single cell, deletes that row/column
+
+For regular selections, the component:
+
+- Creates a temporary cell selection for the source row/column
+- Executes the delete operation
+- Updates the selection to remain in the table
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` - Core Tiptap React integration
+- `@tiptap/pm/tables` - ProseMirror table utilities (CellSelection, deleteRow, deleteColumn)
+- `@tiptap/pm/state` - ProseMirror state management (Transaction)
+- `react` - React framework
+
+### Required Extensions
+
+- `tableHandle` - Table handle extension for detecting row/column context
+- `table` - Table node extension (TableKit)
+
+### Required Components (for full example)
+
+- `Button` (UI primitive) - Base button component
+- `Menu`, `MenuButton`, `MenuContent`, `MenuItem` (UI primitives) - Menu components
+- `TableHandle` - For hover-based table manipulation
+
+### Referenced Utilities
+
+- `useTiptapEditor` (hook) - Custom hook for editor instance management
+- `tiptap-table-utils` (lib) - Utility functions:
+  - `getTable` - Get table node information
+  - `getTableSelectionType` - Determine selection type
+  - `selectCellsByCoords` - Select cells by coordinates
+- `tiptap-utils` (lib) - Utility functions:
+  - `isExtensionAvailable` - Check if an extension is available
+
+## Related Components
+
+- **Table Handle** - For hover-based row/column manipulation
+- **Table Move Row/Column Button** - For moving rows and columns
+- **Table Duplicate Row/Column Button** - For duplicating rows and columns
+- **Table Add Row/Column Button** - For adding new rows and columns
+- **Table Clear Row/Column Content Button** - For clearing content without deletion
+- **Table Sort Row/Column Button** - For sorting rows and columns
+- **Table Node (TableKit)** - The core table node extension
+- **Table Handle Extension** - Required extension for context detection

--- a/src/content/ui-components/components/table-duplicate-row-column-button.mdx
+++ b/src/content/ui-components/components/table-duplicate-row-column-button.mdx
@@ -1,0 +1,449 @@
+---
+title: Table Duplicate Row/Column Button
+meta:
+  title: Table Duplicate Row/Column Button | Tiptap UI Components
+  description: A button component and hook for duplicating table rows and columns in Tiptap editors, with intelligent validation and merged cell handling.
+  category: UI Components
+component:
+  name: Table Duplicate Row/Column Button
+  description: A prebuilt button component and hook for duplicating table rows and columns with all content preserved.
+  type: component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: TableIcon
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+A button component and custom hook for duplicating table rows and columns in Tiptap editors. Supports creating exact copies of rows and columns with all content, formatting, and attributes preserved, while intelligently preventing operations on tables with merged cells.
+
+<CodeDemo
+  isScrollable
+  src="https://template.tiptap.dev/preview/tiptap-ui/table-duplicate-row-column-button"
+/>
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add table-duplicate-row-column-button
+```
+
+## Components
+
+### `<TableDuplicateRowColumnButton />`
+
+A prebuilt button component for triggering row/column duplication operations.
+
+#### Usage
+
+```tsx
+import { TableDuplicateRowColumnButton } from '@/registry/tiptap-ui/table-duplicate-row-column-button'
+
+function MyDuplicateButton() {
+  return <TableDuplicateRowColumnButton editor={editor} index={0} orientation="row" />
+}
+```
+
+### Props
+
+| Name                  | Type             | Default     | Description                                                                     |
+| --------------------- | ---------------- | ----------- | ------------------------------------------------------------------------------- |
+| `editor`              | `Editor \| null` | `undefined` | The Tiptap editor instance                                                      |
+| `index`               | `number`         | `undefined` | The index of the row or column to duplicate. If omitted, uses current selection |
+| `orientation`         | `Orientation`    | `undefined` | Whether duplicating a "row" or "column". Uses context if omitted                |
+| `tablePos`            | `number`         | `undefined` | The position of the table in the document                                       |
+| `hideWhenUnavailable` | `boolean`        | `false`     | Hide the button when duplication isn't currently possible                       |
+| `onDuplicated`        | `() => void`     | `undefined` | Callback function called after a successful duplication                         |
+| `text`                | `string`         | `undefined` | Optional text to display alongside the icon                                     |
+| `...buttonProps`      | `ButtonProps`    | -           | All other props from the base Button component                                  |
+
+## Hook
+
+### `useTableDuplicateRowColumn(config)`
+
+For custom button implementations, use the hook directly:
+
+#### Usage
+
+```tsx
+import { useTableDuplicateRowColumn } from '@/registry/tiptap-ui/table-duplicate-row-column-button'
+
+function CustomDuplicateButton() {
+  const { isVisible, handleDuplicate, label, canDuplicateRowColumn, Icon } =
+    useTableDuplicateRowColumn({
+      orientation: 'row',
+      hideWhenUnavailable: true,
+    })
+
+  if (!isVisible) return null
+
+  return (
+    <button onClick={handleDuplicate} disabled={!canDuplicateRowColumn}>
+      <Icon />
+      {label}
+    </button>
+  )
+}
+```
+
+### Hook Configuration
+
+The `UseTableDuplicateRowColumnConfig` interface supports the following options:
+
+| Name                  | Type             | Default     | Description                                                                     |
+| --------------------- | ---------------- | ----------- | ------------------------------------------------------------------------------- |
+| `editor`              | `Editor \| null` | `undefined` | The Tiptap editor instance. Uses context if omitted                             |
+| `index`               | `number`         | `undefined` | The index of the row or column to duplicate. If omitted, uses current selection |
+| `orientation`         | `Orientation`    | `undefined` | Whether duplicating a "row" or "column". If omitted, uses current selection     |
+| `tablePos`            | `number`         | `undefined` | The position of the table in the document                                       |
+| `hideWhenUnavailable` | `boolean`        | `false`     | Hide when duplication isn't currently possible                                  |
+| `onDuplicated`        | `() => void`     | `undefined` | Callback function called after a successful duplication                         |
+
+### Hook Return Values
+
+| Name                    | Type                  | Description                                             |
+| ----------------------- | --------------------- | ------------------------------------------------------- |
+| `isVisible`             | `boolean`             | Whether the button should be shown                      |
+| `handleDuplicate`       | `() => void`          | Function to execute the duplication operation           |
+| `label`                 | `string`              | Accessible label for the button (e.g., "Duplicate row") |
+| `canDuplicateRowColumn` | `boolean`             | Whether duplication is currently possible               |
+| `Icon`                  | `React.ComponentType` | The copy icon component for the duplicate action        |
+
+## Usage Examples
+
+### Standalone Button
+
+```tsx
+'use client'
+
+import { EditorContent, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { TableDuplicateRowColumnButton } from '@/registry/tiptap-ui/table-duplicate-row-column-button'
+
+export const StandaloneExample = () => {
+  const editor = useEditor({
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Name</strong></p></th>
+            <th><p><strong>Age</strong></p></th>
+            <th><p><strong>City</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Alice</p></td>
+            <td><p>30</p></td>
+            <td><p>New York</p></td>
+          </tr>
+          <tr>
+            <td><p>Bob</p></td>
+            <td><p>25</p></td>
+            <td><p>London</p></td>
+          </tr>
+          <tr>
+            <td><p>Carol</p></td>
+            <td><p>35</p></td>
+            <td><p>Tokyo</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <div style={{ marginTop: 10 }}>
+        <TableDuplicateRowColumnButton
+          editor={editor}
+          index={1}
+          orientation="row"
+          text="Duplicate Row 1"
+        />
+        <TableDuplicateRowColumnButton
+          editor={editor}
+          index={1}
+          orientation="column"
+          text="Duplicate Column 1"
+        />
+      </div>
+    </div>
+  )
+}
+```
+
+### With Table Handle Integration
+
+```tsx
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { useTableDuplicateRowColumn } from '@/registry/tiptap-ui/table-duplicate-row-column-button'
+import { TableHandle } from '@/registry/tiptap-ui/table-handle'
+import type { TableHandleButtonProps } from '@/registry/tiptap-ui/table-handle'
+import { Button } from '@/registry/tiptap-ui-primitive/button'
+import {
+  Menu,
+  MenuButton,
+  MenuContent,
+  MenuGroup,
+  MenuItem,
+} from '@/registry/tiptap-ui-primitive/menu'
+import { Combobox, ComboboxList } from '@/registry/tiptap-ui-primitive/combobox'
+import { MoreVerticalIcon } from '@/registry/tiptap-icons/more-vertical-icon'
+import type { Orientation } from '@/registry/lib/tiptap-table-utils'
+import { cn, SR_ONLY } from '@/registry/lib/tiptap-utils'
+
+const MENU_PLACEMENT_MAP: Record<Orientation, React.ComponentProps<typeof Menu>['placement']> = {
+  row: 'top-start',
+  column: 'bottom-start',
+}
+
+export const TableHandleIntegrationExample = () => {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <h2>Table Duplicate Row/Column Demo</h2>
+      <p>
+        Hover over the table to see handle buttons. Click the menu to duplicate rows and columns. 
+        All content, formatting, and attributes will be preserved in the duplicate.
+      </p>
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Country</strong></p></th>
+            <th><p><strong>Capital</strong></p></th>
+            <th><p><strong>Language</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Spain</p></td>
+            <td><p>Madrid</p></td>
+            <td><p>Spanish</p></td>
+          </tr>
+          <tr>
+            <td><p>Germany</p></td>
+            <td><p>Berlin</p></td>
+            <td><p>German</p></td>
+          </tr>
+          <tr>
+            <td><p>Indonesia</p></td>
+            <td><p>Jakarta</p></td>
+            <td><p>Indonesian</p></td>
+          </tr>
+          <tr>
+            <td><p>Netherlands</p></td>
+            <td><p>Amsterdam</p></td>
+            <td><p>Dutch</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <EditorContent editor={editor} className="control-showcase" />
+      <TableHandle editor={editor} rowButton={DuplicateMenu} columnButton={DuplicateMenu} />
+    </EditorContext.Provider>
+  )
+}
+
+function DuplicateMenu(props: TableHandleButtonProps) {
+  const { editor, index, tablePos, orientation, onToggleOtherHandle } = props
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  const duplicateAction = useTableDuplicateRowColumn({
+    index,
+    tablePos,
+    orientation,
+    hideWhenUnavailable: false,
+    onDuplicated: () => console.log('Duplicated!'),
+  })
+
+  const menuPlacement = useMemo(() => MENU_PLACEMENT_MAP[orientation], [orientation])
+
+  const handleMenuToggle = useCallback(
+    (isOpen: boolean) => {
+      setIsMenuOpen(isOpen)
+
+      if (isOpen) {
+        editor.commands.freezeHandles()
+        onToggleOtherHandle?.(false)
+      } else {
+        editor.commands.unfreezeHandles()
+        onToggleOtherHandle?.(true)
+      }
+    },
+    [editor, onToggleOtherHandle],
+  )
+
+  return (
+    <Menu
+      open={isMenuOpen}
+      onOpenChange={handleMenuToggle}
+      placement={menuPlacement}
+      trigger={
+        <MenuButton
+          className={cn('tiptap-table-handle-menu', isMenuOpen && 'menu-opened', orientation)}
+        >
+          <MoreVerticalIcon className="tiptap-button-icon" />
+        </MenuButton>
+      }
+    >
+      <MenuContent autoFocusOnShow modal>
+        <Combobox style={SR_ONLY} />
+        <ComboboxList>
+          <MenuGroup>
+            <MenuItem
+              render={<Button data-style="ghost" data-active-state="off" />}
+              onClick={duplicateAction.handleDuplicate}
+              disabled={!duplicateAction.canDuplicateRowColumn}
+            >
+              <duplicateAction.Icon className="tiptap-button-icon" />
+              <span className="tiptap-button-text">{duplicateAction.label}</span>
+            </MenuItem>
+          </MenuGroup>
+        </ComboboxList>
+      </MenuContent>
+    </Menu>
+  )
+}
+```
+
+### Using Hook with Custom Button
+
+```tsx
+'use client'
+
+import { useTableDuplicateRowColumn } from '@/registry/tiptap-ui/table-duplicate-row-column-button'
+
+function CustomDuplicateControls() {
+  const duplicateRow = useTableDuplicateRowColumn({
+    orientation: 'row',
+    hideWhenUnavailable: true,
+    onDuplicated: () => console.log('Row duplicated!'),
+  })
+
+  const duplicateColumn = useTableDuplicateRowColumn({
+    orientation: 'column',
+    hideWhenUnavailable: true,
+  })
+
+  return (
+    <div>
+      {duplicateRow.isVisible && (
+        <button
+          onClick={duplicateRow.handleDuplicate}
+          disabled={!duplicateRow.canDuplicateRowColumn}
+          aria-label={duplicateRow.label}
+        >
+          <duplicateRow.Icon />
+          {duplicateRow.label}
+        </button>
+      )}
+      {duplicateColumn.isVisible && (
+        <button
+          onClick={duplicateColumn.handleDuplicate}
+          disabled={!duplicateColumn.canDuplicateRowColumn}
+          aria-label={duplicateColumn.label}
+        >
+          <duplicateColumn.Icon />
+          {duplicateColumn.label}
+        </button>
+      )}
+    </div>
+  )
+}
+```
+
+## Behavior
+
+### Content Preservation
+
+The component performs comprehensive content duplication:
+
+1. **Cell attributes** - All cell attributes (alignment, background color, etc.) are copied
+2. **Cell content** - The entire content tree inside each cell is duplicated
+3. **Cell marks** - Any marks on the cell node are preserved
+4. **Structure** - The cell structure remains identical to the source
+
+### Merged Cell Detection
+
+The component performs validation to prevent duplications that would create invalid table structures:
+
+1. **Checks source cells** - Validates that the row/column being duplicated doesn't contain merged cells (`rowspan > 1` or `colspan > 1`)
+2. **Prevents duplication** - When merged cells are detected, the duplication is automatically disabled
+3. **Uses `getRowOrColumnCells`** - Utility function that identifies all cells and specifically tracks merged cells
+
+When merged cells are detected in the source position, duplication is not possible to maintain table integrity.
+
+### Selection Handling
+
+The component handles two types of selections:
+
+1. **CellSelection** - When multiple cells are selected, duplicates the selected row/column
+2. **Regular selection** - When cursor is in a single cell, duplicates that row/column
+
+For regular selections, the component:
+
+- Creates a temporary cell selection for the source row/column
+- Executes the add operation
+- Replaces content in the new row/column
+- Updates selection to the duplicated position
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` - Core Tiptap React integration
+- `@tiptap/pm/tables` - ProseMirror table utilities (CellSelection, addRowAfter, addColumnAfter)
+- `react` - React framework
+
+### Required Extensions
+
+- `tableHandle` - Table handle extension for detecting row/column context
+- `table` - Table node extension (TableKit)
+
+### Required Components (for full example)
+
+- `Button` (UI primitive) - Base button component
+- `Menu`, `MenuButton`, `MenuContent`, `MenuItem` (UI primitives) - Menu components
+- `TableHandle` - For hover-based table manipulation
+
+### Referenced Utilities
+
+- `useTiptapEditor` (hook) - Custom hook for editor instance management
+- `tiptap-table-utils` (lib) - Utility functions:
+  - `getTable` - Get table node information
+  - `getTableSelectionType` - Determine selection type
+  - `getRowOrColumnCells` - Get cells in a row/column and detect merged cells
+  - `selectCellsByCoords` - Select cells by coordinates
+  - `getIndexCoordinates` - Get cell coordinates for an index
+  - `updateSelectionAfterAction` - Update selection after duplication
+- `tiptap-utils` (lib) - Utility functions:
+  - `isExtensionAvailable` - Check if an extension is available
+
+## Related Components
+
+- **Table Handle** - For hover-based row/column manipulation
+- **Table Move Row/Column Button** - For moving rows and columns
+- **Table Delete Row/Column Button** - For deleting rows and columns
+- **Table Add Row/Column Button** - For adding new rows and columns
+- **Table Sort Row/Column Button** - For sorting rows and columns
+- **Table Clear Row/Column Content Button** - For clearing content without deletion
+- **Table Node (TableKit)** - The core table node extension
+- **Table Handle Extension** - Required extension for context detection

--- a/src/content/ui-components/components/table-duplicate-row-column-button.mdx
+++ b/src/content/ui-components/components/table-duplicate-row-column-button.mdx
@@ -439,11 +439,11 @@ For regular selections, the component:
 
 ## Related Components
 
-- **Table Handle** - For hover-based row/column manipulation
-- **Table Move Row/Column Button** - For moving rows and columns
-- **Table Delete Row/Column Button** - For deleting rows and columns
-- **Table Add Row/Column Button** - For adding new rows and columns
-- **Table Sort Row/Column Button** - For sorting rows and columns
-- **Table Clear Row/Column Content Button** - For clearing content without deletion
-- **Table Node (TableKit)** - The core table node extension
+- **[Table Handle](/ui-components/components/table-handle)** - For hover-based row/column manipulation
+- **[Table Move Row/Column Button](/ui-components/components/table-move-row-column-button)** - For moving rows and columns
+- **[Table Delete Row/Column Button](/ui-components/components/table-delete-row-column-button)** - For deleting rows and columns
+- **[Table Add Row/Column Button](/ui-components/components/table-add-row-column-button)** - For adding new rows and columns
+- **[Table Sort Row/Column Button](/ui-components/components/table-sort-row-column-button)** - For sorting rows and columns
+- **[Table Clear Row/Column Content Button](/ui-components/components/table-clear-row-column-content-button)** - For clearing content without deletion
+- **[Table Node (TableKit)](/ui-components/node-components/table-node)** - The core table node extension
 - **Table Handle Extension** - Required extension for context detection

--- a/src/content/ui-components/components/table-extend-row-column-button.mdx
+++ b/src/content/ui-components/components/table-extend-row-column-button.mdx
@@ -292,10 +292,10 @@ During drag operations:
 
 ## Related Components
 
-- **Table Handle** - For hover-based row/column manipulation
-- **Table Add Row/Column Button** - For adding rows/columns at specific positions
-- **Table Delete Row/Column Button** - For deleting specific rows/columns
-- **Table Move Row/Column Button** - For moving rows and columns
-- **Table Duplicate Row/Column Button** - For duplicating rows and columns
-- **Table Node (TableKit)** - The core table node extension
+- **[Table Handle](/ui-components/components/table-handle)** - For hover-based row/column manipulation
+- **[Table Add Row/Column Button](/ui-components/components/table-add-row-column-button)** - For adding rows/columns at specific positions
+- **[Table Delete Row/Column Button](/ui-components/components/table-delete-row-column-button)** - For deleting specific rows/columns
+- **[Table Move Row/Column Button](/ui-components/components/table-move-row-column-button)** - For moving rows and columns
+- **[Table Duplicate Row/Column Button](/ui-components/components/table-duplicate-row-column-button)** - For duplicating rows and columns
+- **[Table Node (TableKit)](/ui-components/node-components/table-node)** - The core table node extension
 - **Table Handle Extension** - Required extension for table state detection

--- a/src/content/ui-components/components/table-extend-row-column-button.mdx
+++ b/src/content/ui-components/components/table-extend-row-column-button.mdx
@@ -1,0 +1,301 @@
+---
+title: Table Extend Row/Column Button
+meta:
+  title: Table Extend Row/Column Button | Tiptap UI Components
+  description: Interactive buttons for extending and contracting table dimensions by dragging or clicking, with smart empty cell detection.
+  category: UI Components
+component:
+  name: Table Extend Row/Column Button
+  description: Interactive drag handles for adding or removing rows and columns at table edges.
+  type: component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: TableIcon
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+Interactive button components for extending and contracting table dimensions in Tiptap editors. These buttons appear at the bottom and right edges of tables, allowing users to add or remove rows and columns through both clicking and dragging interactions.
+
+<CodeDemo
+  isScrollable
+  src="https://template.tiptap.dev/preview/tiptap-ui/table-extend-row-column-button"
+/>
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add table-extend-row-column-button
+```
+
+## Components
+
+### `<TableExtendRowColumnButtons />`
+
+The main component that renders both row and column extend buttons positioned at the table edges using Floating UI.
+
+#### Usage
+
+```tsx
+import { EditorContext } from '@tiptap/react'
+import { TableExtendRowColumnButtons } from '@/registry/tiptap-ui/table-extend-row-column-button'
+
+function MyEditor() {
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <EditorContent editor={editor} />
+      <TableExtendRowColumnButtons />
+    </EditorContext.Provider>
+  )
+}
+```
+
+### Props
+
+| Name          | Type             | Default     | Description                                         |
+| ------------- | ---------------- | ----------- | --------------------------------------------------- |
+| `editor`      | `Editor \| null` | `undefined` | The Tiptap editor instance. Uses context if omitted |
+| `onMouseDown` | `() => void`     | `undefined` | Callback when drag operation starts                 |
+| `onMouseUp`   | `() => void`     | `undefined` | Callback when drag operation ends                   |
+
+### `<TableExtendRowColumnButton />`
+
+The individual button component for a single orientation (row or column). This is typically used internally by `TableExtendRowColumnButtons` but can be used directly for custom implementations.
+
+#### Props
+
+| Name          | Type             | Default      | Description                                |
+| ------------- | ---------------- | ------------ | ------------------------------------------ |
+| `editor`      | `Editor \| null` | `undefined`  | The Tiptap editor instance                 |
+| `block`       | `Node`           | **required** | The table node                             |
+| `onMouseDown` | `() => void`     | **required** | Callback when drag operation starts        |
+| `onMouseUp`   | `() => void`     | **required** | Callback when drag operation ends          |
+| `orientation` | `Orientation`    | **required** | Whether this is a "row" or "column" button |
+| `children`    | `ReactNode`      | `undefined`  | Custom content (defaults to plus icon)     |
+
+## Usage Examples
+
+### Basic Implementation
+
+```tsx
+'use client'
+
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { TableExtendRowColumnButtons } from '@/registry/tiptap-ui/table-extend-row-column-button'
+
+export const BasicExample = () => {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <h2>Table with Extend Buttons</h2>
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Product</strong></p></th>
+            <th><p><strong>Price</strong></p></th>
+            <th><p><strong>Stock</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Laptop</p></td>
+            <td><p>$999</p></td>
+            <td><p>25</p></td>
+          </tr>
+          <tr>
+            <td><p>Phone</p></td>
+            <td><p>$699</p></td>
+            <td><p>50</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <EditorContent editor={editor} />
+      <TableExtendRowColumnButtons />
+    </EditorContext.Provider>
+  )
+}
+```
+
+### With Callbacks
+
+```tsx
+'use client'
+
+import { useCallback } from 'react'
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { TableExtendRowColumnButtons } from '@/registry/tiptap-ui/table-extend-row-column-button'
+
+export const CallbackExample = () => {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <table>
+        <tbody>
+          <tr>
+            <td><p>Cell 1</p></td>
+            <td><p>Cell 2</p></td>
+          </tr>
+          <tr>
+            <td><p>Cell 3</p></td>
+            <td><p>Cell 4</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  const handleDragStart = useCallback(() => {
+    console.log('Started dragging to extend/contract table')
+  }, [])
+
+  const handleDragEnd = useCallback(() => {
+    console.log('Finished dragging')
+  }, [])
+
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <EditorContent editor={editor} />
+      <TableExtendRowColumnButtons onMouseDown={handleDragStart} onMouseUp={handleDragEnd} />
+    </EditorContext.Provider>
+  )
+}
+```
+
+## Behavior
+
+### Button Positioning
+
+The extend buttons are positioned using Floating UI:
+
+- **Row button** - Appears at the bottom edge of the table, spanning the full width
+- **Column button** - Appears at the right edge of the table, spanning the full height
+- **Visibility** - Buttons only appear when hovering over the table and the editor is editable
+- **Placement** - Automatically adjusts based on available space
+
+The buttons are rendered via `FloatingPortal` to ensure they appear above other content.
+
+### Click Interaction
+
+When a user **clicks** an extend button:
+
+1. **Selects last cell** - Focuses the last cell in the current row/column
+2. **Adds one row/column** - Executes `addRowAfter()` or `addColumnAfter()`
+3. **Preserves cursor** - Maintains cursor position after the operation
+4. **Single action** - Adds exactly one row or column
+
+### Drag Interaction
+
+When a user **drags** an extend button:
+
+1. **Tracks mouse position** - Monitors movement in the drag direction (Y for rows, X for columns)
+2. **Calculates delta** - Determines how many rows/columns to add or remove based on drag distance
+3. **Executes operations** - Adds or removes rows/columns in batch
+
+### Adding Rows/Columns (Drag Outward)
+
+When dragging outward (positive delta):
+
+1. **Selects last cell** - Sets focus to the last cell in the table
+2. **Adds multiple** - Iterates and adds rows/columns one at a time
+3. **Preserves content** - All existing content remains unchanged
+4. **No limit** - Can add as many rows/columns as dragged
+
+### Removing Rows/Columns (Drag Inward)
+
+When dragging inward (negative delta):
+
+1. **Counts empty cells** - Uses `countEmptyRowsFromEnd()` or `countEmptyColumnsFromEnd()`
+2. **Validates removal** - Only removes empty rows/columns from the end
+3. **Safety limit** - Keeps at least 1 row/column (cannot remove the entire table)
+4. **Preserves content** - Non-empty rows/columns cannot be removed
+
+#### Empty Cell Detection
+
+The component uses utility functions to count consecutive empty cells from the end:
+
+- **`countEmptyRowsFromEnd()`** - Scans from the last row upward
+- **`countEmptyColumnsFromEnd()`** - Scans from the last column leftward
+- **Deduplication** - Uses `TableMap` to handle merged cells correctly
+- **Empty definition** - A cell is empty if it has no content or only whitespace
+
+### Cursor Preservation
+
+All operations use `runPreservingCursor()` to maintain the user's cursor position:
+
+```typescript
+runPreservingCursor(editor, () => {
+  selectLastCell(editor, state.block, state.blockPos, orientation)
+  // Perform add/remove operations
+})
+```
+
+This ensures that the cursor returns to its original position after the table modification.
+
+### Handle Freezing
+
+During drag operations:
+
+- **`freezeHandles()`** - Called on `mousedown` to prevent other table handles from interfering
+- **`unfreezeHandles()`** - Called on `mouseup` to restore normal handle behavior
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` - Core Tiptap React integration
+- `@tiptap/pm/model` - ProseMirror model (Node)
+- `@tiptap/pm/tables` - ProseMirror table utilities (TableMap)
+- `@floating-ui/react` - Floating UI for positioning (FloatingPortal, useFloating, useTransitionStyles)
+- `react` - React framework
+
+### Required Extensions
+
+- `tableHandle` - Table handle extension for detecting table state
+- `table` - Table node extension (TableKit)
+
+### Required Components
+
+- No additional UI components required - this is a standalone component
+
+### Required Hooks
+
+- `useTiptapEditor` - Custom hook for editor instance management
+- `useTableHandleState` - Hook for detecting table state and position
+
+### Referenced Utilities
+
+- `tiptap-table-utils` (lib) - Utility functions:
+  - `countEmptyRowsFromEnd` - Count empty rows from table bottom
+  - `countEmptyColumnsFromEnd` - Count empty columns from table right
+  - `selectLastCell` - Select the last cell in a row/column
+  - `runPreservingCursor` - Execute operations while preserving cursor position
+  - `marginRound` - Round with dead zone for smooth drag UX
+  - `EMPTY_CELL_HEIGHT` - Default empty cell height (40px)
+  - `EMPTY_CELL_WIDTH` - Default empty cell width (100px)
+
+## Related Components
+
+- **Table Handle** - For hover-based row/column manipulation
+- **Table Add Row/Column Button** - For adding rows/columns at specific positions
+- **Table Delete Row/Column Button** - For deleting specific rows/columns
+- **Table Move Row/Column Button** - For moving rows and columns
+- **Table Duplicate Row/Column Button** - For duplicating rows and columns
+- **Table Node (TableKit)** - The core table node extension
+- **Table Handle Extension** - Required extension for table state detection

--- a/src/content/ui-components/components/table-fit-to-width-button.mdx
+++ b/src/content/ui-components/components/table-fit-to-width-button.mdx
@@ -330,7 +330,7 @@ The action is **not available** when:
 
 ## Related Components
 
-- **Table Handle** - For hover-based table manipulation
-- **Table Node (TableKit)** - The core table node extension that provides the `width` attribute
+- **[Table Handle](/ui-components/components/table-handle)** - For hover-based table manipulation
+- **[Table Node (TableKit)](/ui-components/node-components/table-node)** - The core table node extension that provides the `width` attribute
 - **Table Handle Extension** - Required extension for table tooling
 - **Table Column Resize** - For manually adjusting column widths (opposite operation)

--- a/src/content/ui-components/components/table-fit-to-width-button.mdx
+++ b/src/content/ui-components/components/table-fit-to-width-button.mdx
@@ -1,0 +1,336 @@
+---
+title: Table Fit to Width Button
+meta:
+  title: Table Fit to Width Button | Tiptap UI Components
+  description: A button component for making tables expand to fit their container width by clearing fixed column widths.
+  category: UI Components
+component:
+  name: Table Fit to Width Button
+  description: A button component for adjusting table width to fit its container.
+  type: component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: TableIcon
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+A button component for making tables expand to fit their container width in Tiptap editors. This component sets the table width to 100% and clears cell-level column width attributes, allowing the table to adapt fluidly to its container.
+
+<CodeDemo
+  isScrollable
+  src="https://template.tiptap.dev/preview/tiptap-ui/table-fit-to-width-button"
+/>
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add table-fit-to-width-button
+```
+
+## Components
+
+### `<TableFitToWidthButton />`
+
+A prebuilt button component for fitting tables to container width.
+
+#### Usage
+
+```tsx
+import { TableFitToWidthButton } from '@/registry/tiptap-ui/table-fit-to-width-button'
+
+function MyFitButton() {
+  return <TableFitToWidthButton editor={editor} />
+}
+```
+
+### Props
+
+| Name                  | Type             | Default     | Description                                                |
+| --------------------- | ---------------- | ----------- | ---------------------------------------------------------- |
+| `editor`              | `Editor \| null` | `undefined` | The Tiptap editor instance. Uses context if omitted        |
+| `hideWhenUnavailable` | `boolean`        | `false`     | Hide the button when the action isn't currently possible   |
+| `onWidthAdjusted`     | `() => void`     | `undefined` | Callback function called after successful width adjustment |
+| `text`                | `string`         | `undefined` | Optional text to display alongside the icon                |
+| `...buttonProps`      | `ButtonProps`    | -           | All other props from the base Button component             |
+
+## Hook
+
+### `useTableFitToWidth(config)`
+
+For custom button implementations, use the hook directly:
+
+#### Usage
+
+```tsx
+import { useTableFitToWidth } from '@/registry/tiptap-ui/table-fit-to-width-button'
+
+function CustomFitButton() {
+  const { isVisible, canFitToWidth, handleFitToWidth, label, Icon } = useTableFitToWidth({
+    hideWhenUnavailable: true,
+  })
+
+  if (!isVisible) return null
+
+  return (
+    <button onClick={handleFitToWidth} disabled={!canFitToWidth}>
+      <Icon />
+      {label}
+    </button>
+  )
+}
+```
+
+### Hook Configuration
+
+The `UseTableFitToWidthConfig` interface supports the following options:
+
+| Name                  | Type             | Default     | Description                                                |
+| --------------------- | ---------------- | ----------- | ---------------------------------------------------------- |
+| `editor`              | `Editor \| null` | `undefined` | The Tiptap editor instance. Uses context if omitted        |
+| `hideWhenUnavailable` | `boolean`        | `false`     | Hide when the action isn't currently possible              |
+| `onWidthAdjusted`     | `() => void`     | `undefined` | Callback function called after successful width adjustment |
+
+### Hook Return Values
+
+| Name               | Type                  | Description                                      |
+| ------------------ | --------------------- | ------------------------------------------------ |
+| `isVisible`        | `boolean`             | Whether the button should be shown               |
+| `canFitToWidth`    | `boolean`             | Whether the action can currently execute         |
+| `handleFitToWidth` | `() => void`          | Function to execute the fit-to-width operation   |
+| `label`            | `string`              | Accessible label for the button ("Fit to width") |
+| `Icon`             | `React.ComponentType` | The horizontal move icon component               |
+
+## Usage Examples
+
+### Standalone Button
+
+```tsx
+'use client'
+
+import { EditorContent, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { TableFitToWidthButton } from '@/registry/tiptap-ui/table-fit-to-width-button'
+
+export const StandaloneExample = () => {
+  const editor = useEditor({
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <h2>Table Width Control</h2>
+      <p>Click the button below to make the table expand to full container width.</p>
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Product</strong></p></th>
+            <th><p><strong>Price</strong></p></th>
+            <th><p><strong>Stock</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Laptop</p></td>
+            <td><p>$999</p></td>
+            <td><p>25</p></td>
+          </tr>
+          <tr>
+            <td><p>Phone</p></td>
+            <td><p>$699</p></td>
+            <td><p>50</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <div style={{ marginTop: 10 }}>
+        <TableFitToWidthButton editor={editor} text="Fit to Container Width" />
+      </div>
+    </div>
+  )
+}
+```
+
+### With Callback
+
+```tsx
+'use client'
+
+import { useCallback } from 'react'
+import { EditorContent, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { TableFitToWidthButton } from '@/registry/tiptap-ui/table-fit-to-width-button'
+
+export const CallbackExample = () => {
+  const editor = useEditor({
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <table>
+        <tbody>
+          <tr>
+            <td><p>Cell 1</p></td>
+            <td><p>Cell 2</p></td>
+            <td><p>Cell 3</p></td>
+          </tr>
+          <tr>
+            <td><p>Cell 4</p></td>
+            <td><p>Cell 5</p></td>
+            <td><p>Cell 6</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  const handleWidthAdjusted = useCallback(() => {
+    console.log('Table width adjusted to fit container')
+  }, [])
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <TableFitToWidthButton
+        editor={editor}
+        onWidthAdjusted={handleWidthAdjusted}
+        hideWhenUnavailable={true}
+        text="Fit to Width"
+      />
+    </div>
+  )
+}
+```
+
+### Using Hook with Custom Button
+
+```tsx
+'use client'
+
+import { useTableFitToWidth } from '@/registry/tiptap-ui/table-fit-to-width-button'
+
+function CustomFitControls() {
+  const fitToWidth = useTableFitToWidth({
+    hideWhenUnavailable: true,
+    onWidthAdjusted: () => console.log('Width adjusted!'),
+  })
+
+  if (!fitToWidth.isVisible) return null
+
+  return (
+    <div>
+      <button
+        onClick={fitToWidth.handleFitToWidth}
+        disabled={!fitToWidth.canFitToWidth}
+        aria-label={fitToWidth.label}
+      >
+        <fitToWidth.Icon />
+        {fitToWidth.label}
+      </button>
+    </div>
+  )
+}
+```
+
+## Behavior
+
+### Fit to Width Operation
+
+The fit-to-width operation performs two key actions:
+
+1. **Sets table width to 100%** - Updates the table's `width` attribute to `"100%"` so it expands to fill its container
+2. **Clears column widths** - Removes all cell-level `colwidth` attributes from table cells and headers, allowing columns to resize fluidly
+
+### Implementation Details
+
+The operation:
+
+1. **Finds the table** - Walks up the document tree from the current selection to locate the nearest table ancestor
+2. **Updates table attribute** - Uses `editor.commands.updateAttributes("table", { width: "100%" })` to set the table width
+3. **Clears cell widths** - Creates a transaction that iterates through all table cells and headers, clearing their `colwidth` attributes
+4. **Dispatches changes** - Applies the transaction if any changes were made
+
+```typescript
+// Simplified implementation
+editor.commands.updateAttributes('table', {
+  width: '100%',
+})
+
+// Clear cell-level column widths
+node.descendants((child, childPos) => {
+  if (child.type.name === 'tableCell' || child.type.name === 'tableHeader') {
+    if (child.attrs.colwidth) {
+      tr.setNodeMarkup(absolutePos, undefined, {
+        ...child.attrs,
+        colwidth: null,
+      })
+    }
+  }
+})
+```
+
+### Availability
+
+The action is available when:
+
+- The editor is editable
+- Required extensions (`table` and `tableHandle`) are available
+- The current selection is inside a table (active in `table`, `tableCell`, or `tableHeader`)
+
+The action is **not available** when:
+
+- The editor is not editable
+- The cursor is outside a table
+- Required extensions are missing
+
+### Effect on Table Layout
+
+**Before fitting to width:**
+
+- Table may have fixed width (e.g., `width="500px"`)
+- Columns may have specific `colwidth` values
+- Table might not use full container width
+
+**After fitting to width:**
+
+- Table has `width="100%"`
+- All `colwidth` attributes are cleared
+- Table expands to fill its container
+- Columns resize proportionally based on content
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` - Core Tiptap React integration
+- `react` - React framework
+
+### Required Extensions
+
+- `table` - Table node extension (TableKit) for updating table attributes
+- `tableHandle` - Table handle extension for table tooling
+
+### Required Components
+
+- `Button` (UI primitive) - Base button component
+
+### Referenced Utilities
+
+- `useTiptapEditor` (hook) - Custom hook for editor instance management
+- `tiptap-utils` (lib) - Utility functions:
+  - `isExtensionAvailable` - Check if an extension is available
+
+## Related Components
+
+- **Table Handle** - For hover-based table manipulation
+- **Table Node (TableKit)** - The core table node extension that provides the `width` attribute
+- **Table Handle Extension** - Required extension for table tooling
+- **Table Column Resize** - For manually adjusting column widths (opposite operation)

--- a/src/content/ui-components/components/table-handle-menu.mdx
+++ b/src/content/ui-components/components/table-handle-menu.mdx
@@ -246,15 +246,15 @@ The TableHandleMenu integrates the following action hooks:
 
 ## Related Components
 
-- **Table Handle** - Parent component that manages handle positioning
-- **Table Move Row/Column Button** - Individual move operation button
-- **Table Add Row/Column Button** - Individual add operation button
-- **Table Delete Row/Column Button** - Individual delete operation button
-- **Table Duplicate Row/Column Button** - Individual duplicate operation button
-- **Table Sort Row/Column Button** - Individual sort operation button
-- **Table Clear Row/Column Content Button** - Individual clear content button
-- **Table Header Row/Column Button** - Individual header toggle button
+- **[Table Handle](/ui-components/components/table-handle)** - Parent component that manages handle positioning
+- **[Table Move Row/Column Button](/ui-components/components/table-move-row-column-button)** - Individual move operation button
+- **[Table Add Row/Column Button](/ui-components/components/table-add-row-column-button)** - Individual add operation button
+- **[Table Delete Row/Column Button](/ui-components/components/table-delete-row-column-button)** - Individual delete operation button
+- **[Table Duplicate Row/Column Button](/ui-components/components/table-duplicate-row-column-button)** - Individual duplicate operation button
+- **[Table Sort Row/Column Button](/ui-components/components/table-sort-row-column-button)** - Individual sort operation button
+- **[Table Clear Row/Column Content Button](/ui-components/components/table-clear-row-column-content-button)** - Individual clear content button
+- **[Table Header Row/Column Button](/ui-components/components/table-header-row-column-button)** - Individual header toggle button
 - **Color Menu** - Submenu for color selection
 - **Table Alignment Menu** - Submenu for alignment options
-- **Table Node (TableKit)** - The core table node extension
+- **[Table Node (TableKit)](/ui-components/node-components/table-node)** - The core table node extension
 - **Table Handle Extension** - Required extension for context detection

--- a/src/content/ui-components/components/table-handle-menu.mdx
+++ b/src/content/ui-components/components/table-handle-menu.mdx
@@ -1,0 +1,260 @@
+---
+title: Table Handle Menu
+meta:
+  title: Table Handle Menu | Tiptap UI Components
+  description: A comprehensive menu component for managing table row and column operations in Tiptap editors, providing a unified interface for all table manipulation actions.
+  category: UI Components
+component:
+  name: Table Handle Menu
+  description: A prebuilt menu component combining multiple table operations (add, move, sort, delete, duplicate, clear, header toggle, color, and alignment) into a single accessible menu.
+  type: component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: TableIcon
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+A comprehensive menu component that provides a unified interface for all table row and column operations in Tiptap editors. Combines adding, moving, sorting, deleting, duplicating, clearing content, toggling headers, changing colors, and setting alignment into a single accessible dropdown menu.
+
+<CodeDemo isScrollable src="https://template.tiptap.dev/preview/tiptap-ui/table-handle-menu" />
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add table-handle-menu
+```
+
+## Components
+
+### `<TableHandleMenu />`
+
+A prebuilt comprehensive menu component that aggregates all table row/column operations into a single dropdown menu.
+
+#### Usage
+
+```tsx
+import { TableHandleMenu } from '@/registry/tiptap-ui/table-handle-menu'
+
+function MyTableMenu() {
+  return <TableHandleMenu editor={editor} orientation="row" index={0} tablePos={tablePosition} />
+}
+```
+
+### Props
+
+| Name                  | Type             | Default      | Description                                                               |
+| --------------------- | ---------------- | ------------ | ------------------------------------------------------------------------- |
+| `editor`              | `Editor \| null` | `undefined`  | The Tiptap editor instance                                                |
+| `orientation`         | `Orientation`    | **required** | Whether managing a "row" or "column"                                      |
+| `index`               | `number`         | **required** | The index of the row or column to manage                                  |
+| `tableNode`           | `Node`           | `undefined`  | The ProseMirror table node                                                |
+| `tablePos`            | `number`         | `undefined`  | The position of the table in the document                                 |
+| `onToggleOtherHandle` | `() => void`     | `undefined`  | Callback to toggle visibility of the other handle (row when column opens) |
+| `onOpenChange`        | `() => void`     | `undefined`  | Callback function called when the menu opens or closes                    |
+
+## Features
+
+The TableHandleMenu component provides a comprehensive set of table manipulation features organized into logical groups:
+
+### Header Actions (First Row/Column Only)
+
+- **Toggle Header** - Convert first row/column between header and regular cells
+
+### Move Actions
+
+- **Move Up/Down** (rows) - Reposition rows within the table
+- **Move Left/Right** (columns) - Reposition columns within the table
+
+### Add Actions
+
+- **Add Above/Below** (rows) - Insert new rows relative to current position
+- **Add Left/Right** (columns) - Insert new columns relative to current position
+
+### Sort Actions
+
+- **Sort Ascending** - Sort table by selected row/column (A→Z or 0→9)
+- **Sort Descending** - Sort table by selected row/column (Z→A or 9→0)
+
+### Formatting Actions
+
+- **Color Menu** - Change text and background colors
+- **Alignment Menu** - Set horizontal and vertical alignment
+- **Clear Content** - Remove content while preserving structure
+
+### Structure Actions
+
+- **Duplicate** - Create a copy of the row/column
+- **Delete** - Remove the row/column from the table
+
+## Usage Examples
+
+### Standalone Usage
+
+```tsx
+'use client'
+
+import { EditorContent, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandleMenu } from '@/registry/tiptap-ui/table-handle-menu'
+
+export const StandaloneExample = () => {
+  const editor = useEditor({
+    extensions: [StarterKit, TableKit],
+    content: `
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Name</strong></p></th>
+            <th><p><strong>Age</strong></p></th>
+            <th><p><strong>City</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Alice</p></td>
+            <td><p>30</p></td>
+            <td><p>New York</p></td>
+          </tr>
+          <tr>
+            <td><p>Bob</p></td>
+            <td><p>25</p></td>
+            <td><p>London</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <div style={{ marginTop: 10 }}>
+        <TableHandleMenu editor={editor} orientation="row" index={1} tablePos={0} />
+      </div>
+    </div>
+  )
+}
+```
+
+### With Table Handle Integration
+
+```tsx
+'use client'
+
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { TableHandle } from '@/registry/tiptap-ui/table-handle'
+import { TableHandleMenu } from '@/registry/tiptap-ui/table-handle-menu'
+
+export const TableHandleIntegrationExample = () => {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <h2>Table Handle Menu Demo</h2>
+      <p>Hover over the table to see handle buttons. Click the menu icon to access all table operations.</p>
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Country</strong></p></th>
+            <th><p><strong>Capital</strong></p></th>
+            <th><p><strong>Language</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Spain</p></td>
+            <td><p>Madrid</p></td>
+            <td><p>Spanish</p></td>
+          </tr>
+          <tr>
+            <td><p>Germany</p></td>
+            <td><p>Berlin</p></td>
+            <td><p>German</p></td>
+          </tr>
+          <tr>
+            <td><p>Indonesia</p></td>
+            <td><p>Jakarta</p></td>
+            <td><p>Indonesian</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <EditorContent editor={editor} className="control-showcase" />
+      {/* TableHandleMenu is used by default when no custom buttons are provided */}
+      <TableHandle editor={editor} />
+    </EditorContext.Provider>
+  )
+}
+```
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` - Core Tiptap React integration
+- `@tiptap/pm/tables` - ProseMirror table utilities (TableMap)
+- `@tiptap/pm/model` - ProseMirror node model (Node)
+- `react` - React framework
+
+### Required Extensions
+
+- `tableHandle` - Table handle extension for detecting row/column context
+
+### Required Components
+
+- `table` - Table node extension (TableKit)
+- `Button` (UI primitive) - Base button component
+- `Menu`, `MenuButton`, `MenuContent`, `MenuGroup`, `MenuItem` (UI primitives) - Menu components
+- `Combobox`, `ComboboxList` (UI primitives) - Combobox components for accessibility
+- `Separator` (UI primitive) - Visual separator between groups
+- `ColorMenu` - Color selection submenu
+- `TableAlignMenu` - Alignment selection submenu
+
+### Required Action Hooks
+
+The TableHandleMenu integrates the following action hooks:
+
+- `useTableMoveRowColumn` - For moving rows/columns
+- `useTableAddRowColumn` - For adding rows/columns
+- `useTableDeleteRowColumn` - For deleting rows/columns
+- `useTableDuplicateRowColumn` - For duplicating rows/columns
+- `useTableSortRowColumn` - For sorting by row/column
+- `useTableClearRowColumnContent` - For clearing content
+- `useTableHeaderRowColumn` - For toggling header state
+
+### Referenced Utilities
+
+- `useTiptapEditor` (hook) - Custom hook for editor instance management
+- `tiptap-table-utils` (lib) - Utility functions:
+  - `selectCellsByCoords` - Select cells by coordinates
+  - `Orientation` - Type for "row" or "column"
+- `tiptap-utils` (lib) - General utilities:
+  - `cn` - Class name utility
+  - `isValidPosition` - Position validation
+  - `SR_ONLY` - Screen reader only styles
+
+## Related Components
+
+- **Table Handle** - Parent component that manages handle positioning
+- **Table Move Row/Column Button** - Individual move operation button
+- **Table Add Row/Column Button** - Individual add operation button
+- **Table Delete Row/Column Button** - Individual delete operation button
+- **Table Duplicate Row/Column Button** - Individual duplicate operation button
+- **Table Sort Row/Column Button** - Individual sort operation button
+- **Table Clear Row/Column Content Button** - Individual clear content button
+- **Table Header Row/Column Button** - Individual header toggle button
+- **Color Menu** - Submenu for color selection
+- **Table Alignment Menu** - Submenu for alignment options
+- **Table Node (TableKit)** - The core table node extension
+- **Table Handle Extension** - Required extension for context detection

--- a/src/content/ui-components/components/table-handle.mdx
+++ b/src/content/ui-components/components/table-handle.mdx
@@ -391,13 +391,13 @@ export const FullCustomMenuExample = () => {
 
 ## Related Components
 
-- **Table Handle Menu** - Default button component with all operations
+- **[Table Handle Menu](/ui-components/components/table-handle-menu)** - Default button component with all operations
 - **Table Handle Extension** - Required extension for state management
-- **Table Move Row/Column Button** - Individual move operation button
-- **Table Add Row/Column Button** - Individual add operation button
-- **Table Delete Row/Column Button** - Individual delete operation button
-- **Table Duplicate Row/Column Button** - Individual duplicate operation button
-- **Table Sort Row/Column Button** - Individual sort operation button
-- **Table Header Row/Column Button** - Individual header toggle button
-- **Table Node (TableKit)** - The core table node extension
-- **Table Extend Row/Column Buttons** - Additional buttons for adding rows/columns at table edges
+- **[Table Move Row/Column Button](/ui-components/components/table-move-row-column-button)** - Individual move operation button
+- **[Table Add Row/Column Button](/ui-components/components/table-add-row-column-button)** - Individual add operation button
+- **[Table Delete Row/Column Button](/ui-components/components/table-delete-row-column-button)** - Individual delete operation button
+- **[Table Duplicate Row/Column Button](/ui-components/components/table-duplicate-row-column-button)** - Individual duplicate operation button
+- **[Table Sort Row/Column Button](/ui-components/components/table-sort-row-column-button)** - Individual sort operation button
+- **[Table Header Row/Column Button](/ui-components/components/table-header-row-column-button)** - Individual header toggle button
+- **[Table Node (TableKit)](/ui-components/node-components/table-node)** - The core table node extension
+- **[Table Extend Row/Column Buttons](/ui-components/components/table-extend-row-column-buttons)** - Additional buttons for adding rows/columns at table edges

--- a/src/content/ui-components/components/table-handle.mdx
+++ b/src/content/ui-components/components/table-handle.mdx
@@ -1,0 +1,403 @@
+---
+title: Table Handle
+meta:
+  title: Table Handle | Tiptap UI Components
+  description: A positioning system for displaying interactive handles alongside table rows and columns in Tiptap editors, enabling hover-based table manipulation.
+  category: UI Components
+component:
+  name: Table Handle
+  description: A component that manages the positioning and rendering of floating table row/column handles with automatic hover detection and customizable button components.
+  type: component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: TableIcon
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+A positioning system component that displays interactive handles alongside table rows and columns in Tiptap editors. Automatically detects hover state and positions floating handles using Floating UI, providing a foundation for table manipulation interfaces.
+
+<CodeDemo isScrollable src="https://template.tiptap.dev/preview/tiptap-ui/table-handle" />
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add table-handle
+```
+
+## Components
+
+### `<TableHandle />`
+
+A component that manages positioning and rendering of floating handles for table rows and columns.
+
+#### Usage
+
+```tsx
+import { TableHandle } from '@/registry/tiptap-ui/table-handle'
+
+function MyTableEditor() {
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <TableHandle editor={editor} />
+    </div>
+  )
+}
+```
+
+### Props
+
+| Name           | Type                                    | Default     | Description                                                        |
+| -------------- | --------------------------------------- | ----------- | ------------------------------------------------------------------ |
+| `editor`       | `Editor \| null`                        | `undefined` | The Tiptap editor instance                                         |
+| `rowButton`    | `ComponentType<TableHandleButtonProps>` | `undefined` | Custom component for row handles. Defaults to `TableHandleMenu`    |
+| `columnButton` | `ComponentType<TableHandleButtonProps>` | `undefined` | Custom component for column handles. Defaults to `TableHandleMenu` |
+
+### TableHandleButtonProps Interface
+
+Custom button components receive these props:
+
+| Name                  | Type                         | Description                                                  |
+| --------------------- | ---------------------------- | ------------------------------------------------------------ |
+| `editor`              | `Editor`                     | The Tiptap editor instance                                   |
+| `orientation`         | `Orientation`                | Either "row" or "column"                                     |
+| `index`               | `number`                     | The index of the current row or column                       |
+| `tablePos`            | `number`                     | The position of the table in the document (optional)         |
+| `onToggleOtherHandle` | `(visible: boolean) => void` | Callback to toggle visibility of the other handle (optional) |
+
+## Usage Examples
+
+### Basic Usage (Default Handles)
+
+```tsx
+'use client'
+
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { TableHandle } from '@/registry/tiptap-ui/table-handle'
+
+export const BasicExample = () => {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <h2>Table Handle Demo</h2>
+      <p>Hover over the table to see row and column handles appear.</p>
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Product</strong></p></th>
+            <th><p><strong>Price</strong></p></th>
+            <th><p><strong>Stock</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Laptop</p></td>
+            <td><p>$999</p></td>
+            <td><p>15</p></td>
+          </tr>
+          <tr>
+            <td><p>Mouse</p></td>
+            <td><p>$29</p></td>
+            <td><p>50</p></td>
+          </tr>
+          <tr>
+            <td><p>Keyboard</p></td>
+            <td><p>$79</p></td>
+            <td><p>30</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <EditorContent editor={editor} />
+      <TableHandle editor={editor} />
+    </EditorContext.Provider>
+  )
+}
+```
+
+### Custom Button Components
+
+```tsx
+'use client'
+
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { TableHandle, TableHandleButtonProps } from '@/registry/tiptap-ui/table-handle'
+import { useTableDeleteRowColumn } from '@/registry/tiptap-ui/table-delete-row-column-button'
+import { Button } from '@/registry/tiptap-ui-primitive/button'
+
+// Custom button component for row/column operations
+function SimpleDeleteButton(props: TableHandleButtonProps) {
+  const { editor, index, orientation, tablePos } = props
+
+  const deleteAction = useTableDeleteRowColumn({
+    editor,
+    index,
+    orientation,
+    tablePos,
+  })
+
+  return (
+    <Button
+      onClick={deleteAction.handleDelete}
+      disabled={!deleteAction.canDeleteRowColumn}
+      aria-label={deleteAction.label}
+    >
+      <deleteAction.Icon />
+    </Button>
+  )
+}
+
+export const CustomButtonExample = () => {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <table>
+        <tbody>
+          <tr>
+            <td><p>Row 1, Col 1</p></td>
+            <td><p>Row 1, Col 2</p></td>
+          </tr>
+          <tr>
+            <td><p>Row 2, Col 1</p></td>
+            <td><p>Row 2, Col 2</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <EditorContent editor={editor} />
+      <TableHandle
+        editor={editor}
+        rowButton={SimpleDeleteButton}
+        columnButton={SimpleDeleteButton}
+      />
+    </EditorContext.Provider>
+  )
+}
+```
+
+### With Custom Menu (Full Example)
+
+```tsx
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { TableHandle, TableHandleButtonProps } from '@/registry/tiptap-ui/table-handle'
+import { useTableMoveRowColumn } from '@/registry/tiptap-ui/table-move-row-column-button'
+import { useTableDeleteRowColumn } from '@/registry/tiptap-ui/table-delete-row-column-button'
+import { Button } from '@/registry/tiptap-ui-primitive/button'
+import {
+  Menu,
+  MenuButton,
+  MenuContent,
+  MenuGroup,
+  MenuItem,
+} from '@/registry/tiptap-ui-primitive/menu'
+import { Combobox, ComboboxList } from '@/registry/tiptap-ui-primitive/combobox'
+import { MoreVerticalIcon } from '@/registry/tiptap-icons/more-vertical-icon'
+import { cn, SR_ONLY } from '@/registry/lib/tiptap-utils'
+import type { Orientation } from '@/registry/lib/tiptap-table-utils'
+
+const MENU_PLACEMENT_MAP: Record<Orientation, React.ComponentProps<typeof Menu>['placement']> = {
+  row: 'top-start',
+  column: 'bottom-start',
+}
+
+function CustomMenu(props: TableHandleButtonProps) {
+  const { editor, index, tablePos, orientation, onToggleOtherHandle } = props
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  const moveUp = useTableMoveRowColumn({
+    index,
+    tablePos,
+    orientation: 'row',
+    direction: 'up',
+    hideWhenUnavailable: true,
+  })
+
+  const moveDown = useTableMoveRowColumn({
+    index,
+    tablePos,
+    orientation: 'row',
+    direction: 'down',
+    hideWhenUnavailable: true,
+  })
+
+  const deleteAction = useTableDeleteRowColumn({
+    index,
+    orientation,
+    tablePos,
+  })
+
+  const menuPlacement = useMemo(() => MENU_PLACEMENT_MAP[orientation], [orientation])
+
+  const handleMenuToggle = useCallback(
+    (isOpen: boolean) => {
+      setIsMenuOpen(isOpen)
+
+      if (isOpen) {
+        editor.commands.freezeHandles()
+        onToggleOtherHandle?.(false)
+      } else {
+        editor.commands.unfreezeHandles()
+        onToggleOtherHandle?.(true)
+      }
+    },
+    [editor, onToggleOtherHandle],
+  )
+
+  return (
+    <Menu
+      open={isMenuOpen}
+      onOpenChange={handleMenuToggle}
+      placement={menuPlacement}
+      trigger={
+        <MenuButton
+          className={cn('tiptap-table-handle-menu', isMenuOpen && 'menu-opened', orientation)}
+        >
+          <MoreVerticalIcon className="tiptap-button-icon" />
+        </MenuButton>
+      }
+    >
+      <MenuContent autoFocusOnShow modal>
+        <Combobox style={SR_ONLY} />
+        <ComboboxList>
+          <MenuGroup>
+            {orientation === 'row' && (
+              <>
+                {moveUp.isVisible && (
+                  <MenuItem
+                    render={<Button data-style="ghost" />}
+                    onClick={moveUp.handleMove}
+                    disabled={!moveUp.canMoveRowColumn}
+                  >
+                    <moveUp.Icon className="tiptap-button-icon" />
+                    <span className="tiptap-button-text">{moveUp.label}</span>
+                  </MenuItem>
+                )}
+                {moveDown.isVisible && (
+                  <MenuItem
+                    render={<Button data-style="ghost" />}
+                    onClick={moveDown.handleMove}
+                    disabled={!moveDown.canMoveRowColumn}
+                  >
+                    <moveDown.Icon className="tiptap-button-icon" />
+                    <span className="tiptap-button-text">{moveDown.label}</span>
+                  </MenuItem>
+                )}
+              </>
+            )}
+            {deleteAction.isVisible && (
+              <MenuItem
+                render={<Button data-style="ghost" />}
+                onClick={deleteAction.handleDelete}
+                disabled={!deleteAction.canDeleteRowColumn}
+              >
+                <deleteAction.Icon className="tiptap-button-icon" />
+                <span className="tiptap-button-text">{deleteAction.label}</span>
+              </MenuItem>
+            )}
+          </MenuGroup>
+        </ComboboxList>
+      </MenuContent>
+    </Menu>
+  )
+}
+
+export const FullCustomMenuExample = () => {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <h2>Custom Menu Example</h2>
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Name</strong></p></th>
+            <th><p><strong>Role</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Alice</p></td>
+            <td><p>Developer</p></td>
+          </tr>
+          <tr>
+            <td><p>Bob</p></td>
+            <td><p>Designer</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <EditorContent editor={editor} />
+      <TableHandle editor={editor} rowButton={CustomMenu} columnButton={CustomMenu} />
+    </EditorContext.Provider>
+  )
+}
+```
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` - Core Tiptap React integration
+- `@floating-ui/react` - Positioning library (FloatingPortal)
+- `react` - React framework
+
+### Required Extensions
+
+- `tableHandle` - Table handle extension that emits `tableHandleState` events
+
+### Required Hooks
+
+- `useTiptapEditor` - Editor instance management
+- `useTableHandleState` - Table handle state subscription
+- `useTableHandlePositioning` - Floating UI positioning
+
+### Default Button Component
+
+- `TableHandleMenu` - Default menu with all table operations (used when no custom buttons provided)
+
+### Referenced Utilities
+
+- `tiptap-table-utils` (lib) - Type definitions:
+  - `Orientation` - Type for "row" or "column"
+
+## Related Components
+
+- **Table Handle Menu** - Default button component with all operations
+- **Table Handle Extension** - Required extension for state management
+- **Table Move Row/Column Button** - Individual move operation button
+- **Table Add Row/Column Button** - Individual add operation button
+- **Table Delete Row/Column Button** - Individual delete operation button
+- **Table Duplicate Row/Column Button** - Individual duplicate operation button
+- **Table Sort Row/Column Button** - Individual sort operation button
+- **Table Header Row/Column Button** - Individual header toggle button
+- **Table Node (TableKit)** - The core table node extension
+- **Table Extend Row/Column Buttons** - Additional buttons for adding rows/columns at table edges

--- a/src/content/ui-components/components/table-header-row-column-button.mdx
+++ b/src/content/ui-components/components/table-header-row-column-button.mdx
@@ -1,0 +1,464 @@
+---
+title: Table Header Row/Column Button
+meta:
+  title: Table Header Row/Column Button | Tiptap UI Components
+  description: A button component and hook for toggling table header rows and columns in Tiptap editors, with proper semantic structure and visual styling.
+  category: UI Components
+component:
+  name: Table Header Row/Column Button
+  description: A prebuilt button component and hook for toggling header formatting on the first row or first column of a table.
+  type: component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: TableIcon
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+A button component and custom hook for toggling table header rows and columns in Tiptap editors. Converts the first row or first column between regular cells and header cells, providing proper semantic structure and visual distinction for table headers.
+
+<CodeDemo
+  isScrollable
+  src="https://template.tiptap.dev/preview/tiptap-ui/table-header-row-column-button"
+/>
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add table-header-row-column-button
+```
+
+## Components
+
+### `<TableHeaderRowColumnButton />`
+
+A prebuilt button component for triggering header row/column toggle operations.
+
+#### Usage
+
+```tsx
+import { TableHeaderRowColumnButton } from '@/registry/tiptap-ui/table-header-row-column-button'
+
+function MyHeaderButton() {
+  return <TableHeaderRowColumnButton editor={editor} index={0} orientation="row" />
+}
+```
+
+### Props
+
+| Name                  | Type             | Default     | Description                                                                               |
+| --------------------- | ---------------- | ----------- | ----------------------------------------------------------------------------------------- |
+| `editor`              | `Editor \| null` | `undefined` | The Tiptap editor instance                                                                |
+| `index`               | `number`         | `undefined` | The index of the row or column. Must be 0 for headers. If omitted, uses current selection |
+| `orientation`         | `Orientation`    | `undefined` | Whether toggling "row" or "column" header. If omitted, uses current selection             |
+| `tablePos`            | `number`         | `undefined` | The position of the table in the document. Used when no cell is selected                  |
+| `hideWhenUnavailable` | `boolean`        | `false`     | Hide the button when header toggle isn't currently possible                               |
+| `onToggled`           | `() => void`     | `undefined` | Callback function called after a successful header toggle                                 |
+| `text`                | `string`         | `undefined` | Optional text to display alongside the icon                                               |
+| `...buttonProps`      | `ButtonProps`    | -           | All other props from the base Button component                                            |
+
+## Hook
+
+### `useTableHeaderRowColumn(config)`
+
+A custom React hook that provides the toggle functionality and state management. Use this for custom button implementations.
+
+#### Usage
+
+```tsx
+import { useTableHeaderRowColumn } from '@/registry/tiptap-ui/table-header-row-column-button'
+
+function CustomHeaderButton() {
+  const { isVisible, handleToggle, label, canToggleHeader, Icon, isActive } =
+    useTableHeaderRowColumn({
+      index: 0,
+      orientation: 'row',
+      hideWhenUnavailable: true,
+    })
+
+  if (!isVisible) return null
+
+  return (
+    <button onClick={handleToggle} disabled={!canToggleHeader} aria-pressed={isActive}>
+      <Icon />
+      {label}
+    </button>
+  )
+}
+```
+
+### Hook Configuration
+
+The `UseTableHeaderRowColumnConfig` interface supports the following options:
+
+| Name                  | Type             | Default     | Description                                                                               |
+| --------------------- | ---------------- | ----------- | ----------------------------------------------------------------------------------------- |
+| `editor`              | `Editor \| null` | `undefined` | The Tiptap editor instance. Uses context if omitted                                       |
+| `index`               | `number`         | `undefined` | The index of the row or column. Must be 0 for headers. If omitted, uses current selection |
+| `orientation`         | `Orientation`    | `undefined` | Whether toggling "row" or "column" header. If omitted, uses current selection             |
+| `tablePos`            | `number`         | `undefined` | The position of the table in the document. Used when no cell is selected                  |
+| `hideWhenUnavailable` | `boolean`        | `false`     | Hide when header toggle isn't currently possible                                          |
+| `onToggled`           | `() => void`     | `undefined` | Callback function called after a successful header toggle                                 |
+
+### Hook Return Values
+
+| Name              | Type                  | Description                                                       |
+| ----------------- | --------------------- | ----------------------------------------------------------------- |
+| `isVisible`       | `boolean`             | Whether the button should be shown                                |
+| `handleToggle`    | `() => void`          | Function to execute the toggle operation                          |
+| `label`           | `string`              | Accessible label for the button ("Header row" or "Header column") |
+| `canToggleHeader` | `boolean`             | Whether toggling is currently possible                            |
+| `Icon`            | `React.ComponentType` | The appropriate icon component for the orientation                |
+| `isActive`        | `boolean`             | Whether headers are currently applied to the row/column           |
+
+## Usage Examples
+
+### Standalone Button
+
+```tsx
+'use client'
+
+import { EditorContent, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { TableHeaderRowColumnButton } from '@/registry/tiptap-ui/table-header-row-column-button'
+
+export const StandaloneExample = () => {
+  const editor = useEditor({
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <table>
+        <tbody>
+          <tr>
+            <td><p>Name</p></td>
+            <td><p>Age</p></td>
+            <td><p>City</p></td>
+          </tr>
+          <tr>
+            <td><p>Alice</p></td>
+            <td><p>30</p></td>
+            <td><p>New York</p></td>
+          </tr>
+          <tr>
+            <td><p>Bob</p></td>
+            <td><p>25</p></td>
+            <td><p>London</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <div style={{ marginTop: 10 }}>
+        <TableHeaderRowColumnButton
+          editor={editor}
+          index={0}
+          orientation="row"
+          text="Toggle Header Row"
+        />
+        <TableHeaderRowColumnButton
+          editor={editor}
+          index={0}
+          orientation="column"
+          text="Toggle Header Column"
+        />
+      </div>
+    </div>
+  )
+}
+```
+
+### With Table Handle Integration
+
+```tsx
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { useTableHeaderRowColumn } from '@/registry/tiptap-ui/table-header-row-column-button'
+import { TableHandle } from '@/registry/tiptap-ui/table-handle'
+import type { TableHandleButtonProps } from '@/registry/tiptap-ui/table-handle'
+import { Button } from '@/registry/tiptap-ui-primitive/button'
+import {
+  Menu,
+  MenuButton,
+  MenuContent,
+  MenuGroup,
+  MenuItem,
+} from '@/registry/tiptap-ui-primitive/menu'
+import { Combobox, ComboboxList } from '@/registry/tiptap-ui-primitive/combobox'
+import { MoreVerticalIcon } from '@/registry/tiptap-icons/more-vertical-icon'
+import type { Orientation } from '@/registry/lib/tiptap-table-utils'
+
+const MENU_PLACEMENT_MAP: Record<Orientation, React.ComponentProps<typeof Menu>['placement']> = {
+  row: 'top-start',
+  column: 'bottom-start',
+}
+
+export const TableHandleIntegrationExample = () => {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <h2>Table Header Row/Column Demo</h2>
+      <p>Hover over the <strong>first row or first column</strong> to see handle buttons. Click to toggle header formatting.</p>
+      <table>
+        <tbody>
+          <tr>
+            <td><p>Title</p></td>
+            <td><p>Author</p></td>
+            <td><p>Genre</p></td>
+            <td><p>Year</p></td>
+            <td><p>Rating</p></td>
+          </tr>
+          <tr>
+            <td><p>1984</p></td>
+            <td><p>George Orwell</p></td>
+            <td><p>Dystopian</p></td>
+            <td><p>1949</p></td>
+            <td><p>4.7</p></td>
+          </tr>
+          <tr>
+            <td><p>The Great Gatsby</p></td>
+            <td><p>F. Scott Fitzgerald</p></td>
+            <td><p>Classic</p></td>
+            <td><p>1925</p></td>
+            <td><p>4.2</p></td>
+          </tr>
+          <tr>
+            <td><p>Harry Potter</p></td>
+            <td><p>J.K. Rowling</p></td>
+            <td><p>Fantasy</p></td>
+            <td><p>1997</p></td>
+            <td><p>4.9</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <EditorContent editor={editor} className="control-showcase" />
+      <TableHandle rowButton={HeaderMenu} columnButton={HeaderMenu} />
+    </EditorContext.Provider>
+  )
+}
+
+function HeaderMenu(props: TableHandleButtonProps) {
+  const { editor, index, tablePos, orientation, onToggleOtherHandle } = props
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  const headerAction = useTableHeaderRowColumn({
+    index,
+    orientation,
+    tablePos,
+  })
+
+  const menuPlacement = useMemo(() => MENU_PLACEMENT_MAP[orientation], [orientation])
+
+  const handleMenuToggle = useCallback(
+    (isOpen: boolean) => {
+      setIsMenuOpen(isOpen)
+
+      if (isOpen) {
+        editor.commands.freezeHandles()
+        onToggleOtherHandle?.(false)
+      } else {
+        editor.commands.unfreezeHandles()
+        onToggleOtherHandle?.(true)
+      }
+    },
+    [editor, onToggleOtherHandle],
+  )
+
+  // Only show header toggle for index 0
+  if (index !== 0) {
+    return null
+  }
+
+  return (
+    <Menu
+      open={isMenuOpen}
+      onOpenChange={handleMenuToggle}
+      placement={menuPlacement}
+      trigger={
+        <MenuButton
+          className={`tiptap-table-handle-menu ${isMenuOpen ? 'menu-opened' : ''} ${orientation}`}
+        >
+          <MoreVerticalIcon className="tiptap-button-icon" />
+        </MenuButton>
+      }
+    >
+      <MenuContent autoFocusOnShow modal>
+        <Combobox style={{ position: 'absolute', left: '-9999px' }} />
+        <ComboboxList>
+          <MenuGroup>
+            <MenuItem
+              render={
+                <Button
+                  data-style="ghost"
+                  data-active-state={headerAction.isActive ? 'on' : 'off'}
+                  disabled={!headerAction.canToggleHeader}
+                >
+                  <headerAction.Icon className="tiptap-button-icon" />
+                  <span className="tiptap-button-text">{headerAction.label}</span>
+                </Button>
+              }
+              onClick={headerAction.handleToggle}
+            />
+          </MenuGroup>
+        </ComboboxList>
+      </MenuContent>
+    </Menu>
+  )
+}
+```
+
+### Custom Hook Usage
+
+```tsx
+'use client'
+
+import { useTableHeaderRowColumn } from '@/registry/tiptap-ui/table-header-row-column-button'
+
+function CustomHeaderControls({ editor }: { editor: Editor | null }) {
+  const rowHeader = useTableHeaderRowColumn({
+    editor,
+    index: 0,
+    orientation: 'row',
+    hideWhenUnavailable: true,
+    onToggled: () => console.log('Row header toggled!'),
+  })
+
+  const columnHeader = useTableHeaderRowColumn({
+    editor,
+    index: 0,
+    orientation: 'column',
+    hideWhenUnavailable: true,
+    onToggled: () => console.log('Column header toggled!'),
+  })
+
+  return (
+    <div>
+      {rowHeader.isVisible && (
+        <button
+          onClick={rowHeader.handleToggle}
+          disabled={!rowHeader.canToggleHeader}
+          aria-label={rowHeader.label}
+          aria-pressed={rowHeader.isActive}
+          style={{
+            fontWeight: rowHeader.isActive ? 'bold' : 'normal',
+          }}
+        >
+          <rowHeader.Icon />
+          {rowHeader.label} {rowHeader.isActive ? '✓' : ''}
+        </button>
+      )}
+      {columnHeader.isVisible && (
+        <button
+          onClick={columnHeader.handleToggle}
+          disabled={!columnHeader.canToggleHeader}
+          aria-label={columnHeader.label}
+          aria-pressed={columnHeader.isActive}
+          style={{
+            fontWeight: columnHeader.isActive ? 'bold' : 'normal',
+          }}
+        >
+          <columnHeader.Icon />
+          {columnHeader.label} {columnHeader.isActive ? '✓' : ''}
+        </button>
+      )}
+    </div>
+  )
+}
+```
+
+## Behavior
+
+### Index 0 Restriction
+
+Header functionality **only applies to index 0**:
+
+- **Header Row**: Only the first row (index 0) can be converted to headers
+- **Header Column**: Only the first column (index 0) can be converted to headers
+
+This restriction ensures proper semantic table structure, as tables should have headers at the beginning, not in the middle.
+
+### Toggle Operation
+
+The toggle operation:
+
+1. **Checks if index is 0** - Validation ensures operation only happens on first row/column
+2. **Determines current state** - Checks if cells are already headers using node type
+3. **Toggles between states**:
+   - If cells are **regular cells** → Converts to `tableHeader` nodes
+   - If cells are **header cells** → Converts to regular `tableCell` nodes
+4. **Preserves content** - All cell content, marks, and attributes are maintained
+5. **Updates selection** - Maintains selection after the toggle
+
+### Selection Handling
+
+The component handles two types of selections:
+
+1. **CellSelection** - When multiple cells are selected:
+
+   - Uses `editor.commands.toggleHeaderRow()` for rows
+   - Uses `editor.commands.toggleHeaderColumn()` for columns
+
+2. **Regular selection** - When cursor is in a single cell:
+   - Uses `index`, `orientation`, and `tablePos` parameters
+   - Creates temporary cell selection using `selectCellsByCoords`
+   - Applies ProseMirror's `toggleHeader("row")` or `toggleHeader("column")`
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` - Core Tiptap React integration
+- `@tiptap/pm/tables` - ProseMirror table utilities (CellSelection, toggleHeader)
+- `@tiptap/pm/state` - ProseMirror state management (Transaction)
+- `react` - React framework
+
+### Required Extensions
+
+- `table` - Table node extension (TableKit)
+
+### Required Components (for full example)
+
+- `Button` (UI primitive) - Base button component
+- `Menu`, `MenuButton`, `MenuContent`, `MenuItem` (UI primitives) - Menu components
+- `TableHandle` - For hover-based table manipulation
+- `TableHandle Extension` - For detecting row/column context
+
+### Referenced Utilities
+
+- `useTiptapEditor` (hook) - Custom hook for editor instance management
+- `tiptap-table-utils` (lib) - Utility functions:
+  - `getIndexCoordinates` - Get cell coordinates for an index
+  - `getRowOrColumnCells` - Get cells in a row or column
+  - `getTableSelectionType` - Determine selection type
+  - `selectCellsByCoords` - Select cells by coordinates
+- `tiptap-utils` (lib) - `isExtensionAvailable`, `isValidPosition` for validation
+
+## Related Components
+
+- **Table Handle** - For hover-based row/column manipulation
+- **Table Sort Row/Column Button** - For sorting rows and columns
+- **Table Move Row/Column Button** - For moving rows and columns
+- **Table Delete Row/Column Button** - For deleting rows and columns
+- **Table Node (TableKit)** - The core table node extension
+- **Table Handle Extension** - Required extension for context detection

--- a/src/content/ui-components/components/table-header-row-column-button.mdx
+++ b/src/content/ui-components/components/table-header-row-column-button.mdx
@@ -456,9 +456,9 @@ The component handles two types of selections:
 
 ## Related Components
 
-- **Table Handle** - For hover-based row/column manipulation
-- **Table Sort Row/Column Button** - For sorting rows and columns
-- **Table Move Row/Column Button** - For moving rows and columns
-- **Table Delete Row/Column Button** - For deleting rows and columns
-- **Table Node (TableKit)** - The core table node extension
+- **[Table Handle](/ui-components/components/table-handle)** - For hover-based row/column manipulation
+- **[Table Sort Row/Column Button](/ui-components/components/table-sort-row-column-button)** - For sorting rows and columns
+- **[Table Move Row/Column Button](/ui-components/components/table-move-row-column-button)** - For moving rows and columns
+- **[Table Delete Row/Column Button](/ui-components/components/table-delete-row-column-button)** - For deleting rows and columns
+- **[Table Node (TableKit)](/ui-components/node-components/table-node)** - The core table node extension
 - **Table Handle Extension** - Required extension for context detection

--- a/src/content/ui-components/components/table-merge-split-cell-button.mdx
+++ b/src/content/ui-components/components/table-merge-split-cell-button.mdx
@@ -314,10 +314,10 @@ Both operations are **disabled** when:
 
 ## Related Components
 
-- **Table Handle** - For hover-based cell manipulation
-- **Table Move Row/Column Button** - For moving rows and columns
-- **Table Delete Row/Column Button** - For deleting rows and columns
-- **Table Duplicate Row/Column Button** - For duplicating rows and columns
-- **Table Sort Row/Column Button** - For sorting rows and columns
-- **Table Node (TableKit)** - The core table node extension
+- **[Table Handle](/ui-components/components/table-handle)** - For hover-based cell manipulation
+- **[Table Move Row/Column Button](/ui-components/components/table-move-row-column-button)** - For moving rows and columns
+- **[Table Delete Row/Column Button](/ui-components/components/table-delete-row-column-button)** - For deleting rows and columns
+- **[Table Duplicate Row/Column Button](/ui-components/components/table-duplicate-row-column-button)** - For duplicating rows and columns
+- **[Table Sort Row/Column Button](/ui-components/components/table-sort-row-column-button)** - For sorting rows and columns
+- **[Table Node (TableKit)](/ui-components/node-components/table-node)** - The core table node extension
 - **Table Handle Extension** - Extension for table manipulation context

--- a/src/content/ui-components/components/table-merge-split-cell-button.mdx
+++ b/src/content/ui-components/components/table-merge-split-cell-button.mdx
@@ -1,0 +1,323 @@
+---
+title: Table Merge/Split Cell Button
+meta:
+  title: Table Merge/Split Cell Button | Tiptap UI Components
+  description: A button component and hook for merging and splitting table cells in Tiptap editors, with intelligent cell selection validation.
+  category: UI Components
+component:
+  name: Table Merge/Split Cell Button
+  description: A prebuilt button component and hook for merging multiple cells into one and splitting merged cells back into individual cells.
+  type: component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: TableIcon
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+A button component and custom hook for merging and splitting table cells in Tiptap editors. Supports merging multiple selected cells into a single cell and splitting merged cells back into individual cells.
+
+<CodeDemo
+  isScrollable
+  src="https://template.tiptap.dev/preview/tiptap-ui/table-merge-split-cell-button"
+/>
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add table-merge-split-cell-button
+```
+
+## Components
+
+### `<TableMergeSplitCellButton />`
+
+A prebuilt button component for triggering cell merge or split operations.
+
+#### Usage
+
+```tsx
+import { TableMergeSplitCellButton } from '@/registry/tiptap-ui/table-merge-split-cell-button'
+
+function MyMergeButton() {
+  return <TableMergeSplitCellButton editor={editor} action="merge" />
+}
+
+function MySplitButton() {
+  return <TableMergeSplitCellButton editor={editor} action="split" />
+}
+```
+
+### Props
+
+| Name                  | Type               | Default      | Description                                                |
+| --------------------- | ------------------ | ------------ | ---------------------------------------------------------- |
+| `editor`              | `Editor \| null`   | `undefined`  | The Tiptap editor instance. Uses context if omitted        |
+| `action`              | `MergeSplitAction` | **required** | The action to perform: "merge" or "split"                  |
+| `hideWhenUnavailable` | `boolean`          | `false`      | Hide the button when the action isn't currently possible   |
+| `onExecuted`          | `(action) => void` | `undefined`  | Callback function called after a successful merge or split |
+| `text`                | `string`           | `undefined`  | Optional text to display alongside the icon                |
+| `...buttonProps`      | `ButtonProps`      | -            | All other props from the base Button component             |
+
+## Hook
+
+### `useTableMergeSplitCell(config)`
+
+For custom button implementations, use the hook directly:
+
+#### Usage
+
+```tsx
+import { useTableMergeSplitCell } from '@/registry/tiptap-ui/table-merge-split-cell-button'
+
+function CustomMergeButton() {
+  const { isVisible, handleExecute, label, canExecute, Icon } = useTableMergeSplitCell({
+    action: 'merge',
+    hideWhenUnavailable: true,
+  })
+
+  if (!isVisible) return null
+
+  return (
+    <button onClick={handleExecute} disabled={!canExecute}>
+      <Icon />
+      {label}
+    </button>
+  )
+}
+```
+
+### Hook Configuration
+
+The `UseTableMergeSplitCellConfig` interface supports the following options:
+
+| Name                  | Type               | Default      | Description                                                |
+| --------------------- | ------------------ | ------------ | ---------------------------------------------------------- |
+| `editor`              | `Editor \| null`   | `undefined`  | The Tiptap editor instance. Uses context if omitted        |
+| `action`              | `MergeSplitAction` | **required** | The action to perform: "merge" or "split"                  |
+| `hideWhenUnavailable` | `boolean`          | `false`      | Hide when the action isn't currently possible              |
+| `onExecuted`          | `(action) => void` | `undefined`  | Callback function called after a successful merge or split |
+
+### Hook Return Values
+
+| Name            | Type                  | Description                                           |
+| --------------- | --------------------- | ----------------------------------------------------- |
+| `isVisible`     | `boolean`             | Whether the button should be shown                    |
+| `handleExecute` | `() => boolean`       | Function to execute the merge/split operation         |
+| `label`         | `string`              | Accessible label for the button (e.g., "Merge cells") |
+| `canExecute`    | `boolean`             | Whether the action is currently possible              |
+| `Icon`          | `React.ComponentType` | The appropriate icon component for the action         |
+
+## Usage Examples
+
+### Standalone Button
+
+```tsx
+'use client'
+
+import { EditorContent, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { TableMergeSplitCellButton } from '@/registry/tiptap-ui/table-merge-split-cell-button'
+
+export const StandaloneExample = () => {
+  const editor = useEditor({
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Product</strong></p></th>
+            <th><p><strong>Price</strong></p></th>
+            <th><p><strong>Stock</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Laptop</p></td>
+            <td><p>$999</p></td>
+            <td><p>25</p></td>
+          </tr>
+          <tr>
+            <td><p>Phone</p></td>
+            <td><p>$699</p></td>
+            <td><p>50</p></td>
+          </tr>
+          <tr>
+            <td><p>Tablet</p></td>
+            <td><p>$399</p></td>
+            <td><p>30</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <div style={{ marginTop: 10 }}>
+        <TableMergeSplitCellButton editor={editor} action="merge" text="Merge Selected Cells" />
+        <TableMergeSplitCellButton editor={editor} action="split" text="Split Merged Cell" />
+      </div>
+    </div>
+  )
+}
+```
+
+### Using the Hook Directly
+
+```tsx
+'use client'
+
+import { useTableMergeSplitCell } from '@/registry/tiptap-ui/table-merge-split-cell-button'
+
+function CustomMergeSplitControls() {
+  const mergeAction = useTableMergeSplitCell({
+    action: 'merge',
+    hideWhenUnavailable: true,
+    onExecuted: () => console.log('Cells merged!'),
+  })
+
+  const splitAction = useTableMergeSplitCell({
+    action: 'split',
+    hideWhenUnavailable: true,
+    onExecuted: () => console.log('Cell split!'),
+  })
+
+  return (
+    <div>
+      {mergeAction.isVisible && (
+        <button
+          onClick={mergeAction.handleExecute}
+          disabled={!mergeAction.canExecute}
+          aria-label={mergeAction.label}
+        >
+          <mergeAction.Icon />
+          {mergeAction.label}
+        </button>
+      )}
+      {splitAction.isVisible && (
+        <button
+          onClick={splitAction.handleExecute}
+          disabled={!splitAction.canExecute}
+          aria-label={splitAction.label}
+        >
+          <splitAction.Icon />
+          {splitAction.label}
+        </button>
+      )}
+    </div>
+  )
+}
+```
+
+## Behavior
+
+### Merge Operation
+
+The merge operation:
+
+1. **Validates selection** - Checks if multiple adjacent cells are selected using CellSelection
+2. **Checks compatibility** - Ensures selected cells form a valid rectangular region
+3. **Executes merge** - Uses ProseMirror's `mergeCells` command to combine cells
+4. **Preserves content** - Maintains the content from all merged cells in the resulting cell
+5. **Updates attributes** - Sets appropriate `colspan` and `rowspan` attributes
+
+**Requirements for merging:**
+
+- Multiple cells must be selected (CellSelection with 2+ cells)
+- Selected cells must form a rectangular region
+- Cells must be adjacent (no gaps in selection)
+
+### Split Operation
+
+The split operation:
+
+1. **Validates selection** - Checks if a merged cell is currently selected
+2. **Detects merged attributes** - Identifies cells with `colspan > 1` or `rowspan > 1`
+3. **Executes split** - Uses ProseMirror's `splitCell` command to divide the cell
+4. **Distributes content** - Places original content in the first cell after split
+5. **Creates empty cells** - Fills remaining cells with empty content
+
+**Requirements for splitting:**
+
+- A single merged cell must be selected
+- Cell must have `colspan > 1` or `rowspan > 1` attributes
+
+### Selection Handling
+
+The component handles two types of selections:
+
+1. **CellSelection** - When multiple cells are selected (drag-select or Shift+arrow keys)
+
+   - **Merge** is available when 2+ adjacent cells are selected
+   - **Split** is not available (requires single merged cell)
+
+2. **Regular selection** - When cursor is in a single cell
+   - **Merge** is not available (requires multiple cells)
+   - **Split** is available only if the cell has colspan/rowspan > 1
+
+### Action Availability
+
+The component intelligently determines which action is available:
+
+- **Merge button enabled** when:
+
+  - Multiple cells are selected via CellSelection
+  - Selected cells form a valid rectangular region
+  - Editor is editable
+
+- **Split button enabled** when:
+  - A single merged cell is selected
+  - Cell has `colspan > 1` or `rowspan > 1`
+  - Editor is editable
+
+Both operations are **disabled** when:
+
+- Editor is not editable
+- Required table extension is not available
+- Selection doesn't meet operation requirements
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` - Core Tiptap React integration
+- `@tiptap/pm/tables` - ProseMirror table utilities (mergeCells, splitCell)
+- `react` - React framework
+
+### Required Extensions
+
+- `table` - Table node extension (TableKit) for basic table functionality
+
+### Required Components (for full example)
+
+- `Button` (UI primitive) - Base button component
+- `ButtonGroup` (UI primitive) - For grouping merge/split buttons
+- `TableHandle` - For hover-based table manipulation (optional)
+
+### Referenced Utilities
+
+- `useTiptapEditor` (hook) - Custom hook for editor instance management
+- `isExtensionAvailable` (lib) - Utility to check if required extensions are loaded
+
+### Icons
+
+- `TableCellMergeIcon` - Icon for merge action
+- `TableCellSplitIcon` - Icon for split action
+
+## Related Components
+
+- **Table Handle** - For hover-based cell manipulation
+- **Table Move Row/Column Button** - For moving rows and columns
+- **Table Delete Row/Column Button** - For deleting rows and columns
+- **Table Duplicate Row/Column Button** - For duplicating rows and columns
+- **Table Sort Row/Column Button** - For sorting rows and columns
+- **Table Node (TableKit)** - The core table node extension
+- **Table Handle Extension** - Extension for table manipulation context

--- a/src/content/ui-components/components/table-move-row-column-button.mdx
+++ b/src/content/ui-components/components/table-move-row-column-button.mdx
@@ -595,9 +595,9 @@ For regular selections, the component:
 
 ## Related Components
 
-- **Table Handle** - For hover-based row/column manipulation
-- **Table Sort Row/Column Button** - For sorting rows and columns
-- **Table Delete Row/Column Button** - For deleting rows and columns
-- **Table Duplicate Row/Column Button** - For duplicating rows and columns
-- **Table Node (TableKit)** - The core table node extension
+- **[Table Handle](/ui-components/components/table-handle)** - For hover-based row/column manipulation
+- **[Table Sort Row/Column Button](/ui-components/components/table-sort-row-column-button)** - For sorting rows and columns
+- **[Table Delete Row/Column Button](/ui-components/components/table-delete-row-column-button)** - For deleting rows and columns
+- **[Table Duplicate Row/Column Button](/ui-components/components/table-duplicate-row-column-button)** - For duplicating rows and columns
+- **[Table Node (TableKit)](/ui-components/node-components/table-node)** - The core table node extension
 - **Table Handle Extension** - Required extension for context detection

--- a/src/content/ui-components/components/table-move-row-column-button.mdx
+++ b/src/content/ui-components/components/table-move-row-column-button.mdx
@@ -1,0 +1,603 @@
+---
+title: Table Move Row/Column Button
+meta:
+  title: Table Move Row/Column Button | Tiptap UI Components
+  description: A button component and hook for moving table rows and columns in Tiptap editors, with intelligent validation and merged cell handling.
+  category: UI Components
+component:
+  name: Table Move Row/Column Button
+  description: A prebuilt button component and hook for moving table rows up/down and columns left/right.
+  type: component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: TableIcon
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+A button component and custom hook for moving table rows and columns in Tiptap editors. Supports moving rows up/down and columns left/right with intelligent validation to prevent operations on tables with merged cells.
+
+<CodeDemo
+  isScrollable
+  src="https://template.tiptap.dev/preview/tiptap-ui/table-move-row-column-button"
+/>
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add table-move-row-column-button
+```
+
+## Components
+
+### `<TableMoveRowColumnButton />`
+
+A prebuilt button component for triggering row/column move operations.
+
+#### Usage
+
+```tsx
+import { TableMoveRowColumnButton } from '@/registry/tiptap-ui/table-move-row-column-button'
+
+function MyMoveButton() {
+  return <TableMoveRowColumnButton editor={editor} index={0} orientation="row" direction="up" />
+}
+```
+
+### Props
+
+| Name                  | Type             | Default      | Description                                                                |
+| --------------------- | ---------------- | ------------ | -------------------------------------------------------------------------- |
+| `editor`              | `Editor \| null` | `undefined`  | The Tiptap editor instance                                                 |
+| `index`               | `number`         | `undefined`  | The index of the row or column to move. If omitted, uses current selection |
+| `orientation`         | `Orientation`    | `undefined`  | Whether moving a "row" or "column". If omitted, uses current selection     |
+| `tablePos`            | `number`         | `undefined`  | The position of the table in the document                                  |
+| `direction`           | `MoveDirection`  | **required** | The direction to move: "up", "down", "left", or "right"                    |
+| `hideWhenUnavailable` | `boolean`        | `false`      | Hide the button when moving isn't currently possible                       |
+| `onMoved`             | `() => void`     | `undefined`  | Callback function called after a successful move                           |
+| `text`                | `string`         | `undefined`  | Optional text to display alongside the icon                                |
+| `...buttonProps`      | `ButtonProps`    | -            | All other props from the base Button component                             |
+
+## Hook
+
+### `useTableMoveRowColumn(config)`
+
+For custom button implementations, use the hook directly:
+
+#### Usage
+
+```tsx
+import { useTableMoveRowColumn } from '@/registry/tiptap-ui/table-move-row-column-button'
+
+function CustomMoveButton() {
+  const { isVisible, handleMove, label, canMoveRowColumn, Icon } = useTableMoveRowColumn({
+    direction: 'up',
+    hideWhenUnavailable: true,
+  })
+
+  if (!isVisible) return null
+
+  return (
+    <button onClick={handleMove} disabled={!canMoveRowColumn}>
+      <Icon />
+      {label}
+    </button>
+  )
+}
+```
+
+### Hook Configuration
+
+The `UseTableMoveRowColumnConfig` interface supports the following options:
+
+| Name                  | Type             | Default      | Description                                                                |
+| --------------------- | ---------------- | ------------ | -------------------------------------------------------------------------- |
+| `editor`              | `Editor \| null` | `undefined`  | The Tiptap editor instance. Uses context if omitted                        |
+| `index`               | `number`         | `undefined`  | The index of the row or column to move. If omitted, uses current selection |
+| `orientation`         | `Orientation`    | `undefined`  | Whether moving a "row" or "column". If omitted, uses current selection     |
+| `tablePos`            | `number`         | `undefined`  | The position of the table in the document                                  |
+| `direction`           | `MoveDirection`  | **required** | The direction to move: "up", "down", "left", or "right"                    |
+| `hideWhenUnavailable` | `boolean`        | `false`      | Hide when moving isn't currently possible                                  |
+| `onMoved`             | `() => void`     | `undefined`  | Callback function called after a successful move                           |
+
+### Hook Return Values
+
+| Name               | Type                  | Description                                           |
+| ------------------ | --------------------- | ----------------------------------------------------- |
+| `isVisible`        | `boolean`             | Whether the button should be shown                    |
+| `handleMove`       | `() => void`          | Function to execute the move operation                |
+| `label`            | `string`              | Accessible label for the button (e.g., "Move row up") |
+| `canMoveRowColumn` | `boolean`             | Whether moving is currently possible                  |
+| `Icon`             | `React.ComponentType` | The appropriate icon component for the move direction |
+
+## Usage Examples
+
+### Standalone Button
+
+```tsx
+'use client'
+
+import { EditorContent, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { TableMoveRowColumnButton } from '@/registry/tiptap-ui/table-move-row-column-button'
+
+export const StandaloneExample = () => {
+  const editor = useEditor({
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Name</strong></p></th>
+            <th><p><strong>Age</strong></p></th>
+            <th><p><strong>City</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Alice</p></td>
+            <td><p>30</p></td>
+            <td><p>New York</p></td>
+          </tr>
+          <tr>
+            <td><p>Bob</p></td>
+            <td><p>25</p></td>
+            <td><p>London</p></td>
+          </tr>
+          <tr>
+            <td><p>Carol</p></td>
+            <td><p>35</p></td>
+            <td><p>Tokyo</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <div style={{ marginTop: 10 }}>
+        <TableMoveRowColumnButton
+          editor={editor}
+          index={1}
+          orientation="row"
+          direction="up"
+          text="Move Row 1 Up"
+        />
+        <TableMoveRowColumnButton
+          editor={editor}
+          index={1}
+          orientation="row"
+          direction="down"
+          text="Move Row 1 Down"
+        />
+        <TableMoveRowColumnButton
+          editor={editor}
+          index={1}
+          orientation="column"
+          direction="left"
+          text="Move Column 1 Left"
+        />
+        <TableMoveRowColumnButton
+          editor={editor}
+          index={1}
+          orientation="column"
+          direction="right"
+          text="Move Column 1 Right"
+        />
+      </div>
+    </div>
+  )
+}
+```
+
+### With Table Handle Integration
+
+```tsx
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { useTableMoveRowColumn } from '@/registry/tiptap-ui/table-move-row-column-button'
+import { TableHandle } from '@/registry/tiptap-ui/table-handle'
+import type { TableHandleButtonProps } from '@/registry/tiptap-ui/table-handle'
+import { Button } from '@/registry/tiptap-ui-primitive/button'
+import {
+  Menu,
+  MenuButton,
+  MenuContent,
+  MenuGroup,
+  MenuItem,
+} from '@/registry/tiptap-ui-primitive/menu'
+import { Combobox, ComboboxList } from '@/registry/tiptap-ui-primitive/combobox'
+import { MoreVerticalIcon } from '@/registry/tiptap-icons/more-vertical-icon'
+import type { Orientation } from '@/registry/lib/tiptap-table-utils'
+
+const MENU_PLACEMENT_MAP: Record<Orientation, React.ComponentProps<typeof Menu>['placement']> = {
+  row: 'top-start',
+  column: 'bottom-start',
+}
+
+export const TableHandleIntegrationExample = () => {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <h2>Table Move Row/Column Demo</h2>
+      <p>Hover over the table to see handle buttons. Click the menu to access move options.</p>
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Country</strong></p></th>
+            <th><p><strong>Capital</strong></p></th>
+            <th><p><strong>Language</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Spain</p></td>
+            <td><p>Madrid</p></td>
+            <td><p>Spanish</p></td>
+          </tr>
+          <tr>
+            <td><p>Germany</p></td>
+            <td><p>Berlin</p></td>
+            <td><p>German</p></td>
+          </tr>
+          <tr>
+            <td><p>Indonesia</p></td>
+            <td><p>Jakarta</p></td>
+            <td><p>Indonesian</p></td>
+          </tr>
+          <tr>
+            <td><p>Netherlands</p></td>
+            <td><p>Amsterdam</p></td>
+            <td><p>Dutch</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <EditorContent editor={editor} className="control-showcase" />
+      <TableHandle editor={editor} rowButton={MoveMenu} columnButton={MoveMenu} />
+    </EditorContext.Provider>
+  )
+}
+
+function MoveMenu(props: TableHandleButtonProps) {
+  const { editor, index, tablePos, orientation, onToggleOtherHandle } = props
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  const moveUpAction = useTableMoveRowColumn({
+    index,
+    tablePos,
+    orientation: 'row',
+    direction: 'up',
+    hideWhenUnavailable: true,
+  })
+
+  const moveDownAction = useTableMoveRowColumn({
+    index,
+    tablePos,
+    orientation: 'row',
+    direction: 'down',
+    hideWhenUnavailable: true,
+  })
+
+  const moveLeftAction = useTableMoveRowColumn({
+    index,
+    tablePos,
+    orientation: 'column',
+    direction: 'left',
+    hideWhenUnavailable: true,
+  })
+
+  const moveRightAction = useTableMoveRowColumn({
+    index,
+    tablePos,
+    orientation: 'column',
+    direction: 'right',
+    hideWhenUnavailable: true,
+  })
+
+  const moveActions = useMemo(
+    () => ({
+      moveUp: moveUpAction,
+      moveDown: moveDownAction,
+      moveLeft: moveLeftAction,
+      moveRight: moveRightAction,
+    }),
+    [moveUpAction, moveDownAction, moveLeftAction, moveRightAction],
+  )
+
+  const getMoveItems = useCallback(() => {
+    const items: Array<{
+      icon: React.ComponentType<any>
+      label: string
+      disabled: boolean
+      onClick: () => void
+    }> = []
+
+    if (moveActions.moveUp.isVisible) {
+      items.push({
+        icon: moveActions.moveUp.Icon,
+        label: moveActions.moveUp.label,
+        disabled: !moveActions.moveUp.canMoveRowColumn,
+        onClick: moveActions.moveUp.handleMove,
+      })
+    }
+
+    if (moveActions.moveDown.isVisible) {
+      items.push({
+        icon: moveActions.moveDown.Icon,
+        label: moveActions.moveDown.label,
+        disabled: !moveActions.moveDown.canMoveRowColumn,
+        onClick: moveActions.moveDown.handleMove,
+      })
+    }
+
+    if (moveActions.moveLeft.isVisible) {
+      items.push({
+        icon: moveActions.moveLeft.Icon,
+        label: moveActions.moveLeft.label,
+        disabled: !moveActions.moveLeft.canMoveRowColumn,
+        onClick: moveActions.moveLeft.handleMove,
+      })
+    }
+
+    if (moveActions.moveRight.isVisible) {
+      items.push({
+        icon: moveActions.moveRight.Icon,
+        label: moveActions.moveRight.label,
+        disabled: !moveActions.moveRight.canMoveRowColumn,
+        onClick: moveActions.moveRight.handleMove,
+      })
+    }
+
+    return items
+  }, [moveActions])
+
+  const menuPlacement = useMemo(() => MENU_PLACEMENT_MAP[orientation], [orientation])
+
+  const handleMenuToggle = useCallback(
+    (isOpen: boolean) => {
+      setIsMenuOpen(isOpen)
+
+      if (isOpen) {
+        editor.commands.freezeHandles()
+        onToggleOtherHandle?.(false)
+      } else {
+        editor.commands.unfreezeHandles()
+        onToggleOtherHandle?.(true)
+      }
+    },
+    [editor, onToggleOtherHandle],
+  )
+
+  return (
+    <Menu
+      open={isMenuOpen}
+      onOpenChange={handleMenuToggle}
+      placement={menuPlacement}
+      trigger={
+        <MenuButton
+          className={`tiptap-table-handle-menu ${isMenuOpen ? 'menu-opened' : ''} ${orientation}`}
+        >
+          <MoreVerticalIcon className="tiptap-button-icon" />
+        </MenuButton>
+      }
+    >
+      <MenuContent autoFocusOnShow modal>
+        <Combobox style={{ position: 'absolute', left: '-9999px' }} />
+        <ComboboxList>
+          <MenuGroup>
+            {getMoveItems().map((item) => (
+              <MenuItem
+                key={item.label}
+                render={
+                  <Button data-style="ghost" disabled={item.disabled}>
+                    <item.icon className="tiptap-button-icon" />
+                    <span className="tiptap-button-text">{item.label}</span>
+                  </Button>
+                }
+                onClick={item.onClick}
+              />
+            ))}
+          </MenuGroup>
+        </ComboboxList>
+      </MenuContent>
+    </Menu>
+  )
+}
+```
+
+### Custom Hook Usage
+
+```tsx
+'use client'
+
+import { useTableMoveRowColumn } from '@/registry/tiptap-ui/table-move-row-column-button'
+
+function CustomMoveControls({ editor }: { editor: Editor | null }) {
+  const moveUp = useTableMoveRowColumn({
+    editor,
+    orientation: 'row',
+    direction: 'up',
+    hideWhenUnavailable: true,
+    onMoved: () => console.log('Moved up!'),
+  })
+
+  const moveDown = useTableMoveRowColumn({
+    editor,
+    orientation: 'row',
+    direction: 'down',
+    hideWhenUnavailable: true,
+    onMoved: () => console.log('Moved down!'),
+  })
+
+  const moveLeft = useTableMoveRowColumn({
+    editor,
+    orientation: 'column',
+    direction: 'left',
+    hideWhenUnavailable: true,
+  })
+
+  const moveRight = useTableMoveRowColumn({
+    editor,
+    orientation: 'column',
+    direction: 'right',
+    hideWhenUnavailable: true,
+  })
+
+  return (
+    <div>
+      {moveUp.isVisible && (
+        <button
+          onClick={moveUp.handleMove}
+          disabled={!moveUp.canMoveRowColumn}
+          aria-label={moveUp.label}
+        >
+          <moveUp.Icon />
+          {moveUp.label}
+        </button>
+      )}
+      {moveDown.isVisible && (
+        <button
+          onClick={moveDown.handleMove}
+          disabled={!moveDown.canMoveRowColumn}
+          aria-label={moveDown.label}
+        >
+          <moveDown.Icon />
+          {moveDown.label}
+        </button>
+      )}
+      {moveLeft.isVisible && (
+        <button
+          onClick={moveLeft.handleMove}
+          disabled={!moveLeft.canMoveRowColumn}
+          aria-label={moveLeft.label}
+        >
+          <moveLeft.Icon />
+          {moveLeft.label}
+        </button>
+      )}
+      {moveRight.isVisible && (
+        <button
+          onClick={moveRight.handleMove}
+          disabled={!moveRight.canMoveRowColumn}
+          aria-label={moveRight.label}
+        >
+          <moveRight.Icon />
+          {moveRight.label}
+        </button>
+      )}
+    </div>
+  )
+}
+```
+
+## Behavior
+
+### Direction and Orientation Validation
+
+The component validates that directions are compatible with orientations:
+
+- **Rows** can only move **up** or **down**
+- **Columns** can only move **left** or **right**
+
+Attempting to use an invalid combination (e.g., moving a row left) will be automatically prevented.
+
+### Move Operation
+
+The move operation:
+
+1. **Validates the move** - Checks if the target position is valid and no merged cells would be affected
+2. **Calculates target index** - Determines the destination index based on direction:
+   - `up`: `currentIndex - 1`
+   - `down`: `currentIndex + 1`
+   - `left`: `currentIndex - 1`
+   - `right`: `currentIndex + 1`
+3. **Executes the move** - Uses ProseMirror's `moveTableRow` or `moveTableColumn` command
+4. **Maintains selection** - Keeps the moved row/column selected after the operation
+
+### Boundary Handling
+
+Moving is **disabled** at table boundaries:
+
+- **Row moving up**: First row (index 0) cannot move up
+- **Row moving down**: Last row cannot move down
+- **Column moving left**: First column (index 0) cannot move left
+- **Column moving right**: Last column cannot move right
+
+### Merged Cell Detection
+
+The component performs advanced validation to prevent moves that would break merged cells:
+
+1. **Checks source cells** - Validates that the row/column being moved doesn't contain merged cells that would break
+2. **Checks target cells** - Validates that the destination row/column doesn't contain overlapping merged cells
+3. **Uses `cellsOverlapRectangle`** - Utility function that checks if any cells in the selection have `rowspan > 1` or `colspan > 1` that would create conflicts
+
+When merged cells are detected in either source or target positions, the move is automatically disabled.
+
+### Selection Handling
+
+The component handles two types of selections:
+
+1. **CellSelection** - When multiple cells are selected, moves the entire selected range
+2. **Regular selection** - When cursor is in a single cell, moves that row/column
+
+For regular selections, the component:
+
+- Creates a temporary cell selection for the source row/column
+- Executes the move operation
+- Restores selection to the moved position
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` - Core Tiptap React integration
+- `@tiptap/pm/tables` - ProseMirror table utilities (CellSelection, moveTableRow, moveTableColumn, selectedRect)
+- `@tiptap/pm/state` - ProseMirror state management (Transaction)
+- `react` - React framework
+
+### Required Extensions
+
+- `tableHandle` - Table handle extension for detecting row/column context
+
+### Required Components (for full example)
+
+- `table` - Table node extension (TableKit)
+- `Button` (UI primitive) - Base button component
+- `Menu`, `MenuButton`, `MenuContent`, `MenuItem` (UI primitives) - Menu components
+- `TableHandle` - For hover-based table manipulation
+
+### Referenced Utilities
+
+- `useTiptapEditor` (hook) - Custom hook for editor instance management
+- `tiptap-table-utils` (lib) - Utility functions:
+  - `getTable` - Get table node information
+  - `getTableSelectionType` - Determine selection type
+  - `selectCellsByCoords` - Select cells by coordinates
+  - `cellsOverlapRectangle` - Check for merged cells
+  - `getIndexCoordinates` - Get cell coordinates for an index
+
+## Related Components
+
+- **Table Handle** - For hover-based row/column manipulation
+- **Table Sort Row/Column Button** - For sorting rows and columns
+- **Table Delete Row/Column Button** - For deleting rows and columns
+- **Table Duplicate Row/Column Button** - For duplicating rows and columns
+- **Table Node (TableKit)** - The core table node extension
+- **Table Handle Extension** - Required extension for context detection

--- a/src/content/ui-components/components/table-selection-overlay.mdx
+++ b/src/content/ui-components/components/table-selection-overlay.mdx
@@ -375,7 +375,7 @@ The component includes a custom hook (`useResizeOverlay`) that:
 
 ## Related Components
 
-- **Table Cell Handle Menu** - Menu component that can be passed via `cellMenu` prop
-- **Table Handle** - For hover-based table manipulation
-- **Table Extend Row Column Button** - For adding rows and columns
-- **Table Node (TableKit)** - The core table node extension
+- **[Table Cell Handle Menu](/ui-components/components/table-cell-handle-menu)** - Menu component that can be passed via `cellMenu` prop
+- **[Table Handle](/ui-components/components/table-handle)** - For hover-based table manipulation
+- **[Table Extend Row Column Button](/ui-components/components/table-extend-row-column-button)** - For adding rows and columns
+- **[Table Node (TableKit)](/ui-components/node-components/table-node)** - The core table node extension

--- a/src/content/ui-components/components/table-selection-overlay.mdx
+++ b/src/content/ui-components/components/table-selection-overlay.mdx
@@ -1,0 +1,381 @@
+---
+title: Table Selection Overlay
+meta:
+  title: Table Selection Overlay | Tiptap UI Components
+  description: A visual overlay component that highlights selected table cells with optional resize handles and menu integration for advanced table interactions.
+  category: UI Components
+component:
+  name: Table Selection Overlay
+  description: A prebuilt React component that renders a visual overlay on selected table cells with resize handles and menu support.
+  type: component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: TableIcon
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+A visual overlay component that highlights selected table cells in Tiptap editors. Provides clear visual feedback for cell selections with optional resize handles, menu integration, and automatic positioning using Floating UI.
+
+<CodeDemo
+  isScrollable
+  src="https://template.tiptap.dev/preview/tiptap-ui/table-selection-overlay"
+/>
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add table-selection-overlay
+```
+
+## Components
+
+### `<TableSelectionOverlay />`
+
+A prebuilt React component that renders a visual overlay on both single and multi-cell selections with optional corner resize handles and menu integration.
+
+#### Usage
+
+```tsx
+import { TableSelectionOverlay } from '@/registry/tiptap-ui/table-selection-overlay'
+
+function MyEditor() {
+  return (
+    <>
+      <EditorContent editor={editor} />
+      <TableSelectionOverlay editor={editor} />
+    </>
+  )
+}
+```
+
+#### Props
+
+| Name                | Type                                                                                                                                                                      | Default     | Description                                          |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------- |
+| `editor`            | `Editor \| null`                                                                                                                                                          | `undefined` | The Tiptap editor instance                           |
+| `cellMenu`          | `React.ComponentType<{ onOpenChange?: (isOpen: boolean) => void; editor?: Editor \| null; onResizeStart?: (handle: ResizeHandle) => (event: React.MouseEvent) => void }>` | `undefined` | Optional menu component to render inside the overlay |
+| `showResizeHandles` | `boolean`                                                                                                                                                                 | `true`      | Whether to show corner resize handles                |
+| `onMenuOpenChange`  | `(isOpen: boolean) => void`                                                                                                                                               | `undefined` | Callback fired when the menu open state changes      |
+
+#### ResizeHandle Type
+
+```typescript
+type ResizeHandle = 'tl' | 'tr' | 'bl' | 'br' | null
+```
+
+- `tl` - Top-left corner
+- `tr` - Top-right corner
+- `bl` - Bottom-left corner
+- `br` - Bottom-right corner
+
+## Usage Examples
+
+### Basic Example
+
+```tsx
+'use client'
+
+import { EditorContent, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableSelectionOverlay } from '@/registry/tiptap-ui/table-selection-overlay'
+
+export const BasicExample = () => {
+  const editor = useEditor({
+    extensions: [StarterKit, TableKit],
+    content: `
+      <h2>Table Selection Overlay Demo</h2>
+      <p>Click inside a table cell or drag to select multiple cells to see the overlay.</p>
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Product</strong></p></th>
+            <th><p><strong>Price</strong></p></th>
+            <th><p><strong>Stock</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Laptop</p></td>
+            <td><p>$999</p></td>
+            <td><p>15</p></td>
+          </tr>
+          <tr>
+            <td><p>Mouse</p></td>
+            <td><p>$29</p></td>
+            <td><p>50</p></td>
+          </tr>
+          <tr>
+            <td><p>Keyboard</p></td>
+            <td><p>$79</p></td>
+            <td><p>30</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <>
+      <EditorContent editor={editor} />
+      <TableSelectionOverlay editor={editor} />
+    </>
+  )
+}
+```
+
+### With Resize Handles Disabled
+
+```tsx
+'use client'
+
+import { EditorContent, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableSelectionOverlay } from '@/registry/tiptap-ui/table-selection-overlay'
+
+export const WithoutResizeHandles = () => {
+  const editor = useEditor({
+    extensions: [StarterKit, TableKit],
+    content: `
+      <h2>Selection Overlay Without Resize Handles</h2>
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Name</strong></p></th>
+            <th><p><strong>Role</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Alice</p></td>
+            <td><p>Developer</p></td>
+          </tr>
+          <tr>
+            <td><p>Bob</p></td>
+            <td><p>Designer</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <>
+      <EditorContent editor={editor} />
+      <TableSelectionOverlay editor={editor} showResizeHandles={false} />
+    </>
+  )
+}
+```
+
+### With Custom Cell Menu
+
+```tsx
+'use client'
+
+import { EditorContent, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableSelectionOverlay } from '@/registry/tiptap-ui/table-selection-overlay'
+import type { Editor } from '@tiptap/react'
+
+// Custom menu component
+const CustomCellMenu = ({
+  editor,
+  onOpenChange,
+}: {
+  editor?: Editor | null
+  onOpenChange?: (isOpen: boolean) => void
+}) => {
+  return (
+    <div style={{ position: 'absolute', top: -40, left: 0 }}>
+      <button onClick={() => editor?.chain().focus().deleteColumn().run()}>Delete Column</button>
+      <button onClick={() => editor?.chain().focus().deleteRow().run()}>Delete Row</button>
+    </div>
+  )
+}
+
+export const WithCellMenu = () => {
+  const editor = useEditor({
+    extensions: [StarterKit, TableKit],
+    content: `
+      <h2>Selection Overlay with Custom Cell Menu</h2>
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Q1</strong></p></th>
+            <th><p><strong>Q2</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>$1.2M</p></td>
+            <td><p>$1.4M</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <>
+      <EditorContent editor={editor} />
+      <TableSelectionOverlay editor={editor} cellMenu={CustomCellMenu} />
+    </>
+  )
+}
+```
+
+### Complete Example
+
+```tsx
+'use client'
+
+import { useState } from 'react'
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
+
+// --- Tiptap Core Extensions ---
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+
+// --- Tiptap UI ---
+import { TableSelectionOverlay } from '@/registry/tiptap-ui/table-selection-overlay'
+
+// --- Tiptap Node Styles ---
+import '@/registry/tiptap-node/heading-node/heading-node.scss'
+import '@/registry/tiptap-node/paragraph-node/paragraph-node.scss'
+import '@/registry/tiptap-node/table-node/table-node.scss'
+
+export const TableSelectionOverlayExample = () => {
+  const [enableResizer, setEnableResizer] = useState(true)
+
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [StarterKit, TableKit],
+    content: `
+      <h2>Table Selection Overlay Demo</h2>
+      <p>
+        Click inside the table cells below to see the overlay with resize handles.
+      </p>
+
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Country</strong></p></th>
+            <th><p><strong>Capital</strong></p></th>
+            <th><p><strong>Language</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Spain</p></td>
+            <td><p>Madrid</p></td>
+            <td><p>Spanish</p></td>
+          </tr>
+          <tr>
+            <td><p>Germany</p></td>
+            <td><p>Berlin</p></td>
+            <td><p>German</p></td>
+          </tr>
+          <tr>
+            <td><p>Indonesia</p></td>
+            <td><p>Jakarta</p></td>
+            <td><p>Indonesian</p></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Features:</h3>
+      <ul>
+        <li><strong>Single cell selection:</strong> Click on any cell to see the overlay</li>
+        <li><strong>Multi-cell selection:</strong> Click and drag across cells or use shift+click</li>
+        <li><strong>Resize handles:</strong> Drag the corner handles to resize your selection</li>
+        <li><strong>Menu integration:</strong> Add custom menus via the cellMenu prop</li>
+      </ul>
+    `,
+  })
+
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <div>
+        <button onClick={() => setEnableResizer(!enableResizer)}>
+          Toggle Resize Handles: {enableResizer ? 'ON' : 'OFF'}
+        </button>
+      </div>
+      <EditorContent editor={editor} role="presentation" className="control-showcase" />
+      <TableSelectionOverlay editor={editor} showResizeHandles={enableResizer} />
+    </EditorContext.Provider>
+  )
+}
+```
+
+## Behavior
+
+### Automatic Positioning
+
+The overlay uses Floating UI for precise positioning and automatically:
+
+- Calculates the bounding box of selected cells
+- Updates position during scrolling and editor changes
+- Renders in a FloatingPortal within the table's overlay container
+- Maintains correct positioning during column resizing operations
+
+### Selection Detection
+
+The component detects and handles two types of selections:
+
+1. **Multi-cell selection (CellSelection)**: When multiple cells are selected via drag or shift+click
+2. **Single cell selection**: When cursor is positioned in a single cell
+
+The overlay updates in real-time as the selection changes.
+
+### Resize Handles
+
+When `showResizeHandles={true}` (default), four corner handles are rendered:
+
+- **Top-left (tl)**: Anchors to bottom-right, extends selection upward and left
+- **Top-right (tr)**: Anchors to bottom-left, extends selection upward and right
+- **Bottom-left (bl)**: Anchors to top-right, extends selection downward and left
+- **Bottom-right (br)**: Anchors to top-left, extends selection downward and right
+
+Handles are disabled when a menu is open to prevent conflicts.
+
+### Column Resizing Integration
+
+The component includes a custom hook (`useResizeOverlay`) that:
+
+- Detects when column resizing begins via the `columnResizingPluginKey` plugin state
+- Starts a requestAnimationFrame loop to update overlay position during drag
+- Stops the loop when resizing ends
+- Ensures the overlay stays aligned with cells during resize operations
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` - Core Tiptap React integration
+- `@tiptap/pm/tables` - ProseMirror table utilities (CellSelection, cellAround, columnResizingPluginKey)
+- `@tiptap/pm/state` - ProseMirror state management
+- `@tiptap/pm/model` - ProseMirror document model
+- `@tiptap/pm/view` - ProseMirror view
+- `@floating-ui/react` - Floating UI for positioning (FloatingPortal, useFloating)
+- `react` - React framework
+
+### Required Extensions
+
+- `table` - Table node extension (TableKit)
+
+### Referenced Components & Utilities
+
+- `useTiptapEditor` (hook) - Custom hook for editor instance management
+- `tiptap-table-utils` (lib) - Utility functions:
+  - `domCellAround` - Find cell element from DOM node
+  - `getTable` - Get table node information
+  - `rectEq` - Compare DOMRect objects for equality
+
+## Related Components
+
+- **Table Cell Handle Menu** - Menu component that can be passed via `cellMenu` prop
+- **Table Handle** - For hover-based table manipulation
+- **Table Extend Row Column Button** - For adding rows and columns
+- **Table Node (TableKit)** - The core table node extension

--- a/src/content/ui-components/components/table-sort-row-column-button.mdx
+++ b/src/content/ui-components/components/table-sort-row-column-button.mdx
@@ -485,9 +485,9 @@ The component **automatically detects and preserves header cells** during sortin
 
 ## Related Components
 
-- **Table Handle** - For hover-based row/column manipulation
-- **Table Move Row/Column Button** - For reordering rows and columns
-- **Table Delete Row/Column Button** - For deleting rows and columns
-- **Table Duplicate Row/Column Button** - For duplicating rows and columns
-- **Table Node (TableKit)** - The core table node extension
+- **[Table Handle](/ui-components/components/table-handle)** - For hover-based row/column manipulation
+- **[Table Move Row/Column Button](/ui-components/components/table-move-row-column-button)** - For reordering rows and columns
+- **[Table Delete Row/Column Button](/ui-components/components/table-delete-row-column-button)** - For deleting rows and columns
+- **[Table Duplicate Row/Column Button](/ui-components/components/table-duplicate-row-column-button)** - For duplicating rows and columns
+- **[Table Node (TableKit)](/ui-components/node-components/table-node)** - The core table node extension
 - **Table Handle Extension** - Required extension for context detection

--- a/src/content/ui-components/components/table-sort-row-column-button.mdx
+++ b/src/content/ui-components/components/table-sort-row-column-button.mdx
@@ -1,0 +1,493 @@
+---
+title: Table Sort Row/Column Button
+meta:
+  title: Table Sort Row/Column Button | Tiptap UI Components
+  description: A button component and hook for sorting table rows and columns alphabetically in Tiptap editors, with automatic header preservation and intelligent sorting logic.
+  category: UI Components
+component:
+  name: Table Sort Row/Column Button
+  description: A prebuilt button component and hook for sorting table rows and columns with header preservation.
+  type: component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: TableIcon
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+A button component and custom hook for sorting table rows and columns alphabetically in Tiptap editors. Automatically preserves header cells while sorting data cells, with support for both ascending (A-Z) and descending (Z-A) sorting.
+
+<CodeDemo
+  isScrollable
+  src="https://template.tiptap.dev/preview/tiptap-ui/table-sort-row-column-button"
+/>
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add table-sort-row-column-button
+```
+
+## Components
+
+### `<TableSortRowColumnButton />`
+
+A prebuilt button component for triggering row/column sort operations.
+
+#### Usage
+
+```tsx
+import { TableSortRowColumnButton } from '@/registry/tiptap-ui/table-sort-row-column-button'
+
+function MySortButton() {
+  return <TableSortRowColumnButton editor={editor} index={0} orientation="column" direction="asc" />
+}
+```
+
+### Props
+
+| Name                  | Type             | Default      | Description                                                                |
+| --------------------- | ---------------- | ------------ | -------------------------------------------------------------------------- |
+| `editor`              | `Editor \| null` | `undefined`  | The Tiptap editor instance                                                 |
+| `index`               | `number`         | `undefined`  | The index of the row or column to sort. If omitted, uses current selection |
+| `orientation`         | `Orientation`    | `undefined`  | Whether sorting a "row" or "column". If omitted, uses current selection    |
+| `tablePos`            | `number`         | `undefined`  | The position of the table in the document                                  |
+| `direction`           | `SortDirection`  | **required** | The sort direction: "asc" (A-Z) or "desc" (Z-A)                            |
+| `hideWhenUnavailable` | `boolean`        | `false`      | Hide the button when sorting isn't currently possible                      |
+| `onSorted`            | `() => void`     | `undefined`  | Callback function called after a successful sort                           |
+| `text`                | `string`         | `undefined`  | Optional text to display alongside the icon                                |
+| `...buttonProps`      | `ButtonProps`    | -            | All other props from the base Button component                             |
+
+## Hook
+
+### `useTableSortRowColumn()`
+
+A custom React hook that provides the sorting functionality and state management. Use this for custom button implementations.
+
+#### Usage
+
+```tsx
+import { useTableSortRowColumn } from '@/registry/tiptap-ui/table-sort-row-column-button'
+
+function CustomSortButton() {
+  const { isVisible, handleSort, label, canSortRowColumn, Icon } = useTableSortRowColumn({
+    direction: 'asc',
+    hideWhenUnavailable: true,
+  })
+
+  if (!isVisible) return null
+
+  return (
+    <button onClick={handleSort} disabled={!canSortRowColumn}>
+      <Icon />
+      {label}
+    </button>
+  )
+}
+```
+
+### Hook Configuration
+
+| Name                  | Type             | Default      | Description                                                                |
+| --------------------- | ---------------- | ------------ | -------------------------------------------------------------------------- |
+| `editor`              | `Editor \| null` | `undefined`  | The Tiptap editor instance. Uses context if omitted                        |
+| `index`               | `number`         | `undefined`  | The index of the row or column to sort. If omitted, uses current selection |
+| `orientation`         | `Orientation`    | `undefined`  | Whether sorting a "row" or "column". If omitted, uses current selection    |
+| `tablePos`            | `number`         | `undefined`  | The position of the table in the document                                  |
+| `direction`           | `SortDirection`  | **required** | The sort direction: "asc" (A-Z) or "desc" (Z-A)                            |
+| `hideWhenUnavailable` | `boolean`        | `false`      | Hide when sorting isn't currently possible                                 |
+| `onSorted`            | `() => void`     | `undefined`  | Callback function called after a successful sort                           |
+
+### Hook Return Values
+
+| Name               | Type                  | Description                                            |
+| ------------------ | --------------------- | ------------------------------------------------------ |
+| `isVisible`        | `boolean`             | Whether the button should be shown                     |
+| `handleSort`       | `() => void`          | Function to execute the sort operation                 |
+| `label`            | `string`              | Accessible label for the button (e.g., "Sort row A-Z") |
+| `canSortRowColumn` | `boolean`             | Whether sorting is currently possible                  |
+| `Icon`             | `React.ComponentType` | The appropriate icon component for the sort direction  |
+
+## Usage Examples
+
+### Standalone Button
+
+```tsx
+'use client'
+
+import { EditorContent, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { TableSortRowColumnButton } from '@/registry/tiptap-ui/table-sort-row-column-button'
+
+export const StandaloneExample = () => {
+  const editor = useEditor({
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Name</strong></p></th>
+            <th><p><strong>Category</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Laptop</p></td>
+            <td><p>Electronics</p></td>
+          </tr>
+          <tr>
+            <td><p>Desk Chair</p></td>
+            <td><p>Furniture</p></td>
+          </tr>
+          <tr>
+            <td><p>Coffee Maker</p></td>
+            <td><p>Appliances</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <div style={{ marginTop: 10 }}>
+        <TableSortRowColumnButton
+          editor={editor}
+          index={0}
+          orientation="column"
+          direction="asc"
+          text="Sort First Column A-Z"
+        />
+        <TableSortRowColumnButton
+          editor={editor}
+          index={0}
+          orientation="column"
+          direction="desc"
+          text="Sort First Column Z-A"
+        />
+      </div>
+    </div>
+  )
+}
+```
+
+### With Table Handle Integration
+
+```tsx
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/registry/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/registry/tiptap-extension/table-handle'
+import { useTableSortRowColumn } from '@/registry/tiptap-ui/table-sort-row-column-button'
+import { TableHandle } from '@/registry/tiptap-ui/table-handle'
+import type { TableHandleButtonProps } from '@/registry/tiptap-ui/table-handle'
+import { Button } from '@/registry/tiptap-ui-primitive/button'
+import {
+  Menu,
+  MenuButton,
+  MenuContent,
+  MenuGroup,
+  MenuItem,
+} from '@/registry/tiptap-ui-primitive/menu'
+import { Combobox, ComboboxList } from '@/registry/tiptap-ui-primitive/combobox'
+import { MoreVerticalIcon } from '@/registry/tiptap-icons/more-vertical-icon'
+import type { Orientation } from '@/registry/lib/tiptap-table-utils'
+
+const MENU_PLACEMENT_MAP: Record<Orientation, React.ComponentProps<typeof Menu>['placement']> = {
+  row: 'top-start',
+  column: 'bottom-start',
+}
+
+export const TableHandleIntegrationExample = () => {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [StarterKit, TableKit, TableHandleExtension],
+    content: `
+      <h2>Table Sort Row/Column Demo</h2>
+      <p>Hover over the table to see handle buttons. Click the menu to access sorting options.</p>
+      <table>
+        <tbody>
+          <tr>
+            <th><p><strong>Product</strong></p></th>
+            <th><p><strong>Category</strong></p></th>
+            <th><p><strong>Price</strong></p></th>
+            <th><p><strong>Rating</strong></p></th>
+          </tr>
+          <tr>
+            <td><p>Wireless Mouse</p></td>
+            <td><p>Electronics</p></td>
+            <td><p>$29.99</p></td>
+            <td><p>4.5</p></td>
+          </tr>
+          <tr>
+            <td><p>Office Desk</p></td>
+            <td><p>Furniture</p></td>
+            <td><p>$199.99</p></td>
+            <td><p>4.2</p></td>
+          </tr>
+          <tr>
+            <td><p>Keyboard</p></td>
+            <td><p>Electronics</p></td>
+            <td><p>$79.99</p></td>
+            <td><p>4.7</p></td>
+          </tr>
+        </tbody>
+      </table>
+    `,
+  })
+
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <EditorContent editor={editor} className="control-showcase" />
+      <TableHandle rowButton={SortMenu} columnButton={SortMenu} />
+    </EditorContext.Provider>
+  )
+}
+
+function SortMenu(props: TableHandleButtonProps) {
+  const { editor, index, tablePos, orientation, onToggleOtherHandle } = props
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  const sortAscAction = useTableSortRowColumn({
+    index,
+    tablePos,
+    orientation,
+    direction: 'asc',
+  })
+
+  const sortDescAction = useTableSortRowColumn({
+    index,
+    tablePos,
+    orientation,
+    direction: 'desc',
+  })
+
+  const sortActions = useMemo(
+    () => ({
+      sortAsc: sortAscAction,
+      sortDesc: sortDescAction,
+    }),
+    [sortAscAction, sortDescAction],
+  )
+
+  const getSortItems = useCallback(() => {
+    const items: Array<{
+      icon: React.ComponentType<any>
+      label: string
+      disabled: boolean
+      onClick: () => void
+    }> = []
+
+    if (sortActions.sortAsc.isVisible) {
+      items.push({
+        icon: sortActions.sortAsc.Icon,
+        label: sortActions.sortAsc.label,
+        disabled: !sortActions.sortAsc.canSortRowColumn,
+        onClick: sortActions.sortAsc.handleSort,
+      })
+    }
+
+    if (sortActions.sortDesc.isVisible) {
+      items.push({
+        icon: sortActions.sortDesc.Icon,
+        label: sortActions.sortDesc.label,
+        disabled: !sortActions.sortDesc.canSortRowColumn,
+        onClick: sortActions.sortDesc.handleSort,
+      })
+    }
+
+    return items
+  }, [sortActions])
+
+  const menuPlacement = useMemo(() => MENU_PLACEMENT_MAP[orientation], [orientation])
+
+  const handleMenuToggle = useCallback(
+    (isOpen: boolean) => {
+      setIsMenuOpen(isOpen)
+
+      if (isOpen) {
+        editor.commands.freezeHandles()
+        onToggleOtherHandle?.(false)
+      } else {
+        editor.commands.unfreezeHandles()
+        onToggleOtherHandle?.(true)
+      }
+    },
+    [editor, onToggleOtherHandle],
+  )
+
+  return (
+    <Menu
+      open={isMenuOpen}
+      onOpenChange={handleMenuToggle}
+      placement={menuPlacement}
+      trigger={
+        <MenuButton
+          className={`tiptap-table-handle-menu ${isMenuOpen ? 'menu-opened' : ''} ${orientation}`}
+        >
+          <MoreVerticalIcon className="tiptap-button-icon" />
+        </MenuButton>
+      }
+    >
+      <MenuContent autoFocusOnShow modal>
+        <Combobox style={{ position: 'absolute', left: '-9999px' }} />
+        <ComboboxList>
+          <MenuGroup>
+            {getSortItems().map((item) => (
+              <MenuItem
+                key={item.label}
+                render={
+                  <Button data-style="ghost" disabled={item.disabled}>
+                    <item.icon className="tiptap-button-icon" />
+                    <span className="tiptap-button-text">{item.label}</span>
+                  </Button>
+                }
+                onClick={item.onClick}
+              />
+            ))}
+          </MenuGroup>
+        </ComboboxList>
+      </MenuContent>
+    </Menu>
+  )
+}
+```
+
+### Custom Hook Usage
+
+```tsx
+'use client'
+
+import { useTableSortRowColumn } from '@/registry/tiptap-ui/table-sort-row-column-button'
+
+function CustomSortControls({ editor }: { editor: Editor | null }) {
+  const sortAsc = useTableSortRowColumn({
+    editor,
+    direction: 'asc',
+    hideWhenUnavailable: true,
+    onSorted: () => console.log('Sorted A-Z!'),
+  })
+
+  const sortDesc = useTableSortRowColumn({
+    editor,
+    direction: 'desc',
+    hideWhenUnavailable: true,
+    onSorted: () => console.log('Sorted Z-A!'),
+  })
+
+  return (
+    <div>
+      {sortAsc.isVisible && (
+        <button
+          onClick={sortAsc.handleSort}
+          disabled={!sortAsc.canSortRowColumn}
+          aria-label={sortAsc.label}
+        >
+          <sortAsc.Icon />
+          {sortAsc.label}
+        </button>
+      )}
+      {sortDesc.isVisible && (
+        <button
+          onClick={sortDesc.handleSort}
+          disabled={!sortDesc.canSortRowColumn}
+          aria-label={sortDesc.label}
+        >
+          <sortDesc.Icon />
+          {sortDesc.label}
+        </button>
+      )}
+    </div>
+  )
+}
+```
+
+## Behavior
+
+### Header Preservation
+
+The component **automatically detects and preserves header cells** during sorting:
+
+- Header cells remain in their original positions
+- Only data cells (non-headers) are sorted
+- This ensures table structure integrity
+
+#### Example:
+
+**Before sorting column by Name (A-Z):**
+
+```
+| Name (header)  | Age (header) |
+| Zebra          | 25           |
+| Apple          | 30           |
+```
+
+**After sorting:**
+
+```
+| Name (header)  | Age (header) |  ← Headers stay in place
+| Apple          | 30           |  ← Data sorted
+| Zebra          | 25           |
+```
+
+### Row vs Column Sorting
+
+**Column sorting** (most common):
+
+- Sorts all rows based on the values in a specific column
+- Header row (if present) stays at the top
+- Data rows are reordered
+
+**Row sorting**:
+
+- Sorts all columns based on the values in a specific row
+- Header column (if present) stays in place
+- Data columns are reordered
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` - Core Tiptap React integration
+- `@tiptap/pm/model` - ProseMirror document model
+- `react` - React framework
+
+### Required Extensions
+
+- `tableHandle` - Table handle extension for detecting row/column context
+
+### Required Components (for full example)
+
+- `table` - Table node extension (TableKit)
+- `Button` (UI primitive) - Base button component
+- `Menu`, `MenuButton`, `MenuContent`, `MenuItem` (UI primitives) - Menu components
+- `TableHandle` - For hover-based table manipulation
+
+### Referenced Utilities
+
+- `useTiptapEditor` (hook) - Custom hook for editor instance management
+- `tiptap-table-utils` (lib) - Utility functions:
+  - `getTable` - Get table node information
+  - `getTableSelectionType` - Determine selection type
+  - `getRowOrColumnCells` - Get cells in a row or column
+  - `isCellEmpty` - Check if cell has content
+- `tiptap-utils` (lib) - `isExtensionAvailable` for checking extension availability
+
+## Related Components
+
+- **Table Handle** - For hover-based row/column manipulation
+- **Table Move Row/Column Button** - For reordering rows and columns
+- **Table Delete Row/Column Button** - For deleting rows and columns
+- **Table Duplicate Row/Column Button** - For duplicating rows and columns
+- **Table Node (TableKit)** - The core table node extension
+- **Table Handle Extension** - Required extension for context detection

--- a/src/content/ui-components/node-components/table-node.mdx
+++ b/src/content/ui-components/node-components/table-node.mdx
@@ -1,0 +1,237 @@
+---
+title: Table Node
+meta:
+  title: Table Node | Tiptap UI Components
+  description: Add tables to your Tiptap editor with row/column management, cell alignment controls, and advanced table manipulation features.
+  category: UI Components
+component:
+  name: Table Node
+  description: An enhanced table node component for Tiptap editors with table handles, row/column manipulation, and advanced management features.
+  type: node-component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: TableIcon
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+An enhanced table node component for Tiptap editors. Features table handles for row/column manipulation, cell alignment controls, add/delete/move/duplicate functionality, and advanced table management capabilities with responsive styling and accessibility features.
+
+<CodeDemo isScrollable src="https://template.tiptap.dev/preview/tiptap-node/table-node" />
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add table-node
+```
+
+## Components
+
+### `<TableNode />`
+
+An enhanced table node component with table handles, row/column manipulation, and advanced management features.
+
+#### Usage
+
+```tsx
+import { useEditor, EditorContent } from '@tiptap/react'
+import { StarterKit } from '@tiptap/starter-kit'
+import { TableKit } from '@/components/tiptap-node/table-node/table-node-extension'
+import { TableHandle as TableHandleExtension } from '@/components/tiptap-extension/table-handle'
+import '@/components/tiptap-node/table-node/table-node.scss'
+
+export default function TableEditor() {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [
+      StarterKit,
+      TableKit.configure({
+        table: {
+          HTMLAttributes: {
+            class: 'custom-table-class',
+          },
+        },
+      }),
+      TableHandleExtension,
+    ],
+    content: `
+      <table>
+        <tr>
+          <th>Header 1</th>
+          <th>Header 2</th>
+        </tr>
+        <tr>
+          <td>Cell 1</td>
+          <td>Cell 2</td>
+        </tr>
+      </table>
+    `,
+  })
+
+  return <EditorContent editor={editor} />
+}
+```
+
+## Extensions
+
+### `TableKit`
+
+A comprehensive table extension kit that bundles multiple table-related extensions together.
+
+#### Usage
+
+```tsx
+import { TableKit } from '@/components/tiptap-node/table-node/table-node-extension'
+
+const editor = useEditor({
+  extensions: [
+    StarterKit,
+    TableKit.configure({
+      table: {
+        HTMLAttributes: {
+          class: 'custom-table',
+        },
+      },
+      tableCell: {
+        HTMLAttributes: {
+          class: 'custom-cell',
+        },
+      },
+      tableHeader: {
+        HTMLAttributes: {
+          class: 'custom-header',
+        },
+      },
+      tableRow: {
+        HTMLAttributes: {
+          class: 'custom-row',
+        },
+      },
+    }),
+  ],
+})
+```
+
+#### Configuration Options
+
+The TableKit accepts the following configuration options:
+
+- **table**: Configure the Table node or set to `false` to disable
+- **tableCell**: Configure the TableCell node or set to `false` to disable
+- **tableHeader**: Configure the TableHeader node or set to `false` to disable
+- **tableRow**: Configure the TableRow node or set to `false` to disable
+
+### `TableNode` (Enhanced)
+
+An extended version of the Tiptap Table extension with custom node view structure.
+
+#### Custom Node View Structure
+
+The table node creates a specialized DOM structure for enhanced functionality:
+
+```html
+<div class="block-content" data-content-type="table">
+  <div class="tableWrapper">
+    <div class="table-container">
+      <table>
+        <!-- table content -->
+      </table>
+    </div>
+    <div class="table-controls">
+      <!-- handle widgets -->
+    </div>
+    <div class="table-selection-overlay-container">
+      <!-- selection overlays -->
+    </div>
+  </div>
+</div>
+```
+
+### `TableCellNode` (Enhanced)
+
+Enhanced TableCell with improved keyboard shortcuts for cell selection.
+
+#### Keyboard Shortcuts
+
+- **Mod-a**: Select all content within the current cell
+
+## Table Handle Components
+
+The table node works with the TableHandle extension to provide contextual controls:
+
+### `<TableHandle />`
+
+Provides row and column handles that appear when hovering over the table. These handles enable:
+
+- Adding rows/columns
+- Deleting rows/columns
+- Moving rows/columns
+- Duplicating rows/columns
+- Accessing advanced table operations via menu
+
+#### Usage with Table Handle Extension
+
+```tsx
+import { TableHandle as TableHandleExtension } from '@/components/tiptap-extension/table-handle'
+import { TableHandle } from '@/components/tiptap-ui/table-handle'
+
+// In your extensions
+const editor = useEditor({
+  extensions: [
+    StarterKit,
+    TableKit,
+    TableHandleExtension, // Required for handle functionality
+  ],
+})
+
+// In your component
+<EditorContent editor={editor} />
+<TableHandle editor={editor} />
+```
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/extension-table` - Core table extensions (Table, TableRow, TableCell, TableHeader)
+- `@tiptap/pm/tables` - ProseMirror table utilities
+- `@tiptap/pm/state` - ProseMirror state management
+- `@tiptap/pm/view` - ProseMirror view utilities
+- `@tiptap/react` - React integration
+- `sass` / `sass-embedded` - For SCSS compilation
+
+### Required Extensions
+
+- `table-handle` - Table handle extension for row/column manipulation context
+
+### Referenced Components
+
+- `use-tiptap-editor` (hook)
+- `tiptap-utils` (lib)
+- `tiptap-table-utils` (lib)
+- `table-handle` (extension)
+- `table-add-row-column-button` (component)
+- `table-delete-row-column-button` (component)
+- `table-move-row-column-button` (component)
+- `table-duplicate-row-column-button` (component)
+- `table-extend-row-column-button` (component)
+- `table-selection-overlay` (component)
+- `table-cell-handle-menu` (component)
+
+## Related Components
+
+- **Table Handle Extension** - Required for table manipulation context
+- **Table Add Row/Column Button** - For adding rows and columns
+- **Table Delete Row/Column Button** - For deleting rows and columns
+- **Table Move Row/Column Button** - For moving rows and columns
+- **Table Duplicate Row/Column Button** - For duplicating rows and columns
+- **Table Extend Row/Column Button** - For interactive row/column sizing
+- **Table Selection Overlay** - For visual selection feedback
+- **Table Cell Handle Menu** - For cell-level operations
+- **Node Alignment Extension** - For cell alignment support

--- a/src/content/ui-components/sidebar.ts
+++ b/src/content/ui-components/sidebar.ts
@@ -254,6 +254,10 @@ export const sidebarConfig: SidebarConfig = {
               href: '/ui-components/components/table-header-row-column-button',
             },
             {
+              title: 'Table Merge Split Cell Button',
+              href: '/ui-components/components/table-merge-split-cell-button',
+            },
+            {
               title: 'Table Move Row/Column Button',
               href: '/ui-components/components/table-move-row-column-button',
             },

--- a/src/content/ui-components/sidebar.ts
+++ b/src/content/ui-components/sidebar.ts
@@ -210,6 +210,62 @@ export const sidebarConfig: SidebarConfig = {
               href: '/ui-components/components/slash-dropdown-menu',
             },
             {
+              title: 'Table Add Row/Column Button',
+              href: '/ui-components/components/table-add-row-column-button',
+            },
+            {
+              title: 'Table Align Cell Button',
+              href: '/ui-components/components/table-align-cell-button',
+            },
+            {
+              title: 'Table Cell Handle Menu',
+              href: '/ui-components/components/table-cell-handle-menu',
+            },
+            {
+              title: 'Table Clear Row/Column Content Button',
+              href: '/ui-components/components/table-clear-row-column-content-button',
+            },
+            {
+              title: 'Table Delete Row/Column Button',
+              href: '/ui-components/components/table-delete-row-column-button',
+            },
+            {
+              title: 'Table Duplicate Row/Column Button',
+              href: '/ui-components/components/table-duplicate-row-column-button',
+            },
+            {
+              title: 'Table Extend Row/Column Button',
+              href: '/ui-components/components/table-extend-row-column-button',
+            },
+            {
+              title: 'Table Fit to Width Button',
+              href: '/ui-components/components/table-fit-to-width-button',
+            },
+            {
+              title: 'Table Handle',
+              href: '/ui-components/components/table-handle',
+            },
+            {
+              title: 'Table Handle Menu',
+              href: '/ui-components/components/table-handle-menu',
+            },
+            {
+              title: 'Table Header Row/Column Button',
+              href: '/ui-components/components/table-header-row-column-button',
+            },
+            {
+              title: 'Table Move Row/Column Button',
+              href: '/ui-components/components/table-move-row-column-button',
+            },
+            {
+              title: 'Table Selection Overlay',
+              href: '/ui-components/components/table-selection-overlay',
+            },
+            {
+              title: 'Table Sort Row/Column Button',
+              href: '/ui-components/components/table-sort-row-column-button',
+            },
+            {
               title: 'Text align button',
               href: '/ui-components/components/text-align-button',
             },

--- a/src/content/ui-components/sidebar.ts
+++ b/src/content/ui-components/sidebar.ts
@@ -337,6 +337,10 @@ export const sidebarConfig: SidebarConfig = {
               title: 'Paragraph node',
               href: '/ui-components/node-components/paragraph-node',
             },
+            {
+              title: 'Table node',
+              href: '/ui-components/node-components/table-node',
+            },
           ],
         },
         {


### PR DESCRIPTION
### **URLs**

```
- /ui-components/components/table-add-row-column-button
- /ui-components/components/table-align-cell-button
- /ui-components/components/table-cell-handle-menu
- /ui-components/components/table-clear-row-column-content-button
- /ui-components/components/table-delete-row-column-button
- /ui-components/components/table-duplicate-row-column-button
- /ui-components/components/table-extend-row-column-button
- /ui-components/components/table-fit-to-width-button
- /ui-components/components/table-handle
- /ui-components/components/table-handle-menu
- /ui-components/components/table-header-row-column-button
- /ui-components/components/table-merge-split-cell-button
- /ui-components/components/table-move-row-column-button
- /ui-components/components/table-selection-overlay
- /ui-components/components/table-sort-row-column-button

- /ui-components/components/table-node
```