### PR TITLE
docs: rename option `contentDOMElementTag` to `as` in ReactNodeViewRe…

### DIFF
--- a/src/content/editor/extensions/custom-extensions/node-views/react.mdx
+++ b/src/content/editor/extensions/custom-extensions/node-views/react.mdx
@@ -114,7 +114,7 @@ return ReactNodeViewRenderer(Component, { contentDOMElementTag: 'header' })
 
 ## Changing the wrapping DOM element
 
-To change the wrapping DOM elements tag, you can use the `contentDOMElementTag` option on the `ReactNodeViewRenderer` function to change the default tag name.
+To change the wrapping DOM elements tag, you can use the `as` option on the `ReactNodeViewRenderer` function to change the default tag name.
 
 ```js
 import { Node } from '@tiptap/core'
@@ -125,7 +125,7 @@ export default Node.create({
   // configuration …
 
   addNodeView() {
-    return ReactNodeViewRenderer(Component, { contentDOMElementTag: 'main' })
+    return ReactNodeViewRenderer(Component, { as: 'main' })
   },
 })
 ```


### PR DESCRIPTION
…nderer

contentDOMElementTag does not change the wrapping DOM element’s tag; only as changes it.

<img width="1664" height="446" alt="CleanShot 2025-10-02 at 11 25 08@2x" src="https://github.com/user-attachments/assets/6e2070ba-d53b-4ba0-ae88-1100a0b22103" />
