### PR TITLE
Docs for the new schema awareness api

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -19,7 +19,7 @@ meta:
 ### Patch Changes
 
 - Fix issue where the detailed diff was shown during streaming, which caused the diff to constantly update. Now, the detailed diff is only shown when the streaming is finished.
-- Fix issue that caused extra paragraphs to be inserted during streaming, at the beginning of the streamed content. 
+- Fix issue that caused extra paragraphs to be inserted during streaming, at the beginning of the streamed content.
 
 ## 3.0.0-alpha.20
 
@@ -81,6 +81,7 @@ meta:
 - Add `readNodeRange` tool. This tool allows the AI to read any range of top-level nodes in the document. It is much more flexible than the previous chunk-based reading tools.
 
 ### Minor Changes
+
 - Add `streamTool` method to stream a tool call into the editor
 
 ## 3.0.0-alpha.13

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.22
+
+### Minor Changes
+
+- Add `addHtmlSchemaAwareness` method to the extension configuration to provide the schema awareness data of a custom Node or Mark extension.
+
 ## 3.0.0-alpha.21
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/inline-edits.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/inline-edits.mdx
@@ -80,8 +80,16 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: openai('gpt-5-mini'),
-    system:
-      "You are an expert writer that can edit rich text documents. The user has selected part of the document. You will receive the current content of the selection (in HTML format) and the user's request. Re-write the content of the selection to meet the user's request. Generate the HTML code for the new content of the selection. If the user's request is not clear or does not relate to editing the document, generate HTML code where you ask the user to clarify the request. Your response should only contain the HTML code, no other text or explanation, no Markdown, and your HTML response should not be wrapped in backticks, Markdown code blocks, or other extra formatting.",
+    system: `You are an expert writer that can edit rich text documents.
+The user has selected part of the document. You will receive the current
+content of the selection (in HTML format) and the user's request. Re-write
+the content of the selection to meet the user's request. Generate the HTML
+code for the new content of the selection. If the user's request is not 
+clear or does not relate to editing the document, generate HTML code where
+you ask the user to clarify the request. Your response should only contain
+the HTML code, no other text or explanation, no Markdown, and your HTML 
+response should not be wrapped in backticks, Markdown code blocks, or other
+extra formatting.`,
     prompt: `User request:
 """
 ${userRequest}

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/schema-awareness.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/schema-awareness.mdx
@@ -36,9 +36,9 @@ const schemaAwareness = toolkit.getHtmlSchemaAwareness()
 If your document contains [custom Nodes and Marks](/editor/extensions/custom-extensions), add the `addHtmlSchemaAwareness` option to the extension configuration. This way, the AI model will be able to generate this custom Node or Mark accurately. For example, if you have a custom node called `'alert'`, you can allow the AI model to generate it by configuring it like this:
 
 ```ts
-import { AlertNode } from './AlertNode'
+import { Node } from '@tiptap/core'
 
-const AlertExtension = Node.configure({
+const CustomExtension = Node.configure({
   name: 'alert',
 
   addHtmlSchemaAwareness() {

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/schema-awareness.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/schema-awareness.mdx
@@ -33,31 +33,24 @@ const schemaAwareness = toolkit.getHtmlSchemaAwareness()
 
 ### Step 2 (optional): configure custom nodes
 
-If your document contains [custom nodes and marks](/editor/extensions/custom-extensions), you can configure them with the `customNodes` option. This way, the AI model will be able to generate these custom elements accurately. For example, if you have a custom node called `'alert'`, you can allow the AI model to generate it by configuring it like this:
+If your document contains [custom Nodes and Marks](/editor/extensions/custom-extensions), add the `addHtmlSchemaAwareness` option to the extension configuration. This way, the AI model will be able to generate this custom Node or Mark accurately. For example, if you have a custom node called `'alert'`, you can allow the AI model to generate it by configuring it like this:
 
 ```ts
-const toolkit = getAiToolkit(editor)
-// Retrieve the schema awareness string with custom elements included
-const schemaAwareness = toolkit.getHtmlSchemaAwareness({
-  customNodes: [
-    {
-      // The `name` property of the custom node extension
-      extensionName: 'alert',
-      // The HTML tag name for the custom node
+import { AlertNode } from './AlertNode'
+
+const AlertExtension = Node.configure({
+  name: 'alert',
+
+  addHtmlSchemaAwareness() {
+    return {
       tag: 'div',
-      // The human-readable name of the element in English
       name: 'Alert Box',
-      // The description of the element in English
       description:
         'A highlighted box used to display important information, warnings, or tips to the user',
-      // Describe the HTML attributes of the node as it is rendered in HTML
       attributes: [
         {
-          // The name of the attribute in the HTML code
           attr: 'data-alert',
-          // Specify the "value" property if the attribute always has that value
           value: '',
-          // A description of the attribute in English
           description: 'Indicates that this is an alert box',
         },
         {
@@ -65,12 +58,21 @@ const schemaAwareness = toolkit.getHtmlSchemaAwareness({
           description: 'The type of alert: info, warning, error, or success',
         },
       ],
-    },
-  ],
+    }
+  },
+
+  // ... Other extension configuration options
 })
 ```
 
-Learn more about the configuration options in the [API Reference](#gethtmlschemaawareness).
+You can also pass an array of `customNodes` items to the `getHtmlSchemaAwareness` method to include more custom nodes in the schema awareness string, this will override the custom nodes configured in the extension configuration. Learn more about the configuration options in the [API Reference](#gethtmlschemaawareness).
+
+<Callout title="What about official Tiptap extensions?" variant="info">
+  Schema awareness for official Tiptap extensions is automatically supported by the AI Toolkit. They
+  do not need to be configured. You can still override the default schema awareness information for
+  official Tiptap extensions by extending the extension and adding the `addHtmlSchemaAwareness`
+  option.
+</Callout>
 
 ### Step 3: add the schema awareness string to the system prompt
 
@@ -160,3 +162,19 @@ Every `SchemaAwarenessItem` object contains these properties:
 // Retrieve the schema awareness string
 const schemaAwareness = toolkit.getHtmlSchemaAwareness()
 ```
+
+## `addHtmlSchemaAwareness` (extension configuration option)
+
+Add schema awareness information about a custom Node or Mark. This option is used to configure custom nodes and marks for the AI model to know about them.
+
+This configuration option is available for [custom Node and Mark extensions](/editor/extensions/custom-extensions/create-new/node).
+
+### Parameters (`addHtmlSchemaAwarenessOptions`)
+
+- `tag` (`string`): The HTML tag name for this element
+- `name` (`string`): The human-readable name of the element in English
+- `description?` (`string | null`): Explanation of what the element is and how it is displayed
+- `attributes?` (`SchemaAwarenessItemAttribute[]`): Possible attributes of the HTML tag. If `undefined`, there are no attributes. Each `SchemaAwarenessItemAttribute` object contains these properties:
+  - `attr` (`string`): The name of the attribute in the HTML code
+  - `value?` (`string`): If `value` is not `undefined`, the attribute always has that value for this element. This is used for attributes that have fixed values
+  - `description?` (`string | null`): Explanation of the attribute in English for AI model understanding

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/schema-awareness.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/schema-awareness.mdx
@@ -65,7 +65,7 @@ const CustomExtension = Node.configure({
 })
 ```
 
-You can also pass an array of `customNodes` items to the `getHtmlSchemaAwareness` method to include more custom nodes in the schema awareness string, this will override the custom nodes configured in the extension configuration. Learn more about the configuration options in the [API Reference](#gethtmlschemaawareness).
+Alternatively, you can configure the `customNodes` option of the `getHtmlSchemaAwareness` method. Learn more about the configuration options in the [API Reference](#gethtmlschemaawareness).
 
 <Callout title="What about official Tiptap extensions?" variant="info">
   Schema awareness for official Tiptap extensions is automatically supported by the AI Toolkit. They
@@ -137,17 +137,17 @@ Returns a string describing the document's schema. This string should be added t
 
 Currently, the `getHtmlSchemaAwareness` method only supports AI models that generate HTML content. We plan to add support for other formats in the future.
 
-### Parameters (`getHtmlSchemaAwarenessOptions`)
+### Parameters (`GetHtmlSchemaAwarenessOptions`)
 
-- `customNodes?` (`SchemaAwarenessItem[]`): Custom schema awareness items to include in addition to the default ones. Default: `[]`.
+- `customNodes?` (`HtmlItem[]`): Custom schema awareness items to include in addition to the default ones. The values defined in this option will override the schema awareness data defined in the `addHtmlSchemaAwareness` configuration option of custom extensions. They will also override the schema awareness data of official Tiptap extensions. Default: `[]`.
 
-Every `SchemaAwarenessItem` object contains these properties:
+Every `HtmlItem` object contains these properties:
 
 - `extensionName` (`string`): The [name of the extension](/editor/extensions/custom-extensions/create-new/extension#name) that provides this element
 - `tag` (`string`): The HTML tag name for this element
 - `name` (`string`): The human-readable name of the element in English
 - `description?` (`string | null`): Explanation of what the element is and how it is displayed
-- `attributes?` (`SchemaAwarenessItemAttribute[]`): Possible attributes of the HTML tag. If `undefined`, there are no attributes. Each `SchemaAwarenessItemAttribute` object contains these properties:
+- `attributes?` (`HtmlAttribute[]`): Possible attributes of the HTML tag. If `undefined`, there are no attributes. Each `HtmlAttribute` object contains these properties:
   - `attr` (`string`): The name of the attribute in the HTML code
   - `value?` (`string`): If `value` is not `undefined`, the attribute always has that value for this element. This is used for attributes that have fixed values
   - `description?` (`string | null`): Explanation of the attribute in English for AI model understanding
@@ -169,12 +169,12 @@ Add schema awareness information about a custom Node or Mark. This option is use
 
 This configuration option is available for [custom Node and Mark extensions](/editor/extensions/custom-extensions/create-new/node).
 
-### Parameters (`addHtmlSchemaAwarenessOptions`)
+### Parameters (`HtmlItem`)
 
 - `tag` (`string`): The HTML tag name for this element
 - `name` (`string`): The human-readable name of the element in English
 - `description?` (`string | null`): Explanation of what the element is and how it is displayed
-- `attributes?` (`SchemaAwarenessItemAttribute[]`): Possible attributes of the HTML tag. If `undefined`, there are no attributes. Each `SchemaAwarenessItemAttribute` object contains these properties:
+- `attributes?` (`HtmlAttribute[]`): Possible attributes of the HTML tag. If `undefined`, there are no attributes. Each `HtmlAttribute` object contains these properties:
   - `attr` (`string`): The name of the attribute in the HTML code
   - `value?` (`string`): If `value` is not `undefined`, the attribute always has that value for this element. This is used for attributes that have fixed values
   - `description?` (`string | null`): Explanation of the attribute in English for AI model understanding


### PR DESCRIPTION
Introduces a new schema awareness API that lets you set up schema awareness by modifying an extension configuration option. 

Docs of this PR: https://github.com/ueberdosis/tiptap-pro/pull/444