### PR TITLE
feat: add PrevNextTiles component for navigation between markdown pages

### DIFF
--- a/src/app/[...markdownPath]/page.tsx
+++ b/src/app/[...markdownPath]/page.tsx
@@ -10,6 +10,7 @@ import { createCanonicalUrl } from '@/server/createCanonicalUrl'
 import { FULL_DOMAIN } from '@/utils/constants'
 import { importSidebarConfigFromMarkdownPath } from '@/server/importSidebarConfigFromMarkdownPath'
 import { Tag } from '@/components/ui/Tag'
+import PrevNextTiles from '@/components/PrevNextTiles'
 
 type Props = {
   params: {
@@ -128,6 +129,7 @@ export default async function MarkdownPage({ params }: Props) {
             </PageHeader.Wrapper>
           ) : null}
           <div className="mdx-content">{pageMdx.default()}</div>
+          <PrevNextTiles config={sidebar.sidebarConfig} currentPath={`/${params.markdownPath.join('/')}`} />
         </Layout.Content>
         {!pageMdx.frontmatter?.sidebars?.hideSecondary ? <Layout.SecondarySidebar /> : null}
       </Layout.Wrapper>

--- a/src/app/[...markdownPath]/page.tsx
+++ b/src/app/[...markdownPath]/page.tsx
@@ -129,7 +129,10 @@ export default async function MarkdownPage({ params }: Props) {
             </PageHeader.Wrapper>
           ) : null}
           <div className="mdx-content">{pageMdx.default()}</div>
-          <PrevNextTiles config={sidebar.sidebarConfig} currentPath={`/${params.markdownPath.join('/')}`} />
+          <PrevNextTiles
+            config={sidebar.sidebarConfig}
+            currentPath={`/${params.markdownPath.join('/')}`}
+          />
         </Layout.Content>
         {!pageMdx.frontmatter?.sidebars?.hideSecondary ? <Layout.SecondarySidebar /> : null}
       </Layout.Wrapper>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { PageHeader } from '@/components/PageHeader'
 import { createCanonicalUrl } from '@/server/createCanonicalUrl'
 import { FULL_DOMAIN } from '@/utils/constants'
 import { importSidebarConfigFromMarkdownPath } from '@/server/importSidebarConfigFromMarkdownPath'
+import PrevNextTiles from '@/components/PrevNextTiles'
 
 export async function generateMetadata() {
   // @ts-ignore
@@ -75,6 +76,7 @@ export default async function HomePage() {
             </PageHeader.Wrapper>
           ) : null}
           <div className="mdx-content">{pageMdx.default()}</div>
+          <PrevNextTiles config={sidebar.sidebarConfig} currentPath="/" />
         </Layout.Content>
         <Layout.SecondarySidebar />
       </Layout.Wrapper>

--- a/src/components/PrevNextTiles.tsx
+++ b/src/components/PrevNextTiles.tsx
@@ -1,0 +1,87 @@
+import { ArrowLeftIcon, ArrowRightIcon } from 'lucide-react'
+import Link from '@/components/Link'
+import { SidebarConfig, SidebarGroup, SidebarLink } from '@/types'
+
+type Props = {
+  config?: SidebarConfig
+  currentPath: string
+}
+
+function normalize(href: string) {
+  if (!href) return '/'
+  // keep absolute URLs untouched
+  if (href.startsWith('http://') || href.startsWith('https://')) return href
+  // ensure leading slash
+  return href.startsWith('/')
+    ? href === '/'
+      ? '/'
+      : href.replace(/\/$/, '')
+    : `/${href.replace(/\/$/, '')}`
+}
+
+function flatten(
+  items: Array<SidebarLink | SidebarGroup | Omit<SidebarLink, 'type'>>,
+): SidebarLink[] {
+  const out: SidebarLink[] = []
+
+  for (const item of items as any[]) {
+    if (item.type === 'group') {
+      const group = item as SidebarGroup
+      if (group.children) {
+        out.push(...flatten(group.children))
+      }
+    } else {
+      // children from sidebar sometimes omit the `type` field, ensure shape
+      const link = item as SidebarLink
+      if (link.href) out.push(link)
+      if ((link as any).children) {
+        out.push(...flatten((link as any).children))
+      }
+    }
+  }
+
+  return out
+}
+
+function Card({ href, title, isNext }: { href: string; title: string; isNext?: boolean }) {
+  return (
+    <Link
+      href={href}
+      className="bg-white group flex gap-6 p-6 items-center border rounded-lg shadow-sm hover:shadow-md transition"
+    >
+      {!isNext ? <ArrowLeftIcon className="size-5 flex-none" /> : null}
+      <span className="flex flex-col gap-2 flex-1">
+        <span className="text-sm text-grayAlpha-500">{isNext ? 'Next up' : 'Previously'}</span>
+        <span className="text-lg font-semibold">{title}</span>
+      </span>
+      {isNext ? <ArrowRightIcon className="size-5 flex-none" /> : null}
+    </Link>
+  )
+}
+
+export default function PrevNextTiles({ config, currentPath }: Props) {
+  if (!config) return null
+
+  const normalizedCurrent = normalize(currentPath)
+  const links = flatten(config.items).filter((l) => !!l.href && !l.external)
+  const normalizedLinks = links.map((l) => ({ ...l, _norm: normalize(l.href) }))
+
+  const idx = normalizedLinks.findIndex((l) => l._norm === normalizedCurrent)
+
+  if (idx === -1) return null
+
+  const prev = idx > 0 ? normalizedLinks[idx - 1] : undefined
+  const next = idx < normalizedLinks.length - 1 ? normalizedLinks[idx + 1] : undefined
+
+  if (!prev && !next) return null
+
+  return (
+    <div className="mt-12">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {prev ? <Card href={prev.href} title={prev.title} /> : <div />}
+
+        {next ? <Card isNext href={next.href} title={next.title} /> : <div />}
+      </div>
+    </div>
+  )
+}

--- a/src/components/PrevNextTiles.tsx
+++ b/src/components/PrevNextTiles.tsx
@@ -89,9 +89,17 @@ export default function PrevNextTiles({ config, currentPath }: Props) {
   return (
     <div className="mt-12">
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        {prev ? <Card href={prev.href} title={prev.title} /> : <div />}
+        {prev ? (
+          <div className="sm:col-start-1">
+            <Card href={prev.href} title={prev.title} />
+          </div>
+        ) : null}
 
-        {next ? <Card isNext href={next.href} title={next.title} /> : <div />}
+        {next ? (
+          <div className={!prev ? 'sm:col-start-2' : ''}>
+            <Card isNext href={next.href} title={next.title} />
+          </div>
+        ) : null}
       </div>
     </div>
   )


### PR DESCRIPTION
<img width="803" height="200" alt="image" src="https://github.com/user-attachments/assets/42ccbaa6-c444-4486-8987-0ff9fc246442" />

This is probably a big improvement for navigation. :D 