### PR TITLE
Update docs for version alpha 24 of the ai toolkit

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 3.0.0-alpha.11
+
+### Major Changes
+
+- Rename `applyDiff` tool to `applyPatch`
+- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations instead of a diff. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
+
 ## 3.0.0-alpha.10
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -13,7 +13,7 @@ meta:
 ### Major Changes
 
 - Rename `applyDiff` tool to `applyPatch`
-- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations instead of a diff. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
+- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
 
 ## 3.0.0-alpha.10
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 3.0.0-alpha.3
+
+### Major Changes
+
+- Rename `applyDiff` tool to `applyPatch`
+- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations instead of a diff. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
+
 ## 3.0.0-alpha.2
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -13,7 +13,7 @@ meta:
 ### Major Changes
 
 - Rename `applyDiff` tool to `applyPatch`
-- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations instead of a diff. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
+- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
 
 ## 3.0.0-alpha.2
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 3.0.0-alpha.7
+
+### Major Changes
+
+- Rename `applyDiff` tool to `applyPatch`
+- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations instead of a diff. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
+
 ## 3.0.0-alpha.6
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -13,7 +13,7 @@ meta:
 ### Major Changes
 
 - Rename `applyDiff` tool to `applyPatch`
-- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations instead of a diff. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
+- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
 
 ## 3.0.0-alpha.6
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 3.0.0-alpha.6
+
+### Major Changes
+
+- Rename `applyDiff` tool to `applyPatch`
+- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations instead of a diff. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
+
 ## 3.0.0-alpha.5
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -13,7 +13,7 @@ meta:
 ### Major Changes
 
 - Rename `applyDiff` tool to `applyPatch`
-- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations instead of a diff. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
+- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
 
 ## 3.0.0-alpha.5
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 3.0.0-alpha.8
+
+### Major Changes
+
+- Rename `applyDiff` tool to `applyPatch`
+- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations instead of a diff. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
+
 ## 3.0.0-alpha.7
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -13,7 +13,7 @@ meta:
 ### Major Changes
 
 - Rename `applyDiff` tool to `applyPatch`
-- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations instead of a diff. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
+- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
 
 ## 3.0.0-alpha.7
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.25
+
+### Patch Changes
+
+- Fix issue (regression) in `applyPatch` tool where the last operation was not being parsed correctly when streaming. This caused the text to gradually disappear during streaming.
+
 ## 3.0.0-alpha.24
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -14,7 +14,7 @@ meta:
 
 - Rename `applyDiff` tool to `applyPatch`
 - Rename `applyHtmlDiff` method to `applyHtmlPatch`.
-- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations instead of a diff. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
+- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
 - Requires upgrading to a version of these provider libraries that is equal or higher than:
   - `@tiptap-pro/ai-toolkit-tool-definitions@3.0.0-alpha.8`
   - `@tiptap-pro/ai-toolkit-ai-sdk@3.0.0-alpha.11`

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,20 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.24
+
+### Major Changes
+
+- Rename `applyDiff` tool to `applyPatch`
+- Rename `applyHtmlDiff` method to `applyHtmlPatch`.
+- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations instead of a diff. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
+- Requires upgrading to a version of these provider libraries that is equal or higher than:
+  - `@tiptap-pro/ai-toolkit-tool-definitions@3.0.0-alpha.8`
+  - `@tiptap-pro/ai-toolkit-ai-sdk@3.0.0-alpha.11`
+  - `@tiptap-pro/ai-toolkit-langchain@3.0.0-alpha.7`
+  - `@tiptap-pro/ai-toolkit-openai@3.0.0-alpha.6`
+  - `@tiptap-pro/ai-toolkit-anthropic@3.0.0-alpha.3`
+
 ## 3.0.0-alpha.23
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/edit-the-document.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/edit-the-document.mdx
@@ -2,7 +2,7 @@
 title: Edit the document
 meta:
   title: Edit the document | Tiptap Content AI
-  description: Insert Text/HTML/JSON and apply precise HTML diffs with review options.
+  description: Edit the document with AI in different formats.
   category: Content AI
 ---
 
@@ -169,17 +169,14 @@ const stream = response.body
 toolkit.streamHtml(stream)
 ```
 
-## `applyHtmlDiff`
+## `applyHtmlPatch`
 
 Apply context-aware HTML diffs to a chunk or the whole document.
 
 ### Parameters
 
-- `diffs` (`HtmlDiff[]`): Each item has:
-  - `context?` (`string`): Text/HTML that appears before `delete` to anchor the change
-  - `delete` (`string`): Exact HTML to remove
-  - `insert` (`string`): HTML to insert
-- `options?` (`ApplyHtmlDiffOptions`): Options for the `applyHtmlDiff` method
+- `operations` (`PatchOperation[]`): A list of patch operations.
+- `options?` (`ApplyHtmlPatchOptions`): Options for the `applyHtmlPatch` method
   - `chunkIndex?` (`number`): Target chunk index. Default: `0`
   - `chunkSize?` (`number`): The maximum size of a string that can be passed as input to the AI model. Prevents the AI from reading too much content at once so that the context window of the AI model is not exceeded. Default: `32000`
   - `reviewOptions?` (`Omit<ReviewOptions, 'diffMode'>`): Control preview/review behavior.
@@ -191,15 +188,44 @@ Apply context-aware HTML diffs to a chunk or the whole document.
       - `renderDecorations?` (`RenderDecorations<{ suggestion: Suggestion }>`): A function to render the suggestion as ProseMirror decorations
     - `metadata?` (`Record<string, any>`): Extra metadata for the suggestions that can be used to store additional information about them (e.g. their source or their category). It is not used internally by the extension but it may help developers customize how the suggestions are displayed in the UI.
 
-### Returns (`ApplyHtmlDiffResult`)
+#### `PatchOperation` (type)
 
-- `errorMessage` (`string | null`): `null` when all diffs applied; error message otherwise
+A `PatchOperation` can be one of two types:
+
+`JumpOperation`: A navigation operation that moves the cursor to a specific context in the document.
+
+- `type` (`'jump'`): The operation type identifier
+- `context` (`string`): The context string to search for and position the cursor after
+
+`ReplaceOperation`: A replace operation that deletes and inserts text at the current cursor position.
+
+Replace operations perform the actual content modifications by removing specified text and replacing it with new text. The delete text must be found at the current cursor position for the operation to succeed.
+
+- `type` (`'replace'`): The operation type identifier
+- `delete` (`string`): The exact text to delete from the document (can be empty for pure insertions)
+- `insert` (`string`): The text to insert in place of the deleted text
+
+### Returns (`ApplyHtmlPatchResult`)
+
+- `docChanged` (`boolean`): Whether the document was modified
+- `error` (`ApplyPatchError | null`): Error if the diff application failed because not all diffs could be applied, null if successful
+
+The method can edit the document but return an error at the same time. This happens when some operations are applied but some fail.
+
+#### `ApplyPatchError` (type)
+
+Error thrown when applying a Universal Patch Format operation fails. This error provides comprehensive context about the failure, including which operation failed, what operations succeeded before it, and the current state of the content.
+
+- `operationIndex` (`number`): The zero-based index of the operation that failed
+- `previousOperations` (`PatchOperation[]`): Array of operations that were successfully applied before the failure
+- `operation` (`PatchOperation`): The operation that failed to apply
+- `contentAfterCursor` (`string`): The content after the current cursor position when the error occurred
 
 ### Example
 
 ```ts
 // Replace "fine" with emphasized "great" in the first chunk
-toolkit.applyHtmlDiff([{ context: '<p>This is ', delete: 'fine', insert: '<em>great</em>' }])
+toolkit.applyHtmlPatch([{ type: 'replace', delete: 'fine', insert: '<em>great</em>' }])
 ```
 
 ---

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/ai-sdk.mdx
@@ -68,7 +68,7 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [Vercel AI SD
 
 - `tools?`: `EnabledTools` - Enable/disable specific tools by setting the value to `true` (enabled) or `false` (disabled).
   - `insertContent?`: `boolean` - Enable/disable the `insertContent` tool (default: `true`)
-  - `applyDiff?`: `boolean` - Enable/disable the `applyDiff` tool (default: `true`)
+  - `applyPatch?`: `boolean` - Enable/disable the `applyPatch` tool (default: `true`)
   - `readNodeRange?`: `boolean` - Enable/disable the `readNodeRange` tool (default: `true`)
   - `readSelection?`: `boolean` - Enable/disable the `readSelection` tool (default: `true`)
 
@@ -77,6 +77,6 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [Vercel AI SD
 An object containing the enabled tool definitions that can be used with the [Vercel AI SDK](https://ai-sdk.dev/)'s tool calling system. The returned object includes:
 
 - `insertContent` - Tool for inserting HTML content at a specific position
-- `applyDiff` - Tool for applying targeted edits via diffs
+- `applyPatch` - Tool for applying small precise edits to the document
 - `readNodeRange` - Tool for reading part of the document by specifying a range of top-level nodes
 - `readSelection` - Tool for reading the currently selected content in the editor

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/anthropic.mdx
@@ -78,7 +78,7 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [Anthropic's 
 
 - `tools?`: `EnabledTools` - Enable/disable specific tools by setting the value to `true` (enabled) or `false` (disabled).
   - `insertContent?`: `boolean` - Enable/disable the `insertContent` tool (default: `true`)
-  - `applyDiff?`: `boolean` - Enable/disable the `applyDiff` tool (default: `true`)
+  - `applyPatch?`: `boolean` - Enable/disable the `applyPatch` tool (default: `true`)
   - `readNodeRange?`: `boolean` - Enable/disable the `readNodeRange` tool (default: `true`)
   - `readSelection?`: `boolean` - Enable/disable the `readSelection` tool (default: `true`)
 
@@ -87,6 +87,6 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [Anthropic's 
 An array containing the enabled tool definitions that can be used with [Anthropic's Messages API](https://docs.claude.com/en/docs/get-started#typescript). The returned array includes:
 
 - `insertContent` - Tool for inserting HTML content at a specific position
-- `applyDiff` - Tool for applying targeted edits via diffs
+- `applyPatch` - Tool for applying small precise edits to the document
 - `readNodeRange` - Tool for reading part of the document by specifying a range of top-level nodes
 - `readSelection` - Tool for reading the currently selected content in the editor

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/available-tools.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/available-tools.mdx
@@ -42,16 +42,15 @@ Insert HTML content at a specific position of the document.
   - `'documentEnd'`: Insert the HTML content at the end of the document
   - `'activeNodeRange'`: Replace the content of the active node range with the HTML content
 
-## `applyDiff`
+## `applyPatch`
 
-Apply targeted edits via diffs to make precise changes to document content.
+Make small precise edits to the document.
 
 ### Parameters
 
-- `diffs` (`Diff[]`): Array of diffs to apply in sequence
-  - `context` (`string`): Context string to help locate the correct position. Must be an exact match.
-  - `delete` (`string`): The content to delete from the document. Must be an exact match.
-  - `insert` (`string`): The content to insert in place of the deleted content. It can be empty for pure deletions.
+- `patch` (`string`): A string in the Universal Patch Format, a language developed by Tiptap for AI document editing. The Universal Patch Format is optimized for small, precise edits, and minimizes token costs when compared to other formats. A string in the Universal Patch Format encodes these operations:
+  - `jump`: Goes to a specific position in the document
+  - `replace`: Deletes some content and inserts new content in its place
 
 ## `readNodeRange`
 

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/langchain-js.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/langchain-js.mdx
@@ -64,7 +64,7 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [LangChain.js
 
 - `tools?`: `EnabledTools` - Enable/disable specific tools by setting the value to `true` (enabled) or `false` (disabled).
   - `insertContent?`: `boolean` - Enable/disable the `insertContent` tool (default: `true`)
-  - `applyDiff?`: `boolean` - Enable/disable the `applyDiff` tool (default: `true`)
+  - `applyPatch?`: `boolean` - Enable/disable the `applyPatch` tool (default: `true`)
   - `readNodeRange?`: `boolean` - Enable/disable the `readNodeRange` tool (default: `true`)
   - `readSelection?`: `boolean` - Enable/disable the `readSelection` tool (default: `true`)
 
@@ -73,6 +73,6 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [LangChain.js
 An array containing the enabled tool definitions that can be used with [LangChain.js](https://js.langchain.com/)'s tool calling system. The returned array includes:
 
 - `insertContent` - Tool for inserting HTML content at a specific position
-- `applyDiff` - Tool for applying targeted edits via diffs
+- `applyPatch` - Tool for applying small precise edits to the document
 - `readNodeRange` - Tool for reading part of the document by specifying a range of top-level nodes
 - `readSelection` - Tool for reading the currently selected content in the editor

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/openai.mdx
@@ -76,7 +76,7 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [OpenAI's res
 
 - `tools?`: `EnabledTools` - Enable/disable specific tools by setting the value to `true` (enabled) or `false` (disabled).
   - `insertContent?`: `boolean` - Enable/disable the `insertContent` tool (default: `true`)
-  - `applyDiff?`: `boolean` - Enable/disable the `applyDiff` tool (default: `true`)
+  - `applyPatch?`: `boolean` - Enable/disable the `applyPatch` tool (default: `true`)
   - `readNodeRange?`: `boolean` - Enable/disable the `readNodeRange` tool (default: `true`)
   - `readSelection?`: `boolean` - Enable/disable the `readSelection` tool (default: `true`)
 
@@ -85,7 +85,7 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [OpenAI's res
 An array containing the enabled tool definitions that can be used with [OpenAI's responses API](https://platform.openai.com/docs/api-reference/responses). The returned array includes:
 
 - `insertContent` - Tool for inserting HTML content at a specific position
-- `applyDiff` - Tool for applying targeted edits via diffs
+- `applyPatch` - Tool for making small precise edits to the document
 - `readNodeRange` - Tool for reading part of the document by specifying a range of top-level nodes
 - `readSelection` - Tool for reading the currently selected content in the editor
 
@@ -97,7 +97,7 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [OpenAI's com
 
 - `tools?`: `EnabledTools` - Enable/disable specific tools. All tools are enabled by default.
   - `insertContent?`: `boolean` - Enable/disable the `insertContent` tool (default: `true`)
-  - `applyDiff?`: `boolean` - Enable/disable the `applyDiff` tool (default: `true`)
+  - `applyPatch?`: `boolean` - Enable/disable the `applyPatch` tool (default: `true`)
   - `readNodeRange?`: `boolean` - Enable/disable the `readNodeRange` tool (default: `true`)
   - `readSelection?`: `boolean` - Enable/disable the `readSelection` tool (default: `true`)
 
@@ -106,6 +106,6 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [OpenAI's com
 An array containing the enabled tool definitions that can be used with [OpenAI's completions API](https://platform.openai.com/docs/api-reference/completions). The returned array includes:
 
 - `insertContent` - Tool for inserting HTML content at a specific position
-- `applyDiff` - Tool for applying targeted edits via diffs
+- `applyPatch` - Tool for making small precise edits to the document
 - `readNodeRange` - Tool for reading part of the document by specifying a range of top-level nodes
 - `readSelection` - Tool for reading the currently selected content in the editor


### PR DESCRIPTION
## 3.0.0-alpha.24

### Major Changes

- Rename `applyDiff` tool to `applyPatch`
- Rename `applyHtmlDiff` method to `applyHtmlPatch`.
- Improve format and tool definition of the `applyDiff` tool (now called `applyPatch`) so that the AI generates a list of patch operations. This improves accuracy (because the AI is not tempted to do unnecessary jumps) and reduces token usage significantly
- Requires upgrading to a version of these provider libraries that is equal or higher than:
  - `@tiptap-pro/ai-toolkit-tool-definitions@3.0.0-alpha.8`
  - `@tiptap-pro/ai-toolkit-ai-sdk@3.0.0-alpha.11`
  - `@tiptap-pro/ai-toolkit-langchain@3.0.0-alpha.7`
  - `@tiptap-pro/ai-toolkit-openai@3.0.0-alpha.6`
  - `@tiptap-pro/ai-toolkit-anthropic@3.0.0-alpha.3`