### PR TITLE
Put ai toolkit demos at the beginning of the guides as well as at the end.

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot.mdx
@@ -30,6 +30,10 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
 Build a simple AI agent chatbot that can read and edit Tiptap documents.
 
+<CodeDemo path="" isScrollable src="https://ai-toolkit-demos.vercel.app/ai-agent-chatbot" />
+
+See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
+
 ## Tech stack
 
 - [React](https://react.dev/) + [Next.js](https://nextjs.org/)

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/inline-edits.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/inline-edits.mdx
@@ -30,6 +30,10 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
 Make simple, small edits to the document. Select content and ask AI model to re-write it based on your instructions.
 
+<CodeDemo path="" isScrollable src="https://ai-toolkit-demos.vercel.app/inline-edits" />
+
+See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
+
 ## Tech stack
 
 - [React](https://react.dev/) + [Next.js](https://nextjs.org/)

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/multi-document.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/multi-document.mdx
@@ -35,6 +35,10 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
 Build an AI agent chatbot that can edit multiple Tiptap documents at once.
 
+<CodeDemo isLarge path="" isScrollable src="https://ai-toolkit-demos.vercel.app/multi-document" />
+
+See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
+
 ## Tech stack
 
 - [React](https://react.dev/) + [Next.js](https://nextjs.org/)

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/review-changes-as-summary.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/review-changes-as-summary.mdx
@@ -24,6 +24,14 @@ After the AI agent finishes its work, show a summary of all the changes.
 
 To implement this feature, we'll use the AI Toolkit's capability to [compare documents in real time](/content-ai/capabilities/ai-toolkit/primitives/compare-documents).
 
+<CodeDemo
+  path=""
+  isScrollable
+  src="https://ai-toolkit-demos.vercel.app/review-changes-as-summary"
+/>
+
+See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
+
 When the user sends a message to the AI, call the `startComparingDocuments` method. This will start comparing the documents before and after the AI made changes.
 
 ```ts

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/review-changes.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/review-changes.mdx
@@ -16,6 +16,10 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 The AI Toolkit lets you show AI-generated changes in a beautiful diff UI, so your users can review and accept or reject them.
 
+<CodeDemo path="" isScrollable src="https://ai-toolkit-demos.vercel.app/review-changes" />
+
+See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
+
 First, configure the `reviewOptions` parameter. Set the mode to `'preview'` to show a preview of the changes before they are applied.
 
 ```ts

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/tool-streaming.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/tool-streaming.mdx
@@ -16,6 +16,10 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 Activate the AI Toolkit's tool streaming capabilities to update the document in real-time while the AI is generating content.
 
+<CodeDemo path="" isScrollable src="https://ai-toolkit-demos.vercel.app/tool-streaming" />
+
+See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
+
 ## Key changes
 
 To add streaming to the AI agent chatbot we built in [the previous guide](/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot), we need to replace the `executeTool` method with the `streamTool` method.

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/compare-documents.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/compare-documents.mdx
@@ -11,6 +11,20 @@ import { Callout } from '@/components/ui/Callout'
 
 Compare two documents in real time and show the diff in the editor.
 
+<CodeDemo
+  isPro
+  isLarge
+  path="/Extensions/AiToolkitCompareDocuments"
+  src="https://deploy-preview-405--tiptap-pro.netlify.app/src/Extensions/AiToolkitCompareDocuments/React/"
+/>
+
+<Callout title="Works in non-AI use cases">
+  This feature does not need AI to work. It can compare any two documents, regardless of whether
+  they are AI-generated or not. A common use case is to compare documents before and after an AI
+  edits them. See the [Review changes
+  guide](/content-ai/capabilities/ai-toolkit/guides/review-changes-as-summary).
+</Callout>
+
 ## Guide: compare two documents
 
 Start by calling the `startComparingDocuments` method. It compares the current document of the editor with another document of your choice. The method takes one parameter: `otherDoc`, the document to compare against.

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/execute-tool.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/execute-tool.mdx
@@ -8,7 +8,7 @@ meta:
 
 Use `executeTool` to apply a tool call from your AI agent to the editor.
 
-Once you've added [tool definitions](/content-ai/capabilities/ai-toolkit/tools/ai-sdk) to your AI agent, the AI agent will generate tool calls. Use the `executeTool` method to apply the tool calls to the editor.
+Once you've added [tool definitions](/content-ai/capabilities/ai-toolkit/tools) to your AI agent, the AI agent will generate tool calls. Use the `executeTool` method to apply the tool calls to the editor.
 
 ## `executeTool`
 


### PR DESCRIPTION
Put ai toolkit demos at the beginning of the guides as well as at the end.

Address this feedback: "Unclear if „Compare Documents“ relies on AI calls or not. As a dumb user I’d assume that it does as it’s inside the AI Toolkit tree."