### PR TITLE
Make the AI Toolkit available in Business plan and above

### DIFF
--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -141,6 +141,18 @@ export const PageHeaderTag = ({
     return <Tag tooltip={tag.tooltip || defaultTooltip}>Available in Team plan</Tag>
   }
 
+  if (tag.type === 'business') {
+    return (
+      <Tag
+        tooltip={
+          tag.tooltip || 'Integrate and use while subscribed to the Business or Enterprise plan.'
+        }
+      >
+        Business plan
+      </Tag>
+    )
+  }
+
   if (tag.type === 'ai') {
     return <Tag tooltip={tag.tooltip}>Content AI</Tag>
   }

--- a/src/content/content-ai/capabilities/ai-toolkit/overview.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: AI Toolkit
 tags:
-  - type: restricted
+  - type: business
   - type: beta
 meta:
   title: AI Toolkit overview | Tiptap Content AI

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ export type GeneralPageTag = {
     | 'team'
     | 'restricted'
     | 'mit'
+    | 'business'
   tooltip?: string
 }
 


### PR DESCRIPTION
Add a tag type for the Business plan.
Make the AI Toolkit available in Business plan and above