### PR TITLE
Add "Copy markdown" button to documentation pages

### DIFF
--- a/src/app/[...markdownPath]/page.tsx
+++ b/src/app/[...markdownPath]/page.tsx
@@ -5,6 +5,7 @@ import { Layout } from '@/components/layouts/Layout'
 import { createMetadata } from '@/server/createMetadata'
 import { PageFrontmatter } from '@/types'
 import { PageHeader } from '@/components/PageHeader'
+import { PageHeaderWithCopyButton } from '@/components/PageHeaderWithCopyButton'
 
 import { createCanonicalUrl } from '@/server/createCanonicalUrl'
 import { FULL_DOMAIN } from '@/utils/constants'
@@ -98,7 +99,10 @@ export default async function MarkdownPage({ params }: Props) {
           {pageMdx.frontmatter ? (
             <PageHeader.Wrapper>
               {sidebar.sidebarConfig ? (
-                <PageHeader.Breadcrumbs config={sidebar.sidebarConfig} />
+                <PageHeaderWithCopyButton
+                  config={sidebar.sidebarConfig}
+                  markdownPath={params.markdownPath}
+                />
               ) : null}
               {pageMdx.frontmatter?.title ? (
                 <PageHeader.Title>{pageMdx.frontmatter.title}</PageHeader.Title>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import { Layout } from '@/components/layouts/Layout'
 import { createMetadata } from '@/server/createMetadata'
 import { PageFrontmatter } from '@/types'
 import { PageHeader } from '@/components/PageHeader'
+import { PageHeaderWithCopyButton } from '@/components/PageHeaderWithCopyButton'
 import { createCanonicalUrl } from '@/server/createCanonicalUrl'
 import { FULL_DOMAIN } from '@/utils/constants'
 import { importSidebarConfigFromMarkdownPath } from '@/server/importSidebarConfigFromMarkdownPath'
@@ -60,7 +61,7 @@ export default async function HomePage() {
           {pageMdx.frontmatter ? (
             <PageHeader.Wrapper>
               {sidebar.sidebarConfig ? (
-                <PageHeader.Breadcrumbs config={sidebar.sidebarConfig} />
+                <PageHeaderWithCopyButton config={sidebar.sidebarConfig} markdownPath={['index']} />
               ) : null}
               <PageHeader.Title>{pageMdx.frontmatter.title}</PageHeader.Title>
               {pageMdx.frontmatter?.tags ? (

--- a/src/components/CopyMarkdownButton.client.tsx
+++ b/src/components/CopyMarkdownButton.client.tsx
@@ -1,9 +1,8 @@
 'use client'
 
 import { useClipboard } from '@mantine/hooks'
-import { CopyIcon } from 'lucide-react'
-import { useCallback } from 'react'
-import { toast } from 'sonner'
+import { CheckIcon, CopyIcon } from 'lucide-react'
+import { useState } from 'react'
 import { cn } from '@/utils'
 
 export type CopyMarkdownButtonClientProps = {
@@ -13,24 +12,28 @@ export type CopyMarkdownButtonClientProps = {
 
 export const CopyMarkdownButtonClient = ({ content, className }: CopyMarkdownButtonClientProps) => {
   const clipboard = useClipboard({ timeout: 500 })
+  const [isCopied, setIsCopied] = useState(false)
 
-  const handleCopy = useCallback(() => {
+  const handleCopy = () => {
+    if (isCopied) return
+    setIsCopied(true)
+    setTimeout(() => setIsCopied(false), 1500)
     clipboard.copy(content)
-    toast('Copied markdown to clipboard', { duration: 1200 })
-  }, [content, clipboard])
+  }
+
+  const IconComponent = isCopied ? CheckIcon : CopyIcon
 
   return (
     <button
       onClick={handleCopy}
       className={cn(
-        'flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700',
-        'bg-gray-50 border border-gray-200 rounded-lg',
-        'hover:bg-gray-100 hover:border-gray-300',
+        'flex items-center gap-2 px-2 py-1 text-sm font-medium text-gray-700',
+        'hover:bg-grayAlpha-100 rounded-lg',
         'transition-colors duration-200',
         className,
       )}
     >
-      <CopyIcon className="size-4" />
+      <IconComponent className="size-4" />
       Copy markdown
     </button>
   )

--- a/src/components/CopyMarkdownButton.client.tsx
+++ b/src/components/CopyMarkdownButton.client.tsx
@@ -11,7 +11,7 @@ export type CopyMarkdownButtonClientProps = {
 }
 
 export const CopyMarkdownButtonClient = ({ content, className }: CopyMarkdownButtonClientProps) => {
-  const clipboard = useClipboard({ timeout: 500 })
+  const clipboard = useClipboard()
   const [isCopied, setIsCopied] = useState(false)
 
   const handleCopy = () => {
@@ -26,6 +26,8 @@ export const CopyMarkdownButtonClient = ({ content, className }: CopyMarkdownBut
   return (
     <button
       onClick={handleCopy}
+      aria-disabled={isCopied}
+      aria-label={isCopied ? 'Copied markdown' : 'Copy markdown'}
       className={cn(
         'flex items-center gap-2 px-2 py-1 text-sm font-medium text-gray-700',
         'hover:bg-grayAlpha-100 rounded-lg',

--- a/src/components/CopyMarkdownButton.client.tsx
+++ b/src/components/CopyMarkdownButton.client.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useClipboard } from '@mantine/hooks'
+import { CopyIcon } from 'lucide-react'
+import { useCallback } from 'react'
+import { toast } from 'sonner'
+import { cn } from '@/utils'
+
+export type CopyMarkdownButtonClientProps = {
+  content: string
+  className?: string
+}
+
+export const CopyMarkdownButtonClient = ({ content, className }: CopyMarkdownButtonClientProps) => {
+  const clipboard = useClipboard({ timeout: 500 })
+
+  const handleCopy = useCallback(() => {
+    clipboard.copy(content)
+    toast('Copied markdown to clipboard', { duration: 1200 })
+  }, [content, clipboard])
+
+  return (
+    <button
+      onClick={handleCopy}
+      className={cn(
+        'flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700',
+        'bg-gray-50 border border-gray-200 rounded-lg',
+        'hover:bg-gray-100 hover:border-gray-300',
+        'transition-colors duration-200',
+        className,
+      )}
+    >
+      <CopyIcon className="size-4" />
+      Copy markdown
+    </button>
+  )
+}

--- a/src/components/CopyMarkdownButton.client.tsx
+++ b/src/components/CopyMarkdownButton.client.tsx
@@ -25,8 +25,9 @@ export const CopyMarkdownButtonClient = ({ content, className }: CopyMarkdownBut
 
   return (
     <button
+      type="button"
       onClick={handleCopy}
-      aria-disabled={isCopied}
+      disabled={isCopied}
       aria-label={isCopied ? 'Copied markdown' : 'Copy markdown'}
       className={cn(
         'flex items-center gap-2 px-2 py-1 text-sm font-medium text-gray-700',

--- a/src/components/CopyMarkdownButton.tsx
+++ b/src/components/CopyMarkdownButton.tsx
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import fs from 'fs/promises'
 import path from 'path'
 import { CopyMarkdownButtonClient } from './CopyMarkdownButton.client'
 
@@ -7,32 +7,67 @@ export type CopyMarkdownButtonProps = {
   className?: string
 }
 
-export const CopyMarkdownButton = ({ markdownPath, className }: CopyMarkdownButtonProps) => {
+// Helper function to sanitize path segments
+const sanitizePathSegment = (segment: string): string => {
+  // Remove any path separators and dangerous characters
+  return segment.replace(/[\/\\]/g, '').replace(/\.{2,}/g, '')
+}
+
+// Helper function to validate that a resolved path is within the content directory
+const isPathWithinContentDir = (resolvedPath: string, contentDir: string): boolean => {
+  const normalizedResolved = path.normalize(resolvedPath)
+  const normalizedContentDir = path.normalize(contentDir)
+  return (
+    normalizedResolved.startsWith(normalizedContentDir + path.sep) ||
+    normalizedResolved === normalizedContentDir
+  )
+}
+
+export const CopyMarkdownButton = async ({ markdownPath, className }: CopyMarkdownButtonProps) => {
   try {
-    const pathArray = markdownPath
-    const directPath = `${pathArray.join('/')}.mdx`
-    const indexPath = `${pathArray.join('/')}/index.mdx`
+    // Sanitize path segments to prevent directory traversal
+    const sanitizedSegments = markdownPath.map(sanitizePathSegment)
+    const directPath = `${sanitizedSegments.join('/')}.mdx`
+    const indexPath = `${sanitizedSegments.join('/')}/index.mdx`
 
     const contentDir = path.join(process.cwd(), 'src/content')
-    const directFilePath = path.join(contentDir, directPath)
-    const indexFilePath = path.join(contentDir, indexPath)
+
+    // Resolve paths and validate they stay within contentDir
+    const directFilePath = path.resolve(contentDir, directPath)
+    const indexFilePath = path.resolve(contentDir, indexPath)
+
+    // Security check: ensure resolved paths are within contentDir
+    if (
+      !isPathWithinContentDir(directFilePath, contentDir) ||
+      !isPathWithinContentDir(indexFilePath, contentDir)
+    ) {
+      console.error('Path traversal attempt detected')
+      return null
+    }
 
     let filePath: string | null = null
 
-    // Check for direct path first
-    if (fs.existsSync(directFilePath)) {
+    // Check for direct path first using async I/O
+    try {
+      await fs.access(directFilePath)
       filePath = directFilePath
-    }
-    // Then check for index path
-    else if (fs.existsSync(indexFilePath)) {
-      filePath = indexFilePath
+    } catch {
+      // Check for index path
+      try {
+        await fs.access(indexFilePath)
+        filePath = indexFilePath
+      } catch {
+        // Neither file exists
+        return null
+      }
     }
 
     if (!filePath) {
       return null
     }
 
-    const content = fs.readFileSync(filePath, 'utf-8')
+    // Read file content asynchronously
+    const content = await fs.readFile(filePath, 'utf-8')
 
     return <CopyMarkdownButtonClient content={content} className={className} />
   } catch (error) {

--- a/src/components/CopyMarkdownButton.tsx
+++ b/src/components/CopyMarkdownButton.tsx
@@ -1,0 +1,42 @@
+import fs from 'fs'
+import path from 'path'
+import { CopyMarkdownButtonClient } from './CopyMarkdownButton.client'
+
+export type CopyMarkdownButtonProps = {
+  markdownPath: string[]
+  className?: string
+}
+
+export const CopyMarkdownButton = ({ markdownPath, className }: CopyMarkdownButtonProps) => {
+  try {
+    const pathArray = markdownPath
+    const directPath = `${pathArray.join('/')}.mdx`
+    const indexPath = `${pathArray.join('/')}/index.mdx`
+
+    const contentDir = path.join(process.cwd(), 'src/content')
+    const directFilePath = path.join(contentDir, directPath)
+    const indexFilePath = path.join(contentDir, indexPath)
+
+    let filePath: string | null = null
+
+    // Check for direct path first
+    if (fs.existsSync(directFilePath)) {
+      filePath = directFilePath
+    }
+    // Then check for index path
+    else if (fs.existsSync(indexFilePath)) {
+      filePath = indexFilePath
+    }
+
+    if (!filePath) {
+      return null
+    }
+
+    const content = fs.readFileSync(filePath, 'utf-8')
+
+    return <CopyMarkdownButtonClient content={content} className={className} />
+  } catch (error) {
+    console.error('Error reading markdown file:', error)
+    return null
+  }
+}

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -14,7 +14,7 @@ const PageHeaderWrapper = forwardRef<HTMLDivElement, PageHeaderWrapperProps>(
   ({ asChild, children, className, ...props }, ref) => {
     const Component = asChild ? Slot : 'header'
 
-    const wrapperClass = cn('mb-12 max-w-[42rem]', className)
+    const wrapperClass = cn('mb-12', className)
 
     return (
       <Component className={wrapperClass} {...props} ref={ref}>
@@ -35,7 +35,7 @@ const PageHeaderTitle = forwardRef<HTMLHeadingElement, PageHeaderTitleProps>(
     const Component = asChild ? Slot : 'h1'
 
     const titleClass = cn(
-      'text-[3.125rem] font-bold text-black leading-none text-balance max-w-[45ch]',
+      'text-[3.125rem] font-bold text-black leading-none text-balance max-w-[42rem]',
       className,
     )
 

--- a/src/components/PageHeaderWithCopyButton.tsx
+++ b/src/components/PageHeaderWithCopyButton.tsx
@@ -1,0 +1,29 @@
+import { CopyMarkdownButton } from './CopyMarkdownButton'
+import { PageHeaderBreadcrumbs } from './PageHeader.client'
+import { SidebarConfig } from '@/types'
+import { cn } from '@/utils'
+
+export type PageHeaderWithCopyButtonProps = {
+  config: SidebarConfig
+  markdownPath?: string[]
+  className?: string
+}
+
+export const PageHeaderWithCopyButton = ({
+  config,
+  markdownPath,
+  className,
+}: PageHeaderWithCopyButtonProps) => {
+  return (
+    <div
+      className={cn(
+        // Stack vertically on mobile (flex-col), horizontally on md+ (flex-row)
+        'flex flex-col items-start md:flex-row justify-between mb-4 gap-2 md:gap-0',
+        className,
+      )}
+    >
+      <PageHeaderBreadcrumbs config={config} />
+      {markdownPath && <CopyMarkdownButton markdownPath={markdownPath} />}
+    </div>
+  )
+}

--- a/src/components/PageHeaderWithCopyButton.tsx
+++ b/src/components/PageHeaderWithCopyButton.tsx
@@ -4,11 +4,25 @@ import { SidebarConfig } from '@/types'
 import { cn } from '@/utils'
 
 export type PageHeaderWithCopyButtonProps = {
+  /**
+   * Configuration for the sidebar. Used by the PageHeaderBreadcrumbs component.
+   */
   config: SidebarConfig
+
+  /**
+   * Path to the markdown file. Used by the CopyMarkdownButton component.
+   */
   markdownPath?: string[]
+
+  /**
+   * Class name for the wrapper div element that organizes the layout of the breadcrumbs and the copy button.
+   */
   className?: string
 }
 
+/**
+ * Contains the breadcrumbs and the copy button, in a horizontal layout.
+ */
 export const PageHeaderWithCopyButton = ({
   config,
   markdownPath,
@@ -17,7 +31,6 @@ export const PageHeaderWithCopyButton = ({
   return (
     <div
       className={cn(
-        // Stack vertically on mobile (flex-col), horizontally on md+ (flex-row)
         'flex flex-col items-start md:flex-row justify-between mb-4 gap-2 md:gap-0',
         className,
       )}

--- a/src/components/PageHeaderWithCopyButton.tsx
+++ b/src/components/PageHeaderWithCopyButton.tsx
@@ -10,12 +10,15 @@ export type PageHeaderWithCopyButtonProps = {
   config: SidebarConfig
 
   /**
-   * Path to the markdown file. Used by the CopyMarkdownButton component.
+   * Path to the markdown file. Used by the CopyMarkdownButton component. It is
+   * formatted as an array of strings where each string is a segment of the
+   * path.
    */
   markdownPath?: string[]
 
   /**
-   * Class name for the wrapper div element that organizes the layout of the breadcrumbs and the copy button.
+   * Class name for the wrapper div element that organizes the layout of the
+   * breadcrumbs and the copy button.
    */
   className?: string
 }


### PR DESCRIPTION
This one is for you, vibe coders.

Inspiration: https://ai-sdk.dev/docs/foundations/overview

## Overview

This PR adds a "Copy Markdown" button that appears next to breadcrumbs on all documentation pages. When clicked, it instantly copies the raw MDX file content to the clipboard with visual feedback.

The implementation uses React Server Components to read the markdown files server-side during SSR, eliminating the need for API calls and providing instant copying. The button shows a copy icon that changes to a check icon for 1.5 seconds after successful copying, providing clean inline feedback without toast notifications.

## Key Changes

- **New Components**: `CopyMarkdownButton.client.tsx` (client interactions), `CopyMarkdownButton.tsx` (server file reading), `PageHeaderWithCopyButton.tsx` (wrapper)
- **Updated Pages**: Modified `[...markdownPath]/page.tsx` and `page.tsx` to use the new wrapper component
- **Removed**: `api/get-markdown/route.ts` (no longer needed)
- **Performance**: Zero network requests for copying, instant clipboard access, smaller bundle size
- **UX**: Responsive design, smooth icon transitions, prevents multiple simultaneous copies