### PR TITLE
Fix broken link and syntax in extend-existing.mdx

### DIFF
--- a/src/content/editor/extensions/custom-extensions/extend-existing.mdx
+++ b/src/content/editor/extensions/custom-extensions/extend-existing.mdx
@@ -10,7 +10,7 @@ import { Callout } from '@/components/ui/Callout'
 
 Every extension has an `extend()` method, which takes an object with everything you want to change or add to it.
 
-Let’s say, you’d like to change the keyboard shortcut for the bullet list. You should start with looking at the source code of the extension, in that case [the `BulletList` node](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-bullet-list/src/bullet-list.ts). For the bespoken example to overwrite the keyboard shortcut, your code could look like this:
+Let’s say, you’d like to change the keyboard shortcut for the bullet list. You should start with looking at the source code of the extension, in that case [the `BulletList` node](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-list/src/bullet-list/bullet-list.ts). For the bespoken example to overwrite the keyboard shortcut, your code could look like this:
 
 ```js
 // 1. Import the extension
@@ -28,7 +28,7 @@ const CustomBulletList = BulletList.extend({
 // 3. Add the custom extension to your editor
 new Editor({
   extensions: [
-    CustomBulletList(),
+    CustomBulletList,
     // …
   ],
 })


### PR DESCRIPTION
### Changes Overview
This PR includes two minor fixes to documentation and a code snippet example related to the [Add to an existing extension](https://tiptap.dev/docs/editor/extensions/custom-extensions/extend-existing) documentation.

### Implementation Approach
1. Fix broken link in BulletList example:
_"Let’s say, you’d like to change the keyboard shortcut for the bullet list. You should start with looking at the source code of the extension, in that case [the BulletList node](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-bullet-list/src/bullet-list.ts). For the bespoken example to overwrite the keyboard shortcut, your code could look like this:"_
- Current: [https://github.com/ueberdosis/tiptap/blob/main/packages/extension-bullet-list/src/bullet-list.ts](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-bullet-list/src/bullet-list.ts)
- New: [https://github.com/ueberdosis/tiptap/blob/main/packages/extension-list/src/bullet-list/bullet-list.ts](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-list/src/bullet-list/bullet-list.ts)

2. Update syntax:
- In the first code snippet referencing `CustomBulletList`, it suggests to add the extension to the editor like a function `CustomBulletList()`. In my experience, this does not work. When removing the parentheses and calling the extension like `CustomBulletList`, it works as expected.

### Related Issues
[#452](https://github.com/ueberdosis/tiptap-docs/issues/452)