### PR TITLE
add ask-ai button to header

### DIFF
--- a/src/app/[...markdownPath]/page.tsx
+++ b/src/app/[...markdownPath]/page.tsx
@@ -13,6 +13,7 @@ import { Tag } from '@/components/ui/Tag'
 import PrevNextTiles from '@/components/PrevNextTiles'
 import { PageHeaderBreadcrumbs } from '@/components/PageHeader.client'
 import { CopyMarkdownButton } from '@/components/CopyMarkdownButton'
+import { AskAi } from '@/components/AskAi'
 
 type Props = {
   params: {
@@ -102,7 +103,10 @@ export default async function MarkdownPage({ params }: Props) {
               {sidebar.sidebarConfig ? (
                 <div className="flex items-start justify-between flex-wrap gap-y-2 mb-4">
                   <PageHeaderBreadcrumbs config={sidebar.sidebarConfig} />
-                  <CopyMarkdownButton markdownPath={params.markdownPath} />
+                  <div className="flex items-center gap-2">
+                    <CopyMarkdownButton markdownPath={params.markdownPath} />
+                    <AskAi />
+                  </div>
                 </div>
               ) : null}
               {pageMdx.frontmatter?.title ? (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -67,7 +67,7 @@ export default function RootLayout({
         <link rel="icon" href={`${FULL_DOMAIN}/favicon.png`} sizes="any" />
         <meta name="docsearch:version" content="2.x" />
       </head>
-      <body className={cn(inter.className, 'font-sans bg-warmGray text-black')}>
+      <body className={cn(inter.className, 'bg-warmGray text-black')}>
         {GTM_ID ? (
           <noscript>
             <iframe

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { AskAi } from '@/components/AskAi'
 import { CopyMarkdownButton } from '@/components/CopyMarkdownButton'
 import { Layout } from '@/components/layouts/Layout'
 import { PageHeader } from '@/components/PageHeader'
@@ -64,7 +65,10 @@ export default async function HomePage() {
               {sidebar.sidebarConfig ? (
                 <div className="flex items-start justify-between flex-wrap gap-y-2 mb-4">
                   <PageHeaderBreadcrumbs config={sidebar.sidebarConfig} />
-                  <CopyMarkdownButton markdownPath={['index']} />
+                  <div className="flex items-center gap-2">
+                    <CopyMarkdownButton markdownPath={['index']} />
+                    <AskAi />
+                  </div>
                 </div>
               ) : null}
               <PageHeader.Title>{pageMdx.frontmatter.title}</PageHeader.Title>

--- a/src/components/AskAi.tsx
+++ b/src/components/AskAi.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import { ChevronDownIcon } from 'lucide-react'
+import { Button } from './ui/Button'
+import { FULL_DOMAIN } from '@/utils/constants'
+
+export const AskAi = () => {
+  const pathname = usePathname()
+  const url = [`${FULL_DOMAIN}`, `${pathname}`].join('')
+  const encoded = encodeURIComponent(`
+You are a helpful AI assistant and expert in Tiptap and ProseMirror.
+
+The user is currently reading this documentation page:
+${url}
+
+Your task:
+- Explain clearly what this page is about and what problem it helps solve.
+- Describe the key concepts, APIs, or components mentioned on the page.
+- Give practical examples or use cases so the user can apply the information right away.
+- If the page contains code, summarize what it does and how to use it.
+- If you cannot directly read the page, give a general explanation of what this topic likely covers in the context of Tiptap.
+- Use plain language and be concise but thorough.
+- End with a short summary of how this feature fits into the bigger Tiptap ecosystem.
+
+Output format:
+1. **Overview**
+2. **How it works**
+3. **Example usage**
+4. **When to use it**
+5. **Related concepts or next steps**
+`)
+
+  const urls = [
+    { key: 'claude', url: `https://claude.ai/new?q=${encoded}`, label: 'Ask Claude' },
+    {
+      key: 'openai',
+      url: `https://chatgpt.com/?hints=search&q=${encoded}`,
+      label: 'Ask OpenAI',
+    },
+    {
+      key: 'perplexity',
+      url: `https://www.perplexity.ai/search?q=${encoded}`,
+      label: 'Ask Perplexity',
+    },
+  ]
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild className="outline-none ring-0">
+        <Button size="small" variant="tertiary">
+          Ask AI <ChevronDownIcon className="size-4" />
+        </Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          sideOffset={5}
+          align="end"
+          className="min-w-[160px] bg-white border border-grayAlpha-200 shadow-cardLight rounded-lg p-1.5"
+        >
+          {urls.map((url) => (
+            <DropdownMenu.Item key={url.key} asChild>
+              <a
+                href={url.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs font-medium text-gray-700 hover:bg-grayAlpha-100 rounded-lg p-2 cursor-pointer outline-none ring-0 flex"
+              >
+                <span className="flex-auto">{url.label}</span>
+              </a>
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}

--- a/src/components/CopyMarkdownButton.client.tsx
+++ b/src/components/CopyMarkdownButton.client.tsx
@@ -3,14 +3,13 @@
 import { useClipboard } from '@mantine/hooks'
 import { CheckIcon, CopyIcon } from 'lucide-react'
 import { useState } from 'react'
-import { cn } from '@/utils'
+import { Button } from './ui/Button'
 
 export type CopyMarkdownButtonClientProps = {
   content: string
-  className?: string
 }
 
-export const CopyMarkdownButtonClient = ({ content, className }: CopyMarkdownButtonClientProps) => {
+export const CopyMarkdownButtonClient = ({ content }: CopyMarkdownButtonClientProps) => {
   const clipboard = useClipboard()
   const [isCopied, setIsCopied] = useState(false)
 
@@ -24,20 +23,16 @@ export const CopyMarkdownButtonClient = ({ content, className }: CopyMarkdownBut
   const IconComponent = isCopied ? CheckIcon : CopyIcon
 
   return (
-    <button
+    <Button
       type="button"
+      size="small"
+      variant="tertiary"
       onClick={handleCopy}
       disabled={isCopied}
       aria-label={isCopied ? 'Copied markdown' : 'Copy markdown'}
-      className={cn(
-        'flex items-center gap-2 px-2 py-1 text-sm font-medium text-gray-700',
-        'hover:bg-grayAlpha-100 rounded-lg',
-        'transition-colors duration-200',
-        className,
-      )}
     >
-      <IconComponent className="size-4" />
+      <IconComponent className="size-3" />
       Copy markdown
-    </button>
+    </Button>
   )
 }

--- a/src/components/CopyMarkdownButton.tsx
+++ b/src/components/CopyMarkdownButton.tsx
@@ -4,7 +4,6 @@ import { CopyMarkdownButtonClient } from './CopyMarkdownButton.client'
 
 export type CopyMarkdownButtonProps = {
   markdownPath: string[]
-  className?: string
 }
 
 // Helper function to sanitize path segments
@@ -23,7 +22,7 @@ const isPathWithinContentDir = (resolvedPath: string, contentDir: string): boole
   )
 }
 
-export const CopyMarkdownButton = async ({ markdownPath, className }: CopyMarkdownButtonProps) => {
+export const CopyMarkdownButton = async ({ markdownPath }: CopyMarkdownButtonProps) => {
   try {
     // Sanitize path segments to prevent directory traversal
     const sanitizedSegments = markdownPath.map(sanitizePathSegment)
@@ -64,7 +63,7 @@ export const CopyMarkdownButton = async ({ markdownPath, className }: CopyMarkdo
     // Read file content asynchronously
     const content = await fs.readFile(filePath, 'utf-8')
 
-    return <CopyMarkdownButtonClient content={content} className={className} />
+    return <CopyMarkdownButtonClient content={content} />
   } catch (error) {
     console.error('Error reading markdown file:', error)
     return null


### PR DESCRIPTION
This pull request introduces a new "Ask AI" feature to the documentation site, allowing users to quickly query external AI services for contextual explanations of the current page. It also refactors the `CopyMarkdownButton` to use a consistent button component and removes unnecessary font styling from the layout. The key changes are grouped below:

<img width="430" height="247" alt="image" src="https://github.com/user-attachments/assets/17c24d2c-ff39-4517-8c71-da7461316e02" />
<img width="470" height="249" alt="image" src="https://github.com/user-attachments/assets/ef0d0e8e-e249-4252-93a1-aa889065ba68" />


**New Feature: AI Assistant Integration**
* Added the `AskAi` component, which provides a dropdown menu to query Claude, OpenAI, and Perplexity with a context-aware prompt based on the current documentation page. (`src/components/AskAi.tsx`)
* Integrated the `AskAi` button into the main page header, alongside the markdown copy button, for easy access. (`src/app/page.tsx`) [[1]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR1) [[2]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR68-R71)

**UI Consistency and Refactoring**
* Refactored `CopyMarkdownButtonClient` to use the shared `Button` component for improved styling consistency and removed the unused `className` prop. (`src/components/CopyMarkdownButton.client.tsx`) [[1]](diffhunk://#diff-e9793796fc57eb2e2e484e2de26c66eab920eea9da5778b7d320f34a5fa0e5baL6-R12) [[2]](diffhunk://#diff-e9793796fc57eb2e2e484e2de26c66eab920eea9da5778b7d320f34a5fa0e5baL27-R36)

**Layout Simplification**
* Removed the redundant `font-sans` class from the root layout's `<body>`, relying on the Inter font for base styling. (`src/app/layout.tsx`)