### PR TITLE
Added new method for create new html suggestions

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/display-suggestions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/display-suggestions.mdx
@@ -227,3 +227,98 @@ function MyComponent() {
   return null
 }
 ```
+
+## `setHTMLSuggestions`
+
+Loads AI-powered suggestions by comparing corrected HTML with the current document content. This method is designed for integration with AI APIs that return corrected text or HTML.
+
+This method supports two input formats:
+
+1. **HTML format**: Provide the corrected HTML and let the toolkit compute the differences automatically
+2. **Changes format**: Provide an array of specific text replacements (insert/delete pairs)
+
+The method uses a diff-based approach to identify changes and creates suggestions at the appropriate document positions.
+
+### Parameters
+
+- `options` (`SetHTMLSuggestionsOptions`): Configuration options
+  - `content?` (`string`): The corrected HTML content from your AI provider. Use this for the HTML-based format. Cannot be used together with `changes`.
+  - `changes?` (`TextChange[]`): Array of text changes in the format `{ insert: string, delete: string }`. Each change specifies text to delete and its replacement. Cannot be used together with `content`.
+  - `range?` (`Range`): Optional range to limit suggestions to a specific portion of the document. If not provided, the entire document will be processed.
+  - `abortSignal?` (`AbortSignal`): Optional abort signal to cancel the operation.
+
+<Callout title="Changes format behavior" variant="info">
+  When using the `changes` format, ALL occurrences of each `delete` text will be replaced with the corresponding `insert` text throughout the specified range. If you need position-specific replacements, use the HTML format instead.
+</Callout>
+
+### Returns
+
+`Promise<SetHTMLSuggestionsResult>`
+
+Returns a promise that resolves to an object containing:
+
+- `suggestions` (`Suggestion[]`): The array of generated suggestions
+
+### Examples
+
+#### HTML format with API integration
+
+```ts
+const toolkit = getAiToolkit(editor)
+
+// Get corrected HTML from your AI API
+const response = await fetch('/api/grammar-check', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ html: editor.getHTML() })
+})
+const { correctedHtml } = await response.json()
+
+// Set suggestions using the corrected HTML
+const result = await toolkit.setHTMLSuggestions({
+  content: correctedHtml
+})
+
+console.log(`Generated ${result.suggestions.length} suggestions`)
+```
+
+#### HTML format with range parameter
+
+```ts
+const toolkit = getAiToolkit(editor)
+
+// Only process a specific range of the document
+await toolkit.setHTMLSuggestions({
+  content: '<p>Corrected paragraph content</p>',
+  range: { from: 0, to: 100 }
+})
+```
+
+#### Changes format with single change
+
+```ts
+const toolkit = getAiToolkit(editor)
+
+// Capitalize all occurrences of 'api' to 'API'
+await toolkit.setHTMLSuggestions({
+  changes: [
+    { insert: 'API', delete: 'api' }
+  ]
+})
+```
+
+#### Changes format with multiple changes
+
+```ts
+const toolkit = getAiToolkit(editor)
+
+// Apply multiple text corrections at once
+await toolkit.setHTMLSuggestions({
+  changes: [
+    { insert: 'JavaScript', delete: 'javascript' },
+    { insert: 'TypeScript', delete: 'typescript' },
+    { insert: 'API', delete: 'api' }
+  ],
+  range: { from: 0, to: 500 }
+})
+```

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/display-suggestions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/display-suggestions.mdx
@@ -228,32 +228,32 @@ function MyComponent() {
 }
 ```
 
-## `setHTMLSuggestions`
+## `getHTMLSuggestions`
 
 Loads AI-powered suggestions by comparing corrected HTML with the current document content. This method is designed for integration with AI APIs that return corrected text or HTML.
 
 This method supports two input formats:
 
-1. **HTML format**: Provide the corrected HTML and let the toolkit compute the differences automatically
-2. **Changes format**: Provide an array of specific text replacements (insert/delete pairs)
+1. **Full document format**: Provide the corrected document and let the toolkit compute the differences automatically
+2. **Changes format**: Provide an array of specific text replacements (delete/insert pairs)
 
 The method uses a diff-based approach to identify changes and creates suggestions at the appropriate document positions.
 
 ### Parameters
 
-- `options` (`SetHTMLSuggestionsOptions`): Configuration options
-  - `content?` (`string`): The corrected HTML content from your AI provider. Use this for the HTML-based format. Cannot be used together with `changes`.
-  - `changes?` (`TextChange[]`): Array of text changes in the format `{ insert: string, delete: string }`. Each change specifies text to delete and its replacement. Cannot be used together with `content`.
-  - `range?` (`Range`): Optional range to limit suggestions to a specific portion of the document. If not provided, the entire document will be processed.
+- `options` (`GetHTMLSuggestionsOptions`): Configuration options
+  - `content?` (`string`): The corrected content from your AI provider (e.g., HTML string). Use this for the full document format. Cannot be used together with `changes`.
+  - `changes?` (`TextChange[]`): Array of text changes in the format `{ delete: string, insert: string }`. Each change specifies text to delete and its replacement. Cannot be used together with `content`.
+  - `range?` (`Range`): Optional range to limit suggestions to a specific portion of the document. The `from` value is **inclusive** and `to` is **exclusive** (`[from, to)`). Values represent **absolute document positions** (starting from 0 at the beginning of the document), using **character offsets** (not node positions). If not provided, the entire document will be processed.
   - `abortSignal?` (`AbortSignal`): Optional abort signal to cancel the operation.
 
 <Callout title="Changes format behavior" variant="info">
-  When using the `changes` format, ALL occurrences of each `delete` text will be replaced with the corresponding `insert` text throughout the specified range. If you need position-specific replacements, use the HTML format instead.
+  When using the `changes` format, ALL occurrences of each `delete` text will be replaced with the corresponding `insert` text throughout the specified range. If you need position-specific replacements, use the full document format instead.
 </Callout>
 
 ### Returns
 
-`Promise<SetHTMLSuggestionsResult>`
+`Promise<GetHTMLSuggestionsResult>`
 
 Returns a promise that resolves to an object containing:
 
@@ -261,7 +261,7 @@ Returns a promise that resolves to an object containing:
 
 ### Examples
 
-#### HTML format with API integration
+#### Full document format with API integration
 
 ```ts
 const toolkit = getAiToolkit(editor)
@@ -275,20 +275,20 @@ const response = await fetch('/api/grammar-check', {
 const { correctedHtml } = await response.json()
 
 // Set suggestions using the corrected HTML
-const result = await toolkit.setHTMLSuggestions({
+const result = await toolkit.getHTMLSuggestions({
   content: correctedHtml
 })
 
 console.log(`Generated ${result.suggestions.length} suggestions`)
 ```
 
-#### HTML format with range parameter
+#### Full document format with range parameter
 
 ```ts
 const toolkit = getAiToolkit(editor)
 
 // Only process a specific range of the document
-await toolkit.setHTMLSuggestions({
+await toolkit.getHTMLSuggestions({
   content: '<p>Corrected paragraph content</p>',
   range: { from: 0, to: 100 }
 })
@@ -300,9 +300,9 @@ await toolkit.setHTMLSuggestions({
 const toolkit = getAiToolkit(editor)
 
 // Capitalize all occurrences of 'api' to 'API'
-await toolkit.setHTMLSuggestions({
+await toolkit.getHTMLSuggestions({
   changes: [
-    { insert: 'API', delete: 'api' }
+    { delete: 'api', insert: 'API' }
   ]
 })
 ```
@@ -313,11 +313,11 @@ await toolkit.setHTMLSuggestions({
 const toolkit = getAiToolkit(editor)
 
 // Apply multiple text corrections at once
-await toolkit.setHTMLSuggestions({
+await toolkit.getHTMLSuggestions({
   changes: [
-    { insert: 'JavaScript', delete: 'javascript' },
-    { insert: 'TypeScript', delete: 'typescript' },
-    { insert: 'API', delete: 'api' }
+    { delete: 'javascript', insert: 'JavaScript' },
+    { delete: 'typescript', insert: 'TypeScript' },
+    { delete: 'api', insert: 'API' }
   ],
   range: { from: 0, to: 500 }
 })

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/display-suggestions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/display-suggestions.mdx
@@ -228,7 +228,7 @@ function MyComponent() {
 }
 ```
 
-## `getHTMLSuggestions`
+## `setHtmlSuggestions`
 
 Loads AI-powered suggestions by comparing corrected HTML with the current document content. This method is designed for integration with AI APIs that return corrected text or HTML.
 
@@ -241,11 +241,10 @@ The method uses a diff-based approach to identify changes and creates suggestion
 
 ### Parameters
 
-- `options` (`GetHTMLSuggestionsOptions`): Configuration options
+- `options` (`SetHtmlSuggestionsOptions`): Configuration options
   - `content?` (`string`): The corrected content from your AI provider (e.g., HTML string). Use this for the full document format. Cannot be used together with `changes`.
   - `changes?` (`TextChange[]`): Array of text changes in the format `{ delete: string, insert: string }`. Each change specifies text to delete and its replacement. Cannot be used together with `content`.
   - `range?` (`Range`): Optional range to limit suggestions to a specific portion of the document. The `from` value is **inclusive** and `to` is **exclusive** (`[from, to)`). Values represent **absolute document positions** (starting from 0 at the beginning of the document), using **character offsets** (not node positions). If not provided, the entire document will be processed.
-  - `abortSignal?` (`AbortSignal`): Optional abort signal to cancel the operation.
 
 <Callout title="Changes format behavior" variant="info">
   When using the `changes` format, ALL occurrences of each `delete` text will be replaced with the corresponding `insert` text throughout the specified range. If you need position-specific replacements, use the full document format instead.
@@ -253,9 +252,9 @@ The method uses a diff-based approach to identify changes and creates suggestion
 
 ### Returns
 
-`Promise<GetHTMLSuggestionsResult>`
+`SetHtmlSuggestionsResult`
 
-Returns a promise that resolves to an object containing:
+Returns an object containing:
 
 - `suggestions` (`Suggestion[]`): The array of generated suggestions
 
@@ -275,7 +274,7 @@ const response = await fetch('/api/grammar-check', {
 const { correctedHtml } = await response.json()
 
 // Set suggestions using the corrected HTML
-const result = await toolkit.getHTMLSuggestions({
+const result = toolkit.setHtmlSuggestions({
   content: correctedHtml
 })
 
@@ -288,7 +287,7 @@ console.log(`Generated ${result.suggestions.length} suggestions`)
 const toolkit = getAiToolkit(editor)
 
 // Only process a specific range of the document
-await toolkit.getHTMLSuggestions({
+toolkit.setHtmlSuggestions({
   content: '<p>Corrected paragraph content</p>',
   range: { from: 0, to: 100 }
 })
@@ -300,7 +299,7 @@ await toolkit.getHTMLSuggestions({
 const toolkit = getAiToolkit(editor)
 
 // Capitalize all occurrences of 'api' to 'API'
-await toolkit.getHTMLSuggestions({
+toolkit.setHtmlSuggestions({
   changes: [
     { delete: 'api', insert: 'API' }
   ]
@@ -313,7 +312,7 @@ await toolkit.getHTMLSuggestions({
 const toolkit = getAiToolkit(editor)
 
 // Apply multiple text corrections at once
-await toolkit.getHTMLSuggestions({
+toolkit.setHtmlSuggestions({
   changes: [
     { delete: 'javascript', insert: 'JavaScript' },
     { delete: 'typescript', insert: 'TypeScript' },


### PR DESCRIPTION
# Whats new

- Added documentation for the new setHTMLSuggestions method to the display-suggestions.mdx file. The method allows loading AI-powered suggestions by comparing corrected HTML with current document content.