### PR TITLE
Documentation for AI Toolkit x Comments support

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 3.0.0-alpha.12
+
+### Major Changes
+
+- Add new `editThreads` and `getThreads` tools for AI-powered comment and thread management
+- Requires upgrading to a version of the `@tiptap-pro/ai-toolkit` package that is equal or higher than `3.0.0-alpha.26`
+
 ## 3.0.0-alpha.11
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 3.0.0-alpha.4
+
+### Major Changes
+
+- Add new `editThreads` and `getThreads` tools for AI-powered comment and thread management
+- Requires upgrading to a version of the `@tiptap-pro/ai-toolkit` package that is equal or higher than `3.0.0-alpha.26`
+
 ## 3.0.0-alpha.3
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 3.0.0-alpha.8
+
+### Major Changes
+
+- Add new `editThreads` and `getThreads` tools for AI-powered comment and thread management
+- Requires upgrading to a version of the `@tiptap-pro/ai-toolkit` package that is equal or higher than `3.0.0-alpha.26`
+
 ## 3.0.0-alpha.7
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 3.0.0-alpha.7
+
+### Major Changes
+
+- Add new `editThreads` and `getThreads` tools for AI-powered comment and thread management
+- Requires upgrading to a version of the `@tiptap-pro/ai-toolkit` package that is equal or higher than `3.0.0-alpha.26`
+
 ## 3.0.0-alpha.6
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 3.0.0-alpha.9
+
+### Major Changes
+
+- Add new `editThreads` and `getThreads` tools for AI-powered comment and thread management
+- Requires upgrading to a version of the `@tiptap-pro/ai-toolkit` package that is equal or higher than `3.0.0-alpha.26`
+
 ## 3.0.0-alpha.8
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.26
+
+### Major Changes
+
+- Add new `editThreads` and `getThreads` tools for AI-powered comment and thread management
+- Requires upgrading to a version of these provider libraries that is equal or higher than:
+  - `@tiptap-pro/ai-toolkit-tool-definitions@3.0.0-alpha.9`
+  - `@tiptap-pro/ai-toolkit-ai-sdk@3.0.0-alpha.12`
+  - `@tiptap-pro/ai-toolkit-anthropic@3.0.0-alpha.4`
+  - `@tiptap-pro/ai-toolkit-langchain@3.0.0-alpha.8`
+  - `@tiptap-pro/ai-toolkit-openai@3.0.0-alpha.7`
+
 ## 3.0.0-alpha.25
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/ai-sdk.mdx
@@ -71,6 +71,8 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [Vercel AI SD
   - `applyPatch?`: `boolean` - Enable/disable the `applyPatch` tool (default: `true`)
   - `readNodeRange?`: `boolean` - Enable/disable the `readNodeRange` tool (default: `true`)
   - `readSelection?`: `boolean` - Enable/disable the `readSelection` tool (default: `true`)
+  - `getThreads?`: `boolean` - Enable/disable the `getThreads` tool (default: `false`)
+  - `editThreads?`: `boolean` - Enable/disable the `editThreads` tool (default: `false`)
 
 #### Returns
 
@@ -80,3 +82,5 @@ An object containing the enabled tool definitions that can be used with the [Ver
 - `applyPatch` - Tool for applying small precise edits to the document
 - `readNodeRange` - Tool for reading part of the document by specifying a range of top-level nodes
 - `readSelection` - Tool for reading the currently selected content in the editor
+- `getThreads` - Tool for retrieving all threads and comments in the document (requires Comments extension)
+- `editThreads` - Tool for performing operations on threads and comments (requires Comments extension)

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/anthropic.mdx
@@ -81,6 +81,8 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [Anthropic's 
   - `applyPatch?`: `boolean` - Enable/disable the `applyPatch` tool (default: `true`)
   - `readNodeRange?`: `boolean` - Enable/disable the `readNodeRange` tool (default: `true`)
   - `readSelection?`: `boolean` - Enable/disable the `readSelection` tool (default: `true`)
+  - `getThreads?`: `boolean` - Enable/disable the `getThreads` tool (default: `false`)
+  - `editThreads?`: `boolean` - Enable/disable the `editThreads` tool (default: `false`)
 
 #### Returns
 
@@ -90,3 +92,5 @@ An array containing the enabled tool definitions that can be used with [Anthropi
 - `applyPatch` - Tool for applying small precise edits to the document
 - `readNodeRange` - Tool for reading part of the document by specifying a range of top-level nodes
 - `readSelection` - Tool for reading the currently selected content in the editor
+- `getThreads` - Tool for retrieving all threads and comments in the document (requires Comments extension)
+- `editThreads` - Tool for performing operations on threads and comments (requires Comments extension)

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/available-tools.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/available-tools.mdx
@@ -91,12 +91,7 @@ No parameters required.
 
 ### Result
 
-- Returns an array of threads, each containing:
-  - `id` (`string`): Unique thread identifier
-  - `location` (`object`): Document location information including node range and HTML content
-  - `comments` (`array`): Array of comments within the thread, each with:
-    - `id` (`string`): Unique comment identifier
-    - `content` (`string`): Comment content in plain text
+The data of all the threads and comments in the document, including their content and location.
 
 ## `editThreads`
 
@@ -104,30 +99,11 @@ Perform operations on threads and comments in the document. This tool enables co
 
 ### Parameters
 
-- `operations` (`array`): Array of operations to perform, each with a `type` field and operation-specific parameters:
+- `operations` (`array`): Array of operations to perform, each with a `type` field and operation-specific parameters.
 
-#### Operation Types
+## Result
 
-**`createThread`**: Creates a new thread with a comment at a specific location
-- `contentBefore` (`string`): The entire HTML content of the paragraph or top-level node before the place where the thread should be created
-- `contentInside` (`string`): The minimal content where the comment is applied (smaller than contentBefore)
-- `firstCommentContent` (`string`): Content of the first comment in the thread
-
-**`createComment`**: Adds a new comment to an existing thread
-- `threadId` (`string`): The ID of the thread to add the comment to
-- `content` (`string`): The content of the new comment
-
-**`updateComment`**: Updates an existing comment
-- `threadId` (`string`): The ID of the thread containing the comment
-- `commentId` (`string`): The ID of the comment to update
-- `content` (`string`): The new content for the comment
-
-**`removeComment`**: Removes a comment from a thread
-- `threadId` (`string`): The ID of the thread containing the comment
-- `commentId` (`string`): The ID of the comment to remove
-
-**`removeThread`**: Removes a thread and all its comments
-- `threadId` (`string`): The ID of the thread to remove
+A success message if the operations were successful, or an error message if they were not.
 
 ### Requirements
 

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/available-tools.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/available-tools.mdx
@@ -80,3 +80,55 @@ No parameters required.
 
 - `selection` (`string`): The selected HTML content
 - `activeNodeRange`: The range of nodes where the selection is located
+
+## `getThreads`
+
+Retrieve all threads and comments in the document. This tool provides comprehensive information about existing discussions and feedback in the document.
+
+### Parameters
+
+No parameters required.
+
+### Result
+
+- Returns an array of threads, each containing:
+  - `id` (`string`): Unique thread identifier
+  - `location` (`object`): Document location information including node range and HTML content
+  - `comments` (`array`): Array of comments within the thread, each with:
+    - `id` (`string`): Unique comment identifier
+    - `content` (`string`): Comment content in plain text
+
+## `editThreads`
+
+Perform operations on threads and comments in the document. This tool enables comprehensive thread and comment management including creating, updating, and deleting threads and comments.
+
+### Parameters
+
+- `operations` (`array`): Array of operations to perform, each with a `type` field and operation-specific parameters:
+
+#### Operation Types
+
+**`createThread`**: Creates a new thread with a comment at a specific location
+- `contentBefore` (`string`): The entire HTML content of the paragraph or top-level node before the place where the thread should be created
+- `contentInside` (`string`): The minimal content where the comment is applied (smaller than contentBefore)
+- `firstCommentContent` (`string`): Content of the first comment in the thread
+
+**`createComment`**: Adds a new comment to an existing thread
+- `threadId` (`string`): The ID of the thread to add the comment to
+- `content` (`string`): The content of the new comment
+
+**`updateComment`**: Updates an existing comment
+- `threadId` (`string`): The ID of the thread containing the comment
+- `commentId` (`string`): The ID of the comment to update
+- `content` (`string`): The new content for the comment
+
+**`removeComment`**: Removes a comment from a thread
+- `threadId` (`string`): The ID of the thread containing the comment
+- `commentId` (`string`): The ID of the comment to remove
+
+**`removeThread`**: Removes a thread and all its comments
+- `threadId` (`string`): The ID of the thread to remove
+
+### Requirements
+
+These tools require the Comments extension to be configured in the editor with a CommentsProvider. The tools are deactivated by default and need to be explicitly enabled.

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/available-tools.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/available-tools.mdx
@@ -101,7 +101,7 @@ Perform operations on threads and comments in the document. This tool enables co
 
 - `operations` (`array`): Array of operations to perform, each with a `type` field and operation-specific parameters.
 
-## Result
+### Result
 
 A success message if the operations were successful, or an error message if they were not.
 

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/langchain-js.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/langchain-js.mdx
@@ -67,6 +67,8 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [LangChain.js
   - `applyPatch?`: `boolean` - Enable/disable the `applyPatch` tool (default: `true`)
   - `readNodeRange?`: `boolean` - Enable/disable the `readNodeRange` tool (default: `true`)
   - `readSelection?`: `boolean` - Enable/disable the `readSelection` tool (default: `true`)
+  - `getThreads?`: `boolean` - Enable/disable the `getThreads` tool (default: `false`)
+  - `editThreads?`: `boolean` - Enable/disable the `editThreads` tool (default: `false`)
 
 #### Returns
 
@@ -76,3 +78,5 @@ An array containing the enabled tool definitions that can be used with [LangChai
 - `applyPatch` - Tool for applying small precise edits to the document
 - `readNodeRange` - Tool for reading part of the document by specifying a range of top-level nodes
 - `readSelection` - Tool for reading the currently selected content in the editor
+- `getThreads` - Tool for retrieving all threads and comments in the document (requires Comments extension)
+- `editThreads` - Tool for performing operations on threads and comments (requires Comments extension)

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/openai.mdx
@@ -79,6 +79,8 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [OpenAI's res
   - `applyPatch?`: `boolean` - Enable/disable the `applyPatch` tool (default: `true`)
   - `readNodeRange?`: `boolean` - Enable/disable the `readNodeRange` tool (default: `true`)
   - `readSelection?`: `boolean` - Enable/disable the `readSelection` tool (default: `true`)
+  - `getThreads?`: `boolean` - Enable/disable the `getThreads` tool (default: `false`)
+  - `editThreads?`: `boolean` - Enable/disable the `editThreads` tool (default: `false`)
 
 #### Returns
 
@@ -88,6 +90,8 @@ An array containing the enabled tool definitions that can be used with [OpenAI's
 - `applyPatch` - Tool for making small precise edits to the document
 - `readNodeRange` - Tool for reading part of the document by specifying a range of top-level nodes
 - `readSelection` - Tool for reading the currently selected content in the editor
+- `getThreads` - Tool for retrieving all threads and comments in the document (requires Comments extension)
+- `editThreads` - Tool for performing operations on threads and comments (requires Comments extension)
 
 ### `completionsApiToolDefinitions`
 
@@ -100,6 +104,8 @@ Creates tool definitions for the Tiptap AI Toolkit compatible with [OpenAI's com
   - `applyPatch?`: `boolean` - Enable/disable the `applyPatch` tool (default: `true`)
   - `readNodeRange?`: `boolean` - Enable/disable the `readNodeRange` tool (default: `true`)
   - `readSelection?`: `boolean` - Enable/disable the `readSelection` tool (default: `true`)
+  - `getThreads?`: `boolean` - Enable/disable the `getThreads` tool (default: `false`)
+  - `editThreads?`: `boolean` - Enable/disable the `editThreads` tool (default: `false`)
 
 #### Returns
 
@@ -109,3 +115,5 @@ An array containing the enabled tool definitions that can be used with [OpenAI's
 - `applyPatch` - Tool for making small precise edits to the document
 - `readNodeRange` - Tool for reading part of the document by specifying a range of top-level nodes
 - `readSelection` - Tool for reading the currently selected content in the editor
+- `getThreads` - Tool for retrieving all threads and comments in the document (requires Comments extension)
+- `editThreads` - Tool for performing operations on threads and comments (requires Comments extension)


### PR DESCRIPTION
Updates the API reference and changelog of the AI Toolkit library to add support for comments.

Does not include guide or example. This will be added in the next PR.