### PR TITLE
Add closing inline code tick

### DIFF
--- a/src/content/editor/api/commands/content/index.mdx
+++ b/src/content/editor/api/commands/content/index.mdx
@@ -11,7 +11,7 @@ Use these commands to dynamically insert, replace, or remove content in your edi
 ## Use Cases
 
 - **Initializing New Documents:** Start fresh with the [`setContent`](/editor/api/commands/content/set-content) command to initialize a clean document or predefined template.
-- **Updating Existing Content:** Use the [`insertContent`](/editor/api/commands/content/insert-content) or [`insertContentAt](/editor/api/commands/content/insert-content-at) commands to add new content or update specific sections based on user interactions.
+- **Updating Existing Content:** Use the [`insertContent`](/editor/api/commands/content/insert-content) or [`insertContentAt`](/editor/api/commands/content/insert-content-at) commands to add new content or update specific sections based on user interactions.
 - **Clearing Content:** Remove all content with the [`clearContent`](/editor/api/commands/content/clear-content) command while maintaining a valid document structure.
 - **Managing User Selections:** Insert or replace content at specific positions or ranges using [`insertContentAt`](/editor/api/commands/content/insert-content-at) according to user selections.
 


### PR DESCRIPTION
Adds a closing inline tick where it was missing in https://tiptap.dev/docs/editor/api/commands/content#use-cases