### PR TITLE
Add link to the AI Toolkit and improve how it is communicated

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/overview.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/overview.mdx
@@ -50,7 +50,7 @@ Use it to build AI agents with document-editing superpowers. Or add custom AI fu
 
 ## Installation guide
 
-The AI Toolkit is restricted to an early access group. [Submit a request](https://tiptap-suite.notion.site/27901ffa3ebc803197d8e4857e5ae394?pvs=105) to join.
+The AI Toolkit is currently in closed access. We onboard customers individually to ensure the best setup. [Request access here](https://tiptap-suite.notion.site/27901ffa3ebc803197d8e4857e5ae394).
 
 Once granted access, configure your package manager by following the [private registry guide](/guides/pro-extensions).
 

--- a/src/content/content-ai/getting-started/overview.mdx
+++ b/src/content/content-ai/getting-started/overview.mdx
@@ -27,7 +27,7 @@ Our AI extensions work out-of-the-box with Tiptap Cloud, so you can deploy them 
   <ProductCard
     title="AI Toolkit"
     description="Give your AI text-editing superpowers. Build AI agents and custom AI integrations."
-    tags={['New', 'Restricted release']}
+    tags={['New']}
     documentationUrl="/content-ai/capabilities/ai-toolkit/overview"
     icon={contentAIIcon.src}
     doubleWidth

--- a/src/content/editor/sidebar.ts
+++ b/src/content/editor/sidebar.ts
@@ -247,7 +247,7 @@ export const sidebarConfig: SidebarConfig = {
           children: [
             {
               href: '/editor/extensions/functionality/ai-agent',
-              title: 'AI Agent',
+              title: 'AI Assistant',
               tags: ['Team'],
               beta: true,
             },
@@ -266,6 +266,12 @@ export const sidebarConfig: SidebarConfig = {
               href: '/editor/extensions/functionality/ai-suggestion',
               title: 'AI Suggestion',
               tags: ['Team'],
+              beta: true,
+            },
+            {
+              href: '/content-ai/capabilities/ai-toolkit',
+              title: 'AI Toolkit',
+              tags: ['Business'],
               beta: true,
             },
             {


### PR DESCRIPTION
- Add link to AI Toolkit in the extensions list
- Improve how closed access group is communicated. Do not talk about "early access", because it's no longer early access. The access requirements are now clear, but it requires private onboarding.
- Do not talk about "Restricted Release" in the Content AI Overview, because it's no longer restricted. The access requirements are now clear, but it requires private onboarding.