### PR TITLE
docs(ui-component): add callout for bun project style

### DIFF
--- a/src/content/ui-components/getting-started/style.mdx
+++ b/src/content/ui-components/getting-started/style.mdx
@@ -17,6 +17,15 @@ Component styles are written in SCSS. The SCSS compiler (`sass` or `sass-embedde
   bundled with whatever you add through the CLI.
 </Callout>
 
+<Callout title="Bun projects automatically convert SCSS to CSS" variant="warning">
+  If you’re using <strong>Bun</strong>, the CLI automatically converts all
+  <code>.scss</code> files into <code>.css</code>
+  files during installation. This means your imports should use <code>.css</code> instead of{' '}
+  <code>.scss</code>, for example: <br />
+  <br /> <code>@import &apos;./styles/_variables.css&apos;;</code>
+  <br /> <code>@import &apos;./styles/_keyframe-animations.css&apos;;</code>
+</Callout>
+
 #### For Next.js
 
 When a template or component is added to your Next.js project, global SCSS files are automatically added in the `styles` directory.

--- a/src/content/ui-components/install/astro.mdx
+++ b/src/content/ui-components/install/astro.mdx
@@ -6,6 +6,8 @@ meta:
   category: UI Components
 ---
 
+import { Callout } from '@/components/ui/Callout'
+
 Use the command below to scaffold a new Astro project with TypeScript.
 
 ```bash
@@ -59,6 +61,15 @@ export default function EditorPage() {
 ```
 
 ## Add Styles
+
+<Callout title="Bun projects automatically convert SCSS to CSS" variant="warning">
+  If you’re using <strong>Bun</strong>, the CLI automatically converts all
+  <code>.scss</code> files into <code>.css</code>
+  files during installation. This means your imports should use <code>.css</code> instead of{' '}
+  <code>.scss</code>, for example: <br />
+  <br /> <code>@import &apos;./styles/_variables.css&apos;;</code>
+  <br /> <code>@import &apos;./styles/_keyframe-animations.css&apos;;</code>
+</Callout>
 
 Before proceeding, ensure that your project includes a CSS reset. If you're using Tailwind CSS, you can skip this step since it comes with a built-in reset.
 

--- a/src/content/ui-components/install/laravel.mdx
+++ b/src/content/ui-components/install/laravel.mdx
@@ -6,6 +6,8 @@ meta:
   category: UI Components
 ---
 
+import { Callout } from '@/components/ui/Callout'
+
 Use the command below to scaffold a new Laravel project with React support:
 
 ```bash
@@ -43,6 +45,15 @@ export default function EditorPage() {
 ```
 
 ## Add Styles
+
+<Callout title="Bun projects automatically convert SCSS to CSS" variant="warning">
+  If you’re using <strong>Bun</strong>, the CLI automatically converts all
+  <code>.scss</code> files into <code>.css</code>
+  files during installation. This means your imports should use <code>.css</code> instead of{' '}
+  <code>.scss</code>, for example: <br />
+  <br /> <code>@import &apos;./styles/_variables.css&apos;;</code>
+  <br /> <code>@import &apos;./styles/_keyframe-animations.css&apos;;</code>
+</Callout>
 
 Before proceeding, ensure that your project includes a CSS reset. If you're using Tailwind CSS, you can skip this step since it comes with a built-in reset.
 

--- a/src/content/ui-components/install/next.mdx
+++ b/src/content/ui-components/install/next.mdx
@@ -58,6 +58,15 @@ export default function App() {
 
 ## Add Styles
 
+<Callout title="Bun projects automatically convert SCSS to CSS" variant="warning">
+  If you’re using <strong>Bun</strong>, the CLI automatically converts all
+  <code>.scss</code> files into <code>.css</code>
+  files during installation. This means your imports should use <code>.css</code> instead of{' '}
+  <code>.scss</code>, for example: <br />
+  <br /> <code>@import &apos;./styles/_variables.css&apos;;</code>
+  <br /> <code>@import &apos;./styles/_keyframe-animations.css&apos;;</code>
+</Callout>
+
 Import the global SCSS styles in the main stylesheet:
 
 **File:** `src/index.css`

--- a/src/content/ui-components/install/react-router.mdx
+++ b/src/content/ui-components/install/react-router.mdx
@@ -6,6 +6,8 @@ meta:
   category: UI Components
 ---
 
+import { Callout } from '@/components/ui/Callout'
+
 Use the command below to scaffold a new React project with TypeScript and then add React Router.
 
 ```bash
@@ -43,6 +45,15 @@ export default function EditorPage() {
 ```
 
 ## Add Styles
+
+<Callout title="Bun projects automatically convert SCSS to CSS" variant="warning">
+  If you’re using <strong>Bun</strong>, the CLI automatically converts all
+  <code>.scss</code> files into <code>.css</code>
+  files during installation. This means your imports should use <code>.css</code> instead of{' '}
+  <code>.scss</code>, for example: <br />
+  <br /> <code>@import &apos;./styles/_variables.css&apos;;</code>
+  <br /> <code>@import &apos;./styles/_keyframe-animations.css&apos;;</code>
+</Callout>
 
 Before proceeding, ensure that your project includes a CSS reset. If you're using Tailwind CSS, you can skip this step since it comes with a built-in reset.
 

--- a/src/content/ui-components/install/vite.mdx
+++ b/src/content/ui-components/install/vite.mdx
@@ -6,6 +6,8 @@ meta:
   category: UI Components
 ---
 
+import { Callout } from '@/components/ui/Callout'
+
 Use the command below to scaffold a new Vite project. When prompted, choose `React + TypeScript`.
 
 ```bash
@@ -97,6 +99,15 @@ export default function App() {
 ```
 
 ## Add Styles
+
+<Callout title="Bun projects automatically convert SCSS to CSS" variant="warning">
+  If you’re using <strong>Bun</strong>, the CLI automatically converts all
+  <code>.scss</code> files into <code>.css</code>
+  files during installation. This means your imports should use <code>.css</code> instead of{' '}
+  <code>.scss</code>, for example: <br />
+  <br /> <code>@import &apos;./styles/_variables.css&apos;;</code>
+  <br /> <code>@import &apos;./styles/_keyframe-animations.css&apos;;</code>
+</Callout>
 
 Before proceeding, ensure that your project includes a CSS reset. If you're using Tailwind CSS, you can skip this step since it comes with a built-in reset.
 

--- a/src/content/ui-components/install/vite.mdx
+++ b/src/content/ui-components/install/vite.mdx
@@ -104,9 +104,11 @@ export default function App() {
   If you’re using <strong>Bun</strong>, the CLI automatically converts all
   <code>.scss</code> files into <code>.css</code>
   files during installation. This means your imports should use <code>.css</code> instead of{' '}
-  <code>.scss</code>, for example: <br />
-  <br /> <code>@import &apos;./styles/_variables.css&apos;;</code>
-  <br /> <code>@import &apos;./styles/_keyframe-animations.css&apos;;</code>
+  <code>.scss</code>, for example:
+
+  ```css
+  @import './styles/_variables.css';
+  @import './styles/_keyframe-animations.css';
 </Callout>
 
 Before proceeding, ensure that your project includes a CSS reset. If you're using Tailwind CSS, you can skip this step since it comes with a built-in reset.

--- a/src/content/ui-components/install/vite.mdx
+++ b/src/content/ui-components/install/vite.mdx
@@ -106,9 +106,11 @@ export default function App() {
   files during installation. This means your imports should use <code>.css</code> instead of{' '}
   <code>.scss</code>, for example:
 
-  ```css
-  @import './styles/_variables.css';
-  @import './styles/_keyframe-animations.css';
+```css
+@import './styles/_variables.css';
+@import './styles/_keyframe-animations.css';
+```
+
 </Callout>
 
 Before proceeding, ensure that your project includes a CSS reset. If you're using Tailwind CSS, you can skip this step since it comes with a built-in reset.


### PR DESCRIPTION
This update adds an additional `<Callout />` section to the **Style Tiptap UI Components** documentation page. It informs users that when using **Bun**, the Tiptap CLI automatically converts `.scss` files into `.css` files, and imports should be updated accordingly.