### PR TITLE
Document changeMergeDistance option in AI Toolkit API reference

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.34
+
+### Minor Changes
+
+- Add `changeMergeDistance` option to `diffUtility`, `startComparingDocuments`, `setSuggestions` (compareDocuments format), `setHtmlSuggestions`, and all edit methods' `reviewOptions`. This allows merging nearby changes when comparing documents by specifying the maximum distance (in document positions) between changes to merge them into a single change.
+
 ## 3.0.0-alpha.33
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/compare-documents.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/compare-documents.mdx
@@ -103,6 +103,7 @@ Starts real-time comparison with another document. Differences are displayed as 
   - `attributes?` (`Record<string, any>`): Attributes added to rendered elements
   - `renderDecorations?` (`RenderDecorations<{ suggestion: Suggestion }>`): Custom rendering function
 - `debounceTimeout?` (`number`): Milliseconds to wait before recomputing diffs. A low value will make the app seem more responsive, but it might cause performance issues in large documents. Default: `500`
+- `changeMergeDistance?` (`number`): Maximum distance (in document positions) between changes to merge them when comparing documents. If two adjacent changes have a distance less than or equal to this value in either rangeA or rangeB, they will be merged into a single change. Set to 0 or undefined to disable merging. Default: `0`
 
 <Callout title="Schema issue" variant="warning">
   The `otherDoc` parameter must have the same schema as the current document. If the other document

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/diff-utility.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/diff-utility.mdx
@@ -17,6 +17,7 @@ Compares two Tiptap documents and returns a list of changes between them.
 - `docA` (`Node`): Original document
 - `docB` (`Node`): Modified document
 - `simplifyChanges?` (`boolean`): Whether to simplify the changes so that if there are multiple changes in the same word, they are merged into one change. Default: `true`
+- `changeMergeDistance?` (`number`): Maximum distance (in document positions) between changes to merge them. If two adjacent changes have a distance less than or equal to this value in either rangeA or rangeB, they will be merged into a single change. Set to 0 or undefined to disable merging. Default: `0`
 
 <Callout title="Schema issue" variant="warning">
   Both documents must have the same schema. If the documents come from different editors, convert

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/display-suggestions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/display-suggestions.mdx
@@ -103,6 +103,7 @@ If two generated suggestions have overlapping ranges, only the first suggestion 
   - `attributes?` (`Record<string, any>`): Attributes added to rendered elements
   - `renderDecorations?` (`RenderDecorations<{ suggestion: Suggestion }>`): Custom rendering function. Defaults to a function renders the suggestion as a diff.
 - `metadata?` (`Record<string, any>`): Extra metadata for the suggestions, that can be used to store additional information about them (e.g. their source or category). It is not used internally by the AI Toolkit extension but it may help developers customize how a suggestion is displayed in the UI.
+- `changeMergeDistance?` (`number`): Maximum distance (in document positions) between changes to merge them. If two adjacent changes have a distance less than or equal to this value in either rangeA or rangeB, they will be merged into a single change. Set to 0 or undefined to disable merging. Default: `0`
 
 <Callout title="Schema issue" variant="warning">
   The `doc` parameter must have the same schema as the current document. If `doc` comes from a
@@ -199,6 +200,7 @@ The method uses a diff-based approach to identify changes and creates suggestion
   - `content?` (`string`): The corrected content from your AI provider (e.g., HTML string). Use this for the full document format. Cannot be used together with `changes`.
   - `changes?` (`TextChange[]`): Array of text changes in the format `{ delete: string, insert: string }`. Each change specifies text to delete and its replacement. Cannot be used together with `content`.
   - `range?` (`Range`): Optional range to limit suggestions to a specific portion of the document. The `from` value is **inclusive** and `to` is **exclusive** (`[from, to)`). Values represent **absolute document positions** (starting from 0 at the beginning of the document), using **character offsets** (not node positions). If not provided, the entire document will be processed.
+  - `changeMergeDistance?` (`number`): Maximum distance (in document positions) between changes to merge them. If two adjacent changes have a distance less than or equal to this value in either rangeA or rangeB, they will be merged into a single change. Set to 0 or undefined to disable merging. Default: `0`
 
 <Callout title="Changes format behavior" variant="info">
   When using the `changes` format, ALL occurrences of each `delete` text will be replaced with the

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/edit-the-document.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/edit-the-document.mdx
@@ -26,6 +26,7 @@ Insert plain text into the editor.
       - `attributes?` (`Record<string, any>`): Extra HTML attributes to be added to the suggestion
       - `renderDecorations?` (`RenderDecorations<{ suggestion: Suggestion }>`): A function to render the suggestion as ProseMirror decorations
     - `metadata?` (`Record<string, any>`): Extra metadata for the suggestions that can be used to store additional information about them (e.g. their source or their category). It is not used internally by the extension but it may help developers customize how the suggestions are displayed in the UI.
+    - `changeMergeDistance?` (`number`): Maximum distance (in document positions) between changes to merge them when comparing documents. If two adjacent changes have a distance less than or equal to this value in either rangeA or rangeB, they will be merged into a single change. Set to 0 to disable merging. Default: `0`
 
 ### Returns
 
@@ -56,6 +57,7 @@ Insert HTML into the editor.
       - `attributes?` (`Record<string, any>`): Extra HTML attributes to be added to the suggestion
       - `renderDecorations?` (`RenderDecorations<{ suggestion: Suggestion }>`): A function to render the suggestion as ProseMirror decorations
     - `metadata?` (`Record<string, any>`): Extra metadata for the suggestions that can be used to store additional information about them (e.g. their source or their category). It is not used internally by the extension but it may help developers customize how the suggestions are displayed in the UI.
+    - `changeMergeDistance?` (`number`): Maximum distance (in document positions) between changes to merge them when comparing documents. If two adjacent changes have a distance less than or equal to this value in either rangeA or rangeB, they will be merged into a single change. Set to 0 to disable merging. Default: `0`
 
 ### Returns
 
@@ -86,6 +88,7 @@ Insert ProseMirror JSON into the editor.
       - `attributes?` (`Record<string, any>`): Extra HTML attributes to be added to the suggestion
       - `renderDecorations?` (`RenderDecorations<{ suggestion: Suggestion }>`): A function to render the suggestion as ProseMirror decorations
     - `metadata?` (`Record<string, any>`): Extra metadata for the suggestions that can be used to store additional information about them (e.g. their source or their category). It is not used internally by the extension but it may help developers customize how the suggestions are displayed in the UI.
+    - `changeMergeDistance?` (`number`): Maximum distance (in document positions) between changes to merge them when comparing documents. If two adjacent changes have a distance less than or equal to this value in either rangeA or rangeB, they will be merged into a single change. Set to 0 to disable merging. Default: `0`
 
 ### Returns
 
@@ -116,6 +119,7 @@ Stream plain text content into the editor in real-time.
       - `attributes?` (`Record<string, any>`): Extra HTML attributes to be added to the suggestion
       - `renderDecorations?` (`RenderDecorations<{ suggestion: Suggestion }>`): A function to render the suggestion as ProseMirror decorations
     - `metadata?` (`Record<string, any>`): Extra metadata for the suggestions that can be used to store additional information about them (e.g. their source or their category). It is not used internally by the extension but it may help developers customize how the suggestions are displayed in the UI.
+    - `changeMergeDistance?` (`number`): Maximum distance (in document positions) between changes to merge them when comparing documents. If two adjacent changes have a distance less than or equal to this value in either rangeA or rangeB, they will be merged into a single change. Set to 0 to disable merging. Default: `0`
   - `checkChunkForError?` (`(status: { chunk: string; content: string; range: Range }) => boolean`): A function to check if the chunk contains an error. Returns `true` if the chunk has an error, `false` otherwise. If `true`, the stream will be stopped and a `StreamingChunkCheckFailedError` will be thrown.
   - `onError?` (`(event: { error: unknown; chunk: string; content: string; range: Range }) => void`): A function to handle errors that occur during streaming.
   - `onChunkInserted?` (`(event: { chunk: string; content: string; range: Range }) => void`): A function to handle when a chunk is streamed. Called after the chunk is inserted into the editor.
@@ -152,6 +156,7 @@ Stream HTML content into the editor in real-time.
       - `attributes?` (`Record<string, any>`): Extra HTML attributes to be added to the suggestion
       - `renderDecorations?` (`RenderDecorations<{ suggestion: Suggestion }>`): A function to render the suggestion as ProseMirror decorations
     - `metadata?` (`Record<string, any>`): Extra metadata for the suggestions that can be used to store additional information about them (e.g. their source or their category). It is not used internally by the extension but it may help developers customize how the suggestions are displayed in the UI.
+    - `changeMergeDistance?` (`number`): Maximum distance (in document positions) between changes to merge them when comparing documents. If two adjacent changes have a distance less than or equal to this value in either rangeA or rangeB, they will be merged into a single change. Set to 0 to disable merging. Default: `0`
   - `checkChunkForError?` (`(status: { chunk: string; content: string; range: Range }) => boolean`): A function to check if the chunk contains an error. Returns `true` if the chunk has an error, `false` otherwise. If `true`, the stream will be stopped and a `StreamingChunkCheckFailedError` will be thrown.
   - `onError?` (`(event: { error: unknown; chunk: string; content: string; range: Range }) => void`): A function to handle errors that occur during streaming.
   - `onChunkInserted?` (`(event: { chunk: string; content: string; range: Range }) => void`): A function to handle when a chunk is streamed. Called after the chunk is inserted into the editor.
@@ -187,6 +192,7 @@ Apply context-aware HTML diffs to a chunk or the whole document.
       - `attributes?` (`Record<string, any>`): Extra HTML attributes to be added to the suggestion
       - `renderDecorations?` (`RenderDecorations<{ suggestion: Suggestion }>`): A function to render the suggestion as ProseMirror decorations
     - `metadata?` (`Record<string, any>`): Extra metadata for the suggestions that can be used to store additional information about them (e.g. their source or their category). It is not used internally by the extension but it may help developers customize how the suggestions are displayed in the UI.
+    - `changeMergeDistance?` (`number`): Maximum distance (in document positions) between changes to merge them when comparing documents. If two adjacent changes have a distance less than or equal to this value in either rangeA or rangeB, they will be merged into a single change. Set to 0 to disable merging. Default: `0`
 
 #### `PatchOperation` (type)
 


### PR DESCRIPTION
Docs of PR https://github.com/ueberdosis/tiptap-pro/pull/460

Updates API reference documentation to include the new `changeMergeDistance` option added in `@tiptap-pro/ai-toolkit@3.0.0-alpha.34`.

## Changes

- Added `changeMergeDistance` parameter documentation to:
  - `compare-documents.mdx` - `startComparingDocuments` method
  - `diff-utility.mdx` - `diffUtility` function
  - `edit-the-document.mdx` - All edit methods' `reviewOptions`
  - `display-suggestions.mdx` - `setSuggestions` (compareDocuments format) and `setHtmlSuggestions` methods
- Updated changelog with new version entry

## Related

- Main repo PR: [link to main repo PR]
- Package version: `@tiptap-pro/ai-toolkit@3.0.0-alpha.34`
