### PR TITLE
Change bubble menu default append location in docs

### DIFF
--- a/src/content/editor/extensions/functionality/bubble-menu.mdx
+++ b/src/content/editor/extensions/functionality/bubble-menu.mdx
@@ -109,7 +109,7 @@ The element to which the bubble menu should be appended to in the DOM. Can be a 
 
 Type: `HTMLElement | (() => HTMLElement) | undefined`
 
-Default: `undefined`, the menu will be appended to `document.body`.
+Default: `undefined`, the menu will be appended to the editor's parent element `(view.dom.parentElement)`.
 
 ### getReferencedVirtualElement
 

--- a/src/content/editor/extensions/functionality/bubble-menu.mdx
+++ b/src/content/editor/extensions/functionality/bubble-menu.mdx
@@ -109,7 +109,7 @@ The element to which the bubble menu should be appended to in the DOM. Can be a 
 
 Type: `HTMLElement | (() => HTMLElement) | undefined`
 
-Default: `undefined`, the menu will be appended to the editor's parent element `(view.dom.parentElement)`.
+Default: `undefined`, the menu will be appended to the editor's parent element `(editor.view.dom.parentElement)`.
 
 ### getReferencedVirtualElement
 

--- a/src/content/editor/extensions/functionality/bubble-menu.mdx
+++ b/src/content/editor/extensions/functionality/bubble-menu.mdx
@@ -109,7 +109,7 @@ The element to which the bubble menu should be appended to in the DOM. Can be a 
 
 Type: `HTMLElement | (() => HTMLElement) | undefined`
 
-Default: `undefined`, the menu will be appended to the editor's parent element `(editor.view.dom.parentElement)`.
+Default: `undefined`, the menu will be appended to the editor's parent element (`editor.view.dom.parentElement`).
 
 ### getReferencedVirtualElement
 


### PR DESCRIPTION
The current documentation states that the default behavior for appendTo (when undefined) is to append the menu to document.body.

This is incorrect. The actual source code (as seen in [bubble-menu-plugin.ts#L531](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-bubble-menu/src/bubble-menu-plugin.ts#L531)) defaults to appending the menu to the editor's parent element (view.dom.parentElement).

Updated the docs of default append location for the bubble menu to the editor's parent element.