### PR TITLE
Update line-height extension documentation

### DIFF
--- a/src/content/editor/extensions/functionality/line-height.mdx
+++ b/src/content/editor/extensions/functionality/line-height.mdx
@@ -23,7 +23,6 @@ extension:
 
 import { CodeDemo } from '@/components/CodeDemo'
 
-This extension enables you to set the line height in the editor. It uses the TextStyle mark, which renders a <span> tag (and only that). The line height is applied as inline style then, for example <span style="line-height: 1.5">.
 This extension enables you to set the *line height* in the editor. It uses the [`TextStyle`](/editor/extensions/marks/text-style) mark, which renders a `<span>` tag (and only that). The line height is applied as inline style then, for example `<span style="line-height: 1.5">`.
 
 <CodeDemo path="/Extensions/LineHeight" />

--- a/src/content/editor/extensions/functionality/line-height.mdx
+++ b/src/content/editor/extensions/functionality/line-height.mdx
@@ -11,19 +11,20 @@ tags:
     label: Downloads
 meta:
   title: Line Height extension | Tiptap Editor Docs
-  description: Add text line-height support to your Tiptap editor with the Color extension. Learn more in our documentation.
+  description: Add text line-height support to your Tiptap editor with the Line Height extension. Learn more in our documentation.
   category: Editor
 extension:
   name: Line Height
   link:
-  description: Add text line-height support to your editor (comes with unlimited colors).
+  description: Add text line-height support to your editor.
   type: extension
   icon: LetterText
 ---
 
 import { CodeDemo } from '@/components/CodeDemo'
 
-This extension enables you to set the background color in the editor. It uses the [`TextStyle`](/editor/extensions/marks/text-style) mark, which renders a `<span>` tag (and only that). The background color is applied as inline style then, for example `<span style="background-color: #958DF1">`.
+This extension enables you to set the line height in the editor. It uses the TextStyle mark, which renders a <span> tag (and only that). The line height is applied as inline style then, for example <span style="line-height: 1.5">.
+This extension enables you to set the *line height* in the editor. It uses the [`TextStyle`](/editor/extensions/marks/text-style) mark, which renders a `<span>` tag (and only that). The line height is applied as inline style then, for example `<span style="line-height: 1.5">`.
 
 <CodeDemo path="/Extensions/LineHeight" />
 
@@ -59,7 +60,7 @@ new Editor({
 
 ### types
 
-A list of marks to which the color attribute should be applied to.
+A list of marks to which the lineHeight attribute should be applied to.
 
 Default: `['textStyle']`
 


### PR DESCRIPTION
lineHeight was incorrectly referencing the background color documentation.  
Corrected it to be line height