### PR TITLE
docs: add text direction and RTL support documentation

### DIFF
--- a/src/content/editor/api/commands/nodes-and-marks/set-text-direction.mdx
+++ b/src/content/editor/api/commands/nodes-and-marks/set-text-direction.mdx
@@ -1,0 +1,47 @@
+---
+title: setTextDirection command
+meta:
+  title: setTextDirection command | Tiptap Editor Docs
+  description: Set text direction for nodes with the setTextDirection command. Control LTR, RTL, and auto direction for proper bidirectional text rendering.
+  category: Editor
+---
+
+The `setTextDirection` command sets the text direction for nodes at the current selection or at a specified position. This is useful for controlling the direction of right-to-left (RTL) languages like Arabic and Hebrew, or for bidirectional text content.
+
+See also: [unsetTextDirection](/editor/api/commands/nodes-and-marks/unset-text-direction)
+
+## Parameters
+
+### direction
+
+The text direction to set. Can be `'ltr'` (left-to-right), `'rtl'` (right-to-left), or `'auto'` (automatically detect based on content).
+
+### position
+
+Optional. The position or range where the direction should be applied. If not provided, the command will use the current selection.
+
+Can be:
+- A number representing a specific position
+- An object with `from` and `to` properties representing a range
+
+## Examples
+
+```js
+// Set RTL direction on current selection
+editor.commands.setTextDirection('rtl')
+
+// Set LTR direction on current selection
+editor.commands.setTextDirection('ltr')
+
+// Set auto direction on current selection
+editor.commands.setTextDirection('auto')
+
+// Set direction on a specific position
+editor.commands.setTextDirection('rtl', 5)
+
+// Set direction on a specific range
+editor.commands.setTextDirection('ltr', { from: 0, to: 10 })
+
+// Chain with other commands
+editor.chain().focus().setTextDirection('rtl').run()
+```

--- a/src/content/editor/api/commands/nodes-and-marks/unset-text-direction.mdx
+++ b/src/content/editor/api/commands/nodes-and-marks/unset-text-direction.mdx
@@ -1,0 +1,37 @@
+---
+title: unsetTextDirection command
+meta:
+  title: unsetTextDirection command | Tiptap Editor Docs
+  description: Remove text direction attributes from nodes with the unsetTextDirection command. Learn more in our docs!
+  category: Editor
+---
+
+The `unsetTextDirection` command removes the text direction attribute from nodes at the current selection or at a specified position. This allows nodes to inherit the direction from the editor's global `textDirection` setting or to have no direction attribute at all.
+
+See also: [setTextDirection](/editor/api/commands/nodes-and-marks/set-text-direction)
+
+## Parameters
+
+### position
+
+Optional. The position or range where the direction should be removed. If not provided, the command will use the current selection.
+
+Can be:
+- A number representing a specific position
+- An object with `from` and `to` properties representing a range
+
+## Examples
+
+```js
+// Remove direction from current selection
+editor.commands.unsetTextDirection()
+
+// Remove direction from a specific position
+editor.commands.unsetTextDirection(5)
+
+// Remove direction from a specific range
+editor.commands.unsetTextDirection({ from: 0, to: 10 })
+
+// Chain with other commands
+editor.chain().focus().unsetTextDirection().run()
+```

--- a/src/content/editor/api/editor.mdx
+++ b/src/content/editor/api/editor.mdx
@@ -94,6 +94,30 @@ new Editor({
 })
 ```
 
+### textDirection
+
+The `textDirection` property sets the text direction for all content in the editor. This is useful for right-to-left (RTL) languages like Arabic and Hebrew, or for bidirectional text content.
+
+| Value       | Description                                                   |
+| ----------- | ------------------------------------------------------------- |
+| `'ltr'`     | Sets left-to-right direction for all content.                |
+| `'rtl'`     | Sets right-to-left direction for all content.                |
+| `'auto'`    | Automatically detects direction based on content.             |
+| `undefined` | No direction attribute is added (default).                    |
+
+```js
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+
+new Editor({
+  content: `<p>مرحبا بك في Tiptap</p>`,
+  extensions: [StarterKit],
+  textDirection: 'auto',
+})
+```
+
+You can also override direction for specific nodes using the `setTextDirection` and `unsetTextDirection` commands. See the [commands documentation](/editor/api/commands) for more details.
+
 ### autofocus
 
 With `autofocus` you can force the cursor to jump in the editor on initialization.

--- a/src/content/editor/sidebar.ts
+++ b/src/content/editor/sidebar.ts
@@ -736,6 +736,10 @@ export const sidebarConfig: SidebarConfig = {
                   title: 'setNode',
                 },
                 {
+                  href: '/editor/api/commands/nodes-and-marks/set-text-direction',
+                  title: 'setTextDirection',
+                },
+                {
                   href: '/editor/api/commands/nodes-and-marks/split-block',
                   title: 'splitBlock',
                 },
@@ -762,6 +766,10 @@ export const sidebarConfig: SidebarConfig = {
                 {
                   href: '/editor/api/commands/nodes-and-marks/unset-mark',
                   title: 'unsetMark',
+                },
+                {
+                  href: '/editor/api/commands/nodes-and-marks/unset-text-direction',
+                  title: 'unsetTextDirection',
                 },
                 {
                   href: '/editor/api/commands/nodes-and-marks/update-attributes',

--- a/src/content/examples/basics/text-direction.mdx
+++ b/src/content/examples/basics/text-direction.mdx
@@ -1,0 +1,60 @@
+---
+title: Text direction & RTL support
+meta:
+  title: Text direction & RTL support example | Tiptap Editor Docs
+  description: Learn how to use text direction controls for RTL languages and bidirectional content with this comprehensive Tiptap example.
+  category: Examples
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+Tiptap includes built-in support for right-to-left (RTL) languages and bidirectional text. This example demonstrates how to set global text direction and control direction on individual nodes.
+
+## Features
+
+- **Global direction control**: Set the default text direction for all content (`ltr`, `rtl`, or `auto`)
+- **Per-node direction**: Override direction for specific nodes using commands
+- **Bidirectional text**: Properly render mixed LTR and RTL content
+- **Multiple languages**: Support for English, Arabic, Hebrew, and other languages
+
+The `auto` setting is particularly useful for bidirectional content, as it automatically detects the text direction based on the first strong directional character in each node.
+
+<CodeDemo path="/Examples/TextDirection" />
+
+## How to use
+
+### Set global direction
+
+Configure the editor with a default text direction:
+
+```js
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+
+const editor = new Editor({
+  extensions: [StarterKit],
+  textDirection: 'auto', // or 'ltr', 'rtl'
+})
+```
+
+### Control direction with commands
+
+Override direction for specific content:
+
+```js
+// Set RTL direction on selected text
+editor.commands.setTextDirection('rtl')
+
+// Set LTR direction on selected text
+editor.commands.setTextDirection('ltr')
+
+// Use automatic detection
+editor.commands.setTextDirection('auto')
+
+// Remove direction override
+editor.commands.unsetTextDirection()
+```
+
+### Use with frameworks
+
+The text direction can be changed dynamically by recreating the editor with a new `textDirection` option. This is demonstrated in the example above with React's `useEditor` hook.

--- a/src/content/examples/index.mdx
+++ b/src/content/examples/index.mdx
@@ -168,6 +168,28 @@ It's hard to get started with a new library. We know that and that's why we crea
     </FilterGrid.Item>
     <FilterGrid.Item filter="Editor">
       <CardGrid.Item asChild>
+        <Link href="/examples/basics/text-direction">
+          <CardGrid.ItemImage
+            asNextImage
+            src={cardCoverDefaultEditor.src}
+            width={cardCoverDefaultEditor.width}
+            height={cardCoverDefaultEditor.height}
+            alt="Image"
+          />
+          <div>
+            <CardGrid.ItemTitle>Text direction & RTL support</CardGrid.ItemTitle>
+            <CardGrid.ItemParagraph>
+              Add support for right-to-left languages and bidirectional text.
+            </CardGrid.ItemParagraph>
+          </div>
+          <CardGrid.ItemFooter>
+            <Tag>Editor</Tag>
+          </CardGrid.ItemFooter>
+        </Link>
+      </CardGrid.Item>
+    </FilterGrid.Item>
+    <FilterGrid.Item filter="Editor">
+      <CardGrid.Item asChild>
         <Link href="/examples/basics/long-texts">
           <CardGrid.ItemImage
             asNextImage

--- a/src/content/examples/sidebar.ts
+++ b/src/content/examples/sidebar.ts
@@ -53,6 +53,10 @@ export const sidebarConfig: SidebarConfig = {
           title: 'Tasks',
           href: '/examples/basics/tasks',
         },
+        {
+          title: 'Text direction & RTL support',
+          href: '/examples/basics/text-direction',
+        },
       ],
     },
     {


### PR DESCRIPTION
Added comprehensive documentation for the new text direction feature:
- textDirection editor option in API reference
- setTextDirection command documentation
- unsetTextDirection command documentation
- Text direction & RTL support example page
- Updated sidebar navigation for all new pages

Relates to ueberdosis/tiptap#3957 & https://github.com/ueberdosis/tiptap/pull/7207