### PR TITLE
docs(ui-components): add React 19 compatibility note and current supported versions

### DIFF
--- a/.changeset/curly-papayas-accept.md
+++ b/.changeset/curly-papayas-accept.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Docs: add React 19 compatibility note and current supported versions on the UI Components overview page

--- a/src/content/ui-components/getting-started/overview.mdx
+++ b/src/content/ui-components/getting-started/overview.mdx
@@ -15,6 +15,13 @@ import cardCoverUIComponents from '@/assets/card-covers/examples/components-prev
 
 Tiptap is headless and modular, giving you full control over the UI. The Tiptap UI Components library provides prebuilt interfaces, so you don’t have to build everything from scratch. Use them as-is or customize them to fit your setup.
 
+<Callout title="React 19 and Framework Compatibility" variant="hint">
+  We’re currently working on upgrading support for React 19 and newer framework versions. Some
+  components may not yet be fully compatible. For now, the UI Components work best with **React 18**
+  (and corresponding framework versions like **Next.js 15**). We’ll update this page once the new
+  versions are fully supported.
+</Callout>
+
 <Section title="Get started">
   <CardGrid.Wrapper>
     <CardGrid.Item asChild>


### PR DESCRIPTION
### What

Adds a Callout hint to the “Integrate Tiptap UI Components” page to clarify current compatibility:
- We’re working on React 19 / latest framework support.
- Best-supported stack today: React 18, Next.js 15 (and equivalents).