### PR TITLE
Add an explanation of how Tiptap JSON works.

### DIFF
--- a/src/content/editor/core-concepts/introduction.mdx
+++ b/src/content/editor/core-concepts/introduction.mdx
@@ -9,7 +9,7 @@ meta:
 
 ## Structure
 
-ProseMirror works with a strict [Schema](/editor/core-concepts/schema), which defines the allowed structure of a document. A document is a tree of headings, paragraphs and others elements, so called nodes. Marks can be attached to a node, e. g. to emphasize part of it. [Commands](/editor/api/commands) change that document programmatically.
+ProseMirror works with a strict [Schema](/editor/core-concepts/schema), which defines the allowed structure of a document. A document is a tree of headings, paragraphs and other elements, called nodes. Marks can be attached to a node, e. g. to emphasize part of it. [Commands](/editor/api/commands) change that document programmatically.
 
 ## State
 
@@ -17,9 +17,9 @@ The document is stored in a state. Changes are applied as transactions to the st
 
 ## Content
 
-The document is stored internally as a [ProseMirror node](https://prosemirror.net/docs/ref/#model.Node), and can be retrieved as a Tiptap JSON object using the `getJSON` method.
+The document is stored internally as a [ProseMirror node](https://prosemirror.net/docs/ref/#model.Node), and can be retrieved as a Tiptap JSON object calling `editor.getJSON()`.
 
-Tiptap JSON is the recommended format for storing the document and manipulating it programmatically. Below is an example Tiptap JSON document:
+Tiptap JSON is the recommended format for storing the document and working with it. Below is an example Tiptap JSON document:
 
 ```json
 {

--- a/src/content/editor/core-concepts/introduction.mdx
+++ b/src/content/editor/core-concepts/introduction.mdx
@@ -11,9 +11,40 @@ meta:
 
 ProseMirror works with a strict [Schema](/editor/core-concepts/schema), which defines the allowed structure of a document. A document is a tree of headings, paragraphs and others elements, so called nodes. Marks can be attached to a node, e. g. to emphasize part of it. [Commands](/editor/api/commands) change that document programmatically.
 
+## State
+
+The document is stored in a state. Changes are applied as transactions to the state. The state has details about the current content, cursor position and selection. You can hook into [events](/editor/api/events), for example to alter transactions before they get applied.
+
 ## Content
 
-The document is stored in a state. All changes are applied as transactions to the state. The state has details about the current content, cursor position and selection. You can hook into a few different [events](/editor/api/events), for example to alter transactions before they get applied.
+The document is stored internally as a [ProseMirror node](https://prosemirror.net/docs/ref/#model.Node), and can be retrieved as a Tiptap JSON object using the `getJSON` method.
+
+Tiptap JSON is the recommended format for storing the document and manipulating it programmatically. Below is an example Tiptap JSON document:
+
+```json
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "paragraph",
+      "attrs": {
+        "textAlign": "center"
+      },
+      "content": [
+        { "type": "text", "text": "Hello, " },
+        {
+          "type": "text",
+          "text": "world",
+          "marks": [{ "type": "bold" }, { "type": "italic" }]
+        },
+        { "type": "text", "text": "!" }
+      ]
+    }
+  ]
+}
+```
+
+A Tiptap JSON document is a tree of nodes. Some nodes can have children, but only text nodes (those with `type: 'text'`) can contain text. Text nodes and other inline nodes can have marks applied to them. Some nodes and marks can have attributes.
 
 ## Extensions
 


### PR DESCRIPTION
Add an explanation and example of Tiptap JSON, the recommended format for storing and manipulating Tiptap documents. This helps developers understand how Tiptap documents are stored and how to work with them, even on the server.

Related PR: https://github.com/ueberdosis/tiptap/pull/7219