### PR TITLE
docs(ui-components): update floating element doc

### DIFF
--- a/.changeset/wacky-keys-shop.md
+++ b/.changeset/wacky-keys-shop.md
@@ -1,0 +1,13 @@
+---
+'tiptap-docs': patch
+---
+
+Updated the floating element documentation:
+
+- Added the missing `referenceElement` prop to the props table.
+- Documented the `isElementWithinEditor` utility.
+- Documented the `isTextSelectionValid` utility.
+- Improved utility documentation with detailed parameter and return-type information.
+- Added complete import statements to all code examples.
+- Added a new example demonstrating `referenceElement` usage.
+- Expanded the Custom Positioning example with clearer implementation details.

--- a/src/content/ui-components/utils-components/floating-element.mdx
+++ b/src/content/ui-components/utils-components/floating-element.mdx
@@ -88,25 +88,27 @@ export const FloatingElementExample = () => {
 
 #### Props
 
-| Name                    | Type                                  | Default                    | Description                                                       |
-| ----------------------- | ------------------------------------- | -------------------------- | ----------------------------------------------------------------- |
-| `editor`                | `Editor \| null`                      | `undefined`                | The Tiptap editor instance to attach to                           |
-| `shouldShow`            | `boolean`                             | `undefined`                | Controls whether the floating element should be visible           |
-| `floatingOptions`       | `Partial<UseFloatingOptions>`         | `undefined`                | Additional options to pass to the floating UI                     |
-| `zIndex`                | `number`                              | `50`                       | Z-index for the floating element                                  |
-| `onOpenChange`          | `(open: boolean) => void`             | `undefined`                | Callback fired when the visibility state changes                  |
-| `onRectChange`          | `(rect: DOMRect \| null) => void`     | `undefined`                | Callback fired when the selection rectangle changes               |
-| `getBoundingClientRect` | `(editor: Editor) => DOMRect \| null` | `getSelectionBoundingRect` | Custom function to determine the position of the floating element |
-| `updateOnScroll`        | `boolean`                             | `true`                     | Whether to update position on scroll events                       |
-| `closeOnEscape`         | `boolean`                             | `true`                     | Whether to close the floating element when Escape key is pressed  |
-| `children`              | `React.ReactNode`                     | `undefined`                | Content to display inside the floating element                    |
+| Name                    | Type                                  | Default                    | Description                                                                                                                   |
+| ----------------------- | ------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `editor`                | `Editor \| null`                      | `undefined`                | The Tiptap editor instance to attach to                                                                                       |
+| `shouldShow`            | `boolean`                             | `undefined`                | Controls whether the floating element should be visible                                                                       |
+| `floatingOptions`       | `Partial<UseFloatingOptions>`         | `undefined`                | Additional options to pass to the floating UI                                                                                 |
+| `zIndex`                | `number`                              | `50`                       | Z-index for the floating element                                                                                              |
+| `onOpenChange`          | `(open: boolean) => void`             | `undefined`                | Callback fired when the visibility state changes                                                                              |
+| `referenceElement`      | `HTMLElement \| null`                 | `undefined`                | Reference element to position the floating element relative to. If provided, this takes precedence over getBoundingClientRect |
+| `getBoundingClientRect` | `(editor: Editor) => DOMRect \| null` | `getSelectionBoundingRect` | Custom function to determine the position of the floating element. Only used if referenceElement is not provided              |
+| `closeOnEscape`         | `boolean`                             | `true`                     | Whether to close the floating element when Escape key is pressed                                                              |
+| `children`              | `React.ReactNode`                     | `undefined`                | Content to display inside the floating element                                                                                |
 
 ## Advanced Usage Examples
 
 ### Basic Floating Toolbar
 
 ```tsx
-function FloatingToolbar() {
+import { shift, flip, offset } from '@floating-ui/react'
+import { FloatingElement } from '@/components/tiptap-ui-utils/floating-element'
+
+function FloatingToolbar({ editor }) {
   return (
     <FloatingElement
       editor={editor}
@@ -124,17 +126,23 @@ function FloatingToolbar() {
 ### Custom Positioning with Mobile Support
 
 ```tsx
-function ResponsiveFloatingMenu() {
+import { FloatingElement } from '@/components/tiptap-ui-utils/floating-element'
+import { useMobile } from '@/hooks/use-mobile'
+
+function ResponsiveFloatingMenu({ editor, isMenuVisible }) {
   const isMobile = useMobile()
+
+  const getCustomRect = (editor) => {
+    // Custom positioning logic
+    // Example: position relative to current cursor
+    return editor.view.coordsAtPos(editor.state.selection.from)
+  }
 
   return (
     <FloatingElement
       editor={editor}
       shouldShow={isMenuVisible}
-      getBoundingClientRect={(editor) => {
-        // Custom positioning logic
-        return getCustomRect(editor)
-      }}
+      getBoundingClientRect={getCustomRect}
       {...(isMobile
         ? {
             style: {
@@ -157,7 +165,11 @@ function ResponsiveFloatingMenu() {
 ### Customize `shouldShow` Floating Menu
 
 ```tsx
-function SelectionMenu() {
+import { useState, useEffect } from 'react'
+import { FloatingElement } from '@/components/tiptap-ui-utils/floating-element'
+import { isSelectionValid } from '@/lib/tiptap-collab-utils'
+
+function SelectionMenu({ editor }) {
   const [isVisible, setIsVisible] = useState(false)
 
   useEffect(() => {
@@ -174,15 +186,48 @@ function SelectionMenu() {
   }, [editor])
 
   return (
-    <FloatingElement
-      editor={editor}
-      shouldShow={isVisible}
-      onRectChange={(rect) => {
-        console.log('Selection rect:', rect)
-      }}
-    >
+    <FloatingElement editor={editor} shouldShow={isVisible}>
       {/* Your floating content here */}
     </FloatingElement>
+  )
+}
+```
+
+### Using Reference Element
+
+Attach the floating element to a specific DOM element instead of the text selection:
+
+```tsx
+import { useState } from 'react'
+import { offset, flip, shift } from '@floating-ui/react'
+import { FloatingElement } from '@/components/tiptap-ui-utils/floating-element'
+
+function ButtonWithTooltip() {
+  const [buttonRef, setButtonRef] = useState<HTMLElement | null>(null)
+  const [showTooltip, setShowTooltip] = useState(false)
+
+  return (
+    <>
+      <button
+        ref={setButtonRef}
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+      >
+        Hover me
+      </button>
+
+      <FloatingElement
+        editor={editor}
+        referenceElement={buttonRef}
+        shouldShow={showTooltip}
+        floatingOptions={{
+          placement: 'top',
+          middleware: [offset(8), flip(), shift()],
+        }}
+      >
+        <div className="tooltip">Helpful tooltip content</div>
+      </FloatingElement>
+    </>
   )
 }
 ```
@@ -193,6 +238,12 @@ function SelectionMenu() {
 
 Gets the bounding rectangle of the current selection in the editor.
 
+**Parameters:**
+
+- `editor` - The Tiptap editor instance
+
+**Returns:** `DOMRect | null` - The bounding rectangle of the current selection
+
 ```tsx
 import { getSelectionBoundingRect } from '@/lib/tiptap-collab-utils'
 
@@ -200,12 +251,63 @@ const rect = getSelectionBoundingRect(editor)
 console.log('Selection bounds:', rect)
 ```
 
-### `isSelectionValid(editor)`
+### `isSelectionValid(editor, selection?, excludedNodeTypes?)`
 
-Checks if the current selection is valid for showing floating elements.
+Checks if the current selection is valid for showing floating elements. Returns `false` for empty selections, code blocks, excluded node types, and table cells.
+
+**Parameters:**
+
+- `editor` - The Tiptap editor instance
+- `selection` (optional) - The selection to validate. Defaults to `editor.state.selection`
+- `excludedNodeTypes` (optional) - Array of node type names to exclude. Defaults to `['imageUpload', 'horizontalRule']`
+
+**Returns:** `boolean` - `true` if the selection is valid for floating elements
 
 ```tsx
 import { isSelectionValid } from '@/lib/tiptap-collab-utils'
 
 const shouldShow = isSelectionValid(editor)
+
+// With custom excluded node types
+const isValid = isSelectionValid(editor, undefined, ['image', 'video'])
+```
+
+### `isTextSelectionValid(editor)`
+
+Checks if the current text selection is valid for editing. Returns `false` for empty selections, code blocks, and node selections.
+
+**Parameters:**
+
+- `editor` - The Tiptap editor instance
+
+**Returns:** `boolean` - `true` if the text selection is valid
+
+```tsx
+import { isTextSelectionValid } from '@/lib/tiptap-collab-utils'
+
+const canEdit = isTextSelectionValid(editor)
+if (canEdit) {
+  // Show text editing toolbar
+}
+```
+
+### `isElementWithinEditor(editor, element)`
+
+Checks if a DOM element is within the editor's DOM tree. Useful for determining click/focus events.
+
+**Parameters:**
+
+- `editor` - The Tiptap editor instance
+- `element` - The DOM element to check
+
+**Returns:** `boolean` - `true` if the element is within the editor
+
+```tsx
+import { isElementWithinEditor } from '@/components/tiptap-ui-utils/floating-element'
+
+const handleClick = (event: MouseEvent) => {
+  if (isElementWithinEditor(editor, event.target as Node)) {
+    console.log('Clicked inside editor')
+  }
+}
 ```


### PR DESCRIPTION
- Add missing `referenceElement` prop to props table
- Document `isElementWithinEditor` utility function
- Document `isTextSelectionValid` utility function
- Enhance utility documentation with detailed parameters and return types
- Add complete imports to all code examples
- Add new example demonstrating `referenceElement` usage
- Improve Custom Positioning example with implementation details