### PR TITLE
docs(ui-components): update code block button doc

### DIFF
--- a/.changeset/two-horses-float.md
+++ b/.changeset/two-horses-float.md
@@ -1,0 +1,8 @@
+---
+'tiptap-docs': patch
+---
+
+Update code block button documentation:
+
+- Added missing imports to `useCodeBlock()` hook example
+- Renamed `handleCodeBlock` to `handleToggle` in hook usage

--- a/src/content/ui-components/components/code-block-button.mdx
+++ b/src/content/ui-components/components/code-block-button.mdx
@@ -40,11 +40,9 @@ A prebuilt React component that toggles code block formatting.
 #### Usage
 
 ```tsx
-import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
+import { useEditor, EditorContent, EditorContext } from '@tiptap/react'
 import { StarterKit } from '@tiptap/starter-kit'
 import { CodeBlockButton } from '@/components/tiptap-ui/code-block-button'
-
-import '@/components/tiptap-node/code-block-node/code-block-node.scss'
 
 export default function MyEditor() {
   const editor = useEditor({
@@ -90,23 +88,21 @@ A custom hook to build your own code block toggle button with full control over 
 #### Usage
 
 ```tsx
+import { useCodeBlock } from '@/components/tiptap-ui/code-block-button'
+import { parseShortcutKeys } from '@/lib/tiptap-utils'
+import { Badge } from '@/components/tiptap-ui-primitive/badge'
+
 function MyCodeBlockButton() {
-  const { isVisible, isActive, canToggle, handleCodeBlock, label, shortcutKeys, Icon } =
-    useCodeBlock({
-      editor: myEditor,
-      hideWhenUnavailable: true,
-      onToggled: () => console.log('Code block toggled!'),
-    })
+  const { isVisible, isActive, canToggle, handleToggle, label, shortcutKeys, Icon } = useCodeBlock({
+    editor: myEditor,
+    hideWhenUnavailable: true,
+    onToggled: () => console.log('Code block toggled!'),
+  })
 
   if (!isVisible) return null
 
   return (
-    <button
-      onClick={handleCodeBlock}
-      disabled={!canToggle}
-      aria-label={label}
-      aria-pressed={isActive}
-    >
+    <button onClick={handleToggle} disabled={!canToggle} aria-label={label} aria-pressed={isActive}>
       <Icon />
       {label}
       {shortcutKeys && <Badge>{parseShortcutKeys({ shortcutKeys })}</Badge>}
@@ -125,15 +121,15 @@ function MyCodeBlockButton() {
 
 #### Return Values
 
-| Name              | Type            | Description                                   |
-| ----------------- | --------------- | --------------------------------------------- |
-| `isVisible`       | `boolean`       | Whether the button should be rendered         |
-| `isActive`        | `boolean`       | If the code block is currently active         |
-| `canToggle`       | `boolean`       | If the code block toggle is currently allowed |
-| `handleCodeBlock` | `() => boolean` | Function to toggle code block formatting      |
-| `label`           | `string`        | Accessible label text for the button          |
-| `shortcutKeys`    | `string`        | Keyboard shortcut (Cmd/Ctrl + Alt + C)        |
-| `Icon`            | `React.FC`      | Icon component for the code block button      |
+| Name           | Type            | Description                                   |
+| -------------- | --------------- | --------------------------------------------- |
+| `isVisible`    | `boolean`       | Whether the button should be rendered         |
+| `isActive`     | `boolean`       | If the code block is currently active         |
+| `canToggle`    | `boolean`       | If the code block toggle is currently allowed |
+| `handleToggle` | `() => boolean` | Function to toggle code block formatting      |
+| `label`        | `string`        | Accessible label text for the button          |
+| `shortcutKeys` | `string`        | Keyboard shortcut (Cmd/Ctrl + Alt + C)        |
+| `Icon`         | `React.FC`      | Icon component for the code block button      |
 
 ## Utilities
 
@@ -141,16 +137,30 @@ function MyCodeBlockButton() {
 
 Checks if code block can be toggled in the current editor state.
 
+**Parameters:**
+
+- `editor`: `Editor | null` - The Tiptap editor instance
+- `turnInto`: `boolean` - Whether to check for convertible node types (default: `true`)
+
+**Returns:** `boolean` - Whether the code block can be toggled
+
 ```tsx
 import { canToggle } from '@/components/tiptap-ui/code-block-button'
 
-const canToggle = canToggle(editor) // Check if can toggle
+const canToggleBlock = canToggle(editor) // Check if can toggle
 const canTurnInto = canToggle(editor, true) // Explicit: check if selection can be turned into a code block
+const canToggleDirect = canToggle(editor, false) // Check if can toggle directly
 ```
 
-#### `toggleCodeBlock(editor)`
+### `toggleCodeBlock(editor)`
 
 Programmatically toggles code block formatting for the current selection.
+
+**Parameters:**
+
+- `editor`: `Editor | null` - The Tiptap editor instance
+
+**Returns:** `boolean` - Whether the toggle was successful
 
 ```tsx
 import { toggleCodeBlock } from '@/components/tiptap-ui/code-block-button'
@@ -159,6 +169,27 @@ const success = toggleCodeBlock(editor)
 if (success) {
   console.log('Code block toggled successfully!')
 }
+```
+
+### `shouldShowButton(props)`
+
+Determines if the code block button should be shown based on editor state and configuration.
+
+**Parameters:**
+
+- `props`: `object`
+  - `editor`: `Editor | null` - The Tiptap editor instance
+  - `hideWhenUnavailable`: `boolean` - Whether to hide when unavailable
+
+**Returns:** `boolean` - Whether the button should be shown
+
+```tsx
+import { shouldShowButton } from '@/components/tiptap-ui/code-block-button'
+
+const shouldShow = shouldShowButton({
+  editor,
+  hideWhenUnavailable: true,
+})
 ```
 
 ## Keyboard Shortcuts


### PR DESCRIPTION
- Added missing imports to `useCodeBlock()` hook example
- Renamed `handleCodeBlock` to `handleToggle` in hook usage
