### PR TITLE
Add missing S3 extension to Server Extensions overview

### DIFF
--- a/.changeset/giant-kids-create.md
+++ b/.changeset/giant-kids-create.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Add missing S3 extension to the Server Extensions overview table.

--- a/src/content/hocuspocus/server/extensions/overview.mdx
+++ b/src/content/hocuspocus/server/extensions/overview.mdx
@@ -19,3 +19,4 @@ We already created some very useful extensions you should check out for sure:
 | [SQLite](/hocuspocus/server/extensions/sqlite)     | Persist documents to SQLite.                                                   |
 | [Throttle](/hocuspocus/server/extensions/throttle) | Throttle connections by ips.                                                   |
 | [Webhook](/hocuspocus/server/extensions/webhook)   | Send document changes via webhook to your API.                                 |
+| [S3](/hocuspocus/server/extensions/s3)             | Persist documents to Amazon S3 or any S3-compatible storage service.           |


### PR DESCRIPTION
This PR adds the missing “S3” extension entry to the Server Extensions overview table.

The S3 extension already exists in the documentation sidebar and has a full page, but the overview list did not include it, creating an inconsistency. This update adds:

- S3 - “Persist documents to Amazon S3 or any S3-compatible storage service.”

This keeps the overview consistent with the rest of the extensions (Database, Logger, Redis, SQLite, Throttle, Webhook).

This is a documentation-only change.

Related discussions: N/A
Related issues: N/A

A changeset has been added (patch).

**Before:**
<img width="1617" height="403" alt="image" src="https://github.com/user-attachments/assets/e4cb6908-891d-41a6-ac85-1821078bc8b0" />

**After:**
<img width="1913" height="647" alt="image" src="https://github.com/user-attachments/assets/c25540f7-e907-41e9-870e-87494df38fd9" />

