### PR TITLE
Update AI Toolkit and Pages documentation and UI

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -276,7 +276,7 @@ const nextConfig = {
       },
       {
         source: '/content-ai/capabilities/ai-toolkit/advanced-guides',
-        destination: '/content-ai/capabilities/ai-toolkit/advanced-guides/multi-document',
+        destination: '/content-ai/capabilities/ai-toolkit/advanced-guides/ai-engineering',
         permanent: true,
       },
       {

--- a/src/components/EnterpriseCallout.tsx
+++ b/src/components/EnterpriseCallout.tsx
@@ -5,14 +5,7 @@ import { Button } from './ui/Button'
 import { cn } from '@/utils'
 
 export type EnterpriseCalloutProps = {
-  variant:
-    | 'migration'
-    | 'ai-agent'
-    | 'ai-toolkit'
-    | 'pages'
-    | 'semantic-search'
-    | 'docx'
-    | 'deprecated'
+  variant: 'migration' | 'ai-agent' | 'ai-toolkit' | 'semantic-search' | 'docx' | 'deprecated'
   inline?: boolean
   disableWaitlist?: boolean
   inverted?: boolean
@@ -29,14 +22,12 @@ export const EnterpriseCallout = forwardRef<HTMLDivElement, EnterpriseCalloutPro
         : variant === 'ai-agent'
           ? 'Build AI Agents with expert support'
           : variant === 'ai-toolkit'
-            ? 'Integrate the AI Toolkit'
-            : variant === 'pages'
-              ? 'Integrate Pages with expert support'
-              : variant === 'docx'
-                ? 'Ship DOCX faster with expert support'
-                : variant === 'deprecated'
-                  ? 'Migrate to AI Toolkit'
-                  : 'Join the semantic search beta'
+            ? 'Add AI Toolkit to your subscription'
+            : variant === 'docx'
+              ? 'Ship DOCX faster with expert support'
+              : variant === 'deprecated'
+                ? 'Migrate to AI Toolkit'
+                : 'Join the semantic search beta'
 
     const description =
       variant === 'migration'
@@ -44,30 +35,28 @@ export const EnterpriseCallout = forwardRef<HTMLDivElement, EnterpriseCalloutPro
         : variant === 'ai-agent'
           ? "We're onboarding Enterprise teams building real-time editors. Get direct support for Agent setup, LLM integration, and performance tuning."
           : variant === 'ai-toolkit'
-            ? "Get started by subscribing to the Business plan. We'll guide your integration with dedicated engineering support via Slack."
-            : variant === 'pages'
-              ? "We're onboarding Enterprise teams ready to implement the page layout. Get direct engineering support and shape the product roadmap."
-              : variant === 'docx'
-                ? 'Get dedicated Slack support, priority features, and hands-on help from our engineers to integrate DOCX into your enterprise application.'
-                : variant === 'deprecated'
-                  ? "The AI Toolkit replaces this extension with better performance and more features. Your current setup keeps working. We'll help you migrate when ready."
-                  : 'Build intelligent search with dedicated engineering help and shape vector search capabilities by joining the Enterprise Beta program.'
+            ? 'Reach out to add AI Toolkit to your subscription. We can guide your integration with dedicated engineering support via Slack.'
+            : variant === 'docx'
+              ? 'Get dedicated Slack support, priority features, and hands-on help from our engineers to integrate DOCX into your enterprise application.'
+              : variant === 'deprecated'
+                ? "The AI Toolkit replaces this extension with better performance and more features. Your current setup keeps working. We'll help you migrate when ready."
+                : 'Build intelligent search with dedicated engineering help and shape vector search capabilities by joining the Enterprise Beta program.'
 
     const waitlistText = 'On a different plan? Join the'
 
     const waitlistUrl =
       variant === 'ai-toolkit'
-        ? 'https://tiptap-suite.notion.site/27901ffa3ebc803197d8e4857e5ae394?pvs=105'
-        : 'https://tiptap-suite.notion.site/1b601ffa3ebc80a281a8ea0b03b19bdd?pvs=105'
+        ? 'https://tiptap.dev/contact-sales?form=ai-toolkit'
+        : 'https://tiptap.dev/contact-sales?form=ai-toolkit'
 
     const talkToEngineerUrl =
       variant === 'ai-toolkit'
-        ? 'https://tiptap-suite.notion.site/27901ffa3ebc803197d8e4857e5ae394?pvs=105'
+        ? 'https://tiptap.dev/contact-sales?form=ai-toolkit'
         : variant === 'deprecated'
-          ? 'mailto:humans@tiptap.dev'
-          : 'https://tiptap.dev/contact-sales'
+          ? 'https://tiptap.dev/contact-sales?form=ai-toolkit'
+          : 'https://tiptap.dev/contact-sales?form=ai-toolkit'
 
-    const buttonText = variant === 'deprecated' ? 'Contact us' : 'Talk to an engineer'
+    const buttonText = variant === 'deprecated' ? 'Talk to an engineer' : 'Talk to an engineer'
 
     if (inline) {
       return (

--- a/src/components/EnterpriseCalloutAuto.tsx
+++ b/src/components/EnterpriseCalloutAuto.tsx
@@ -5,14 +5,7 @@ import { createPortal } from 'react-dom'
 import { EnterpriseCallout } from './EnterpriseCallout'
 
 export type EnterpriseCalloutAutoProps = {
-  variant:
-    | 'migration'
-    | 'ai-agent'
-    | 'ai-toolkit'
-    | 'pages'
-    | 'semantic-search'
-    | 'docx'
-    | 'deprecated'
+  variant: 'migration' | 'ai-agent' | 'ai-toolkit' | 'semantic-search' | 'docx' | 'deprecated'
   renderMode?: 'inline' | 'sidebar'
   disableWaitlist?: boolean
   inverted?: boolean

--- a/src/components/ExtensionGrid.tsx
+++ b/src/components/ExtensionGrid.tsx
@@ -17,6 +17,7 @@ const SEARCH_FILTER = {
   OPEN_SOURCE: 'opensource',
   START: 'start',
   TEAM: 'team',
+  ADDON: 'addon',
 } as const
 
 type SearchFilter = (typeof SEARCH_FILTER)[keyof typeof SEARCH_FILTER]
@@ -49,6 +50,10 @@ function useSearch() {
     setFilter(SEARCH_FILTER.TEAM)
   }, [])
 
+  const showAddon = useCallback(() => {
+    setFilter(SEARCH_FILTER.ADDON)
+  }, [])
+
   return {
     query,
     handleInput,
@@ -58,6 +63,7 @@ function useSearch() {
     showOpenSource,
     showStart,
     showTeam,
+    showAddon,
   }
 }
 
@@ -83,6 +89,15 @@ function useFilteredExtensions(
       // Check if it's either a Team extension or also has Start tag
       return (
         (ext.tags?.includes('Team') || ext.tags?.includes('Start')) &&
+        (ext.name.toLowerCase().includes(query.toLowerCase()) ||
+          ext.description.toLowerCase().includes(query.toLowerCase()))
+      )
+    }
+
+    // When "Addon" is selected, show only Addon extensions
+    if (filter === SEARCH_FILTER.ADDON) {
+      return (
+        ext.tags?.includes('Addon') &&
         (ext.name.toLowerCase().includes(query.toLowerCase()) ||
           ext.description.toLowerCase().includes(query.toLowerCase()))
       )
@@ -184,8 +199,17 @@ export const ExtensionGrid = ({
   nodeExtensions,
   hideAll,
 }: ExtensionGridProps) => {
-  const { clear, handleInput, query, filter, showAll, showOpenSource, showStart, showTeam } =
-    useSearch()
+  const {
+    clear,
+    handleInput,
+    query,
+    filter,
+    showAll,
+    showOpenSource,
+    showStart,
+    showTeam,
+    showAddon,
+  } = useSearch()
   const allExtensions = useAllExtensions(nodeExtensions, markExtensions, functionalityExtensions)
   const filteredNodeExtensions = useFilteredExtensions(query, nodeExtensions, filter)
   const filteredMarkExtensions = useFilteredExtensions(query, markExtensions, filter)
@@ -205,6 +229,10 @@ export const ExtensionGrid = ({
   )
   const hasTeamExtensions = useMemo(
     () => allExtensions.some((ext) => ext.tags?.includes('Team')),
+    [allExtensions],
+  )
+  const hasAddonExtensions = useMemo(
+    () => allExtensions.some((ext) => ext.tags?.includes('Addon')),
     [allExtensions],
   )
 
@@ -251,6 +279,11 @@ export const ExtensionGrid = ({
           {hasTeamExtensions ? (
             <FilterButton isActive={filter === SEARCH_FILTER.TEAM} onClick={showTeam}>
               Team Plan
+            </FilterButton>
+          ) : null}
+          {hasAddonExtensions ? (
+            <FilterButton isActive={filter === SEARCH_FILTER.ADDON} onClick={showAddon}>
+              Add-on
             </FilterButton>
           ) : null}
         </div>

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -126,6 +126,12 @@ export const PageHeaderTag = ({
     return <Tag tooltip={tag.tooltip || defaultTooltip}>Available in Start plan</Tag>
   }
 
+  if (tag.type === 'addon') {
+    return (
+      <Tag tooltip={tag.tooltip || 'Add AI Toolkit to your subscription'}>Add-on for any plan</Tag>
+    )
+  }
+
   if (tag.type === 'mit') {
     return (
       <Tag variant="invert" tooltip={tag.tooltip || 'Free to use under MIT license.'}>

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/multi-document.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/multi-document.mdx
@@ -12,7 +12,7 @@ import { Requirements, RequirementItem } from '@/components/Requirements'
 
 <Requirements>
   <RequirementItem label="1. Get access">
-    Subscribe to the <a href="https://tiptap.dev/pricing">Business plan</a> and schedule your onboarding call from the <a href="https://cloud.tiptap.dev/login">Cloud dashboard</a>.
+    <a href="https://tiptap.dev/contact-sales?form=ai-toolkit">Contact our team</a> to add the AI Toolkit add-on to your subscription. Available for all plans. Includes onboarding and support.
   </RequirementItem>
   <RequirementItem label="2. Access the private registry">
     The AI Toolkit extension is published in Tiptap's private npm registry. Authenticate to Tiptap's

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/proofreader.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/proofreader.mdx
@@ -12,12 +12,11 @@ import { Requirements, RequirementItem } from '@/components/Requirements'
 
 <Requirements>
   <RequirementItem label="1. Get access">
-    Subscribe to the <a href="https://tiptap.dev/pricing">Business plan</a> and schedule your onboarding call from the <a href="https://cloud.tiptap.dev/login">Cloud dashboard</a>.
+    <a href="https://tiptap.dev/contact-sales?form=ai-toolkit">Contact our team</a> to add the AI Toolkit add-on to your subscription. Available for all plans. Includes onboarding and support.
   </RequirementItem>
   <RequirementItem label="2. Access the private registry">
     The AI Toolkit extension is published in Tiptap&apos;s private npm registry. Authenticate to
-    Tiptap&apos;s private npm registry by following the{' '}
-    <a href="/guides/pro-extensions">setup guide</a>.
+    Tiptap&apos;s private npm registry by following the [setup guide](/guides/pro-extensions).
   </RequirementItem>
   <RequirementItem label="3. Install the extension">
     Install the extension from the private registry using npm or your preferred package manager.

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/selection-awareness.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/selection-awareness.mdx
@@ -12,12 +12,11 @@ import { Requirements, RequirementItem } from '@/components/Requirements'
 
 <Requirements>
   <RequirementItem label="1. Get access">
-    Subscribe to the <a href="https://tiptap.dev/pricing">Business plan</a> and schedule your onboarding call from the <a href="https://cloud.tiptap.dev/login">Cloud dashboard</a>.
+    <a href="https://tiptap.dev/contact-sales?form=ai-toolkit">Contact our team</a> to add the AI Toolkit add-on to your subscription. Available for all plans. Includes onboarding and support.
   </RequirementItem>
   <RequirementItem label="2. Access the private registry">
     The AI Toolkit extension is published in Tiptap&apos;s private npm registry. Authenticate to
-    Tiptap&apos;s private npm registry by following the{' '}
-    <a href="/guides/pro-extensions">setup guide</a>.
+    Tiptap&apos;s private npm registry by following the [setup guide](/guides/pro-extensions).
   </RequirementItem>
   <RequirementItem label="3. Install the extension">
     Install the extension from the private registry using npm or your preferred package manager.

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot.mdx
@@ -12,7 +12,7 @@ import { Requirements, RequirementItem } from '@/components/Requirements'
 
 <Requirements>
   <RequirementItem label="1. Get access">
-    Subscribe to the <a href="https://tiptap.dev/pricing">Business plan</a> and schedule your onboarding call from the <a href="https://cloud.tiptap.dev/login">Cloud dashboard</a>.
+    <a href="https://tiptap.dev/contact-sales?form=ai-toolkit">Contact our team</a> to add the AI Toolkit add-on to your subscription. Available for all plans. Includes onboarding and support.
   </RequirementItem>
   <RequirementItem label="2. Access the private registry">
     The AI Toolkit extension is published in Tiptap's private npm registry. Authenticate to Tiptap's

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/inline-edits.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/inline-edits.mdx
@@ -12,7 +12,7 @@ import { Requirements, RequirementItem } from '@/components/Requirements'
 
 <Requirements>
   <RequirementItem label="1. Get access">
-    Subscribe to the <a href="https://tiptap.dev/pricing">Business plan</a> and schedule your onboarding call from the <a href="https://cloud.tiptap.dev/login">Cloud dashboard</a>.
+    <a href="https://tiptap.dev/contact-sales?form=ai-toolkit">Contact our team</a> to add the AI Toolkit add-on to your subscription. Available for all plans. Includes onboarding and support.
   </RequirementItem>
   <RequirementItem label="2. Access the private registry">
     The AI Toolkit extension is published in Tiptap's private npm registry. Authenticate to Tiptap's

--- a/src/content/content-ai/capabilities/ai-toolkit/install.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/install.mdx
@@ -11,7 +11,7 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
 <Requirements>
   <RequirementItem label="1. Get access">
-    Subscribe to the <a href="https://tiptap.dev/pricing">Business plan</a> and schedule your onboarding call from the <a href="https://cloud.tiptap.dev/login">Cloud dashboard</a>.
+    <a href="https://tiptap.dev/contact-sales?form=ai-toolkit">Contact our team</a> to add the AI Toolkit add-on to your subscription. Available for all plans. Includes onboarding and support.
   </RequirementItem>
   <RequirementItem label="2. Access the private registry">
     The AI Toolkit extension is published in Tiptap's private npm registry. Authenticate to Tiptap's
@@ -24,9 +24,7 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
 <EnterpriseCalloutAuto variant="ai-toolkit" renderMode="sidebar" />
 
-Subscribe to the [Business plan](https://tiptap.dev/pricing) and schedule your onboarding call from the [Cloud dashboard](https://cloud.tiptap.dev/login).
-
-Once granted access, configure your package manager by following the [private registry guide](/guides/pro-extensions).
+<a href="https://tiptap.dev/contact-sales?form=ai-toolkit">Contact our team</a> to add the AI Toolkit add-on to your subscription. After gaining access, configure your package manager by following the [private registry guide](/guides/pro-extensions).
 
 Then, install the package:
 

--- a/src/content/content-ai/capabilities/ai-toolkit/live-demo.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/live-demo.mdx
@@ -1,7 +1,7 @@
 ---
 title: AI Toolkit Live Demo
 tags:
-  - type: business
+  - type: addon
   - type: beta
 meta:
   title: AI Toolkit Live Demo | Tiptap Content AI
@@ -12,27 +12,42 @@ sidebars:
 ---
 
 import { CodeDemo } from '@/components/CodeDemo'
-import { Button } from '@/components/ui/Button'
 import { Link } from '@/components/Link'
-import { ArrowRightIcon } from 'lucide-react'
 import { Callout } from '@/components/ui/Callout'
+import { ExternalLinkIcon, Expand } from 'lucide-react'
 
 This interactive demo showcases the AI Toolkit's capabilities in a real document editing environment. The demo features an AI agent that can read, edit, and manipulate documents using the toolkit's primitives.
 
-<div className="flex items-center gap-4 mt-8">
-  <Button variant="primary" size="medium">
-    <Link
-      href="https://template.tiptap.dev/page-ai-toolkit"
-      target="_blank"
-      className="flex items-center justify-center gap-2"
-    >
-      View in Full Screen
-      <ArrowRightIcon className="size-3.5" />
-    </Link>
-  </Button>
-</div>
-
-<CodeDemo isScrollable isLarge src="https://template.tiptap.dev/page-ai-toolkit" />
+<CodeDemo
+    isScrollable
+    isLarge
+    src="https://template.tiptap.dev/page-ai-toolkit"
+    caption={
+        <>
+            <strong>Try the AI Toolkit</strong> in action with this interactive demo featuring an AI agent that can read, edit, and manipulate documents.
+        </>
+    }
+    captionActions={
+        <>
+            <a
+                href="https://template.tiptap.dev/page-ai-toolkit"
+                target="_blank"
+                className="flex items-center gap-1 text-grayAlpha-600 hover:text-grayAlpha-800 font-medium whitespace-nowrap"
+            >
+                Full screen
+                <Expand className="size-3" />
+            </a>
+            <span className="text-grayAlpha-300">|</span>
+            <Link
+                href="/content-ai/capabilities/ai-toolkit/live-demo"
+                className="flex items-center gap-1 text-grayAlpha-600 hover:text-grayAlpha-800 font-medium whitespace-nowrap"
+            >
+                Learn more
+                <ExternalLinkIcon className="size-3" />
+            </Link>
+        </>
+    }
+/>
 
 ### Document Operations
 - **Reading**: The AI can read and analyze document content in chunks, handling large documents efficiently
@@ -45,17 +60,6 @@ This interactive demo showcases the AI Toolkit's capabilities in a real document
 - **Selection-aware prompts**: Operations work on selected text or the entire document
 - **Change tracking**: Google Docs-style accept/reject workflow for AI edits
 
-## Source Code Access
-
-<Callout title="Business plan required" variant="info">
-  The complete source code for this demo is available to Business plan subscribers. We'll provide access during your onboarding call. Usage is subject to our [Terms of Service](https://tiptap.dev/terms-of-service) and [Pro License](https://tiptap.dev/pro-license).
+<Callout title="Access the source code" variant="info">
+  The complete source code for this demo is available once you add the AI Toolkit to your subscription. We'll provide access during your onboarding call. Usage is subject to our [Terms of Service](https://tiptap.dev/terms-of-service) and [Pro License](https://tiptap.dev/pro-license).
 </Callout>
-
-## Next Steps
-
-After exploring the demo, get started with the AI Toolkit:
-
-1. [Subscribe to the Business plan](https://tiptap.dev/pricing) and schedule your onboarding call
-2. Follow the [Installation guide](/content-ai/capabilities/ai-toolkit/overview#installation-guide)
-3. Try the [AI agent chatbot quickstart](/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot)
-4. Explore [advanced guides](/content-ai/capabilities/ai-toolkit/advanced-guides) for specific use cases

--- a/src/content/content-ai/capabilities/ai-toolkit/migration-guides/ai-generation.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/migration-guides/ai-generation.mdx
@@ -8,8 +8,6 @@ meta:
 
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
-<EnterpriseCalloutAuto variant="deprecated" renderMode="sidebar" />
-
 The AI Generation extension allows you to select content and ask AI model to re-write it based on your instructions.
 
 To implement the same functionality with the AI Toolkit, the recommend path is to follow the [inline edits guide](/content-ai/capabilities/ai-toolkit/guides/inline-edits).

--- a/src/content/content-ai/capabilities/ai-toolkit/overview.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: AI Toolkit
 tags:
-  - type: business
+  - type: addon
   - type: beta
 meta:
   title: AI Toolkit overview | Tiptap Content AI
@@ -13,7 +13,6 @@ sidebars:
 
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
-import { Callout } from '@/components/ui/Callout'
 import * as CardGrid from '@/components/CardGrid'
 import Link from '@/components/Link'
 import { CodeDemo } from '@/components/CodeDemo'
@@ -21,7 +20,7 @@ import { ExternalLinkIcon, Expand } from 'lucide-react'
 
 <Requirements>
   <RequirementItem label="1. Get access">
-    Subscribe to the <a href="https://tiptap.dev/pricing">Business plan</a> and schedule your onboarding call from the <a href="https://cloud.tiptap.dev/login">Cloud dashboard</a>.
+    <a href="https://tiptap.dev/contact-sales?form=ai-toolkit">Contact our team</a> to add the AI Toolkit add-on to your subscription. Available for all plans. Includes onboarding and support.
   </RequirementItem>
   <RequirementItem label="2. Access the private registry">
     The AI Toolkit extension is published in Tiptap's private npm registry. Authenticate to Tiptap's
@@ -69,14 +68,9 @@ Use it to build AI agents with document-editing superpowers. Or add custom AI fu
   }
 />
 
-
 ## Core Capabilities
 
 The AI Toolkit provides two complementary approaches to building AI features: **AI Agent Tools** for automated workflows where your LLM makes decisions, and **Primitives** for custom implementations where you control the logic.
-
-<Callout title="Flexible approach" variant="hint">
-    The AI Toolkit provides flexible building blocks rather than prescribing a single approach to implementation. Start by envisioning the feature you want to create, then use the tools and primitives to integrate it.
-</Callout>
 
 ### AI Agent Tools
 
@@ -164,6 +158,7 @@ Low-level methods for building custom AI features. Use these when you need fine-
   </Link>
 </div>
 
+<EnterpriseCalloutAuto variant="ai-toolkit" renderMode="inline" />
 
 ## Guides and Examples
 

--- a/src/content/content-ai/sidebar.ts
+++ b/src/content/content-ai/sidebar.ts
@@ -28,7 +28,7 @@ export const sidebarConfig: SidebarConfig = {
         {
           title: 'AI Toolkit',
           href: '/content-ai/capabilities/ai-toolkit',
-          tags: ['Business'],
+          tags: ['Add on'],
           beta: true,
           children: [
             {
@@ -74,24 +74,24 @@ export const sidebarConfig: SidebarConfig = {
               href: '/content-ai/capabilities/ai-toolkit/advanced-guides',
               children: [
                 {
-                  title: 'Selection awareness',
-                  href: '/content-ai/capabilities/ai-toolkit/advanced-guides/selection-awareness',
-                },
-                {
-                  title: 'Multi-document AI agent',
-                  href: '/content-ai/capabilities/ai-toolkit/advanced-guides/multi-document',
+                  title: 'AI engineering guide',
+                  href: '/content-ai/capabilities/ai-toolkit/advanced-guides/ai-engineering',
                 },
                 {
                   title: 'Add comments',
                   href: '/content-ai/capabilities/ai-toolkit/advanced-guides/comments',
                 },
                 {
-                  title: 'AI engineering guide',
-                  href: '/content-ai/capabilities/ai-toolkit/advanced-guides/ai-engineering',
+                  title: 'Multi-document AI agent',
+                  href: '/content-ai/capabilities/ai-toolkit/advanced-guides/multi-document',
                 },
                 {
                   title: 'Proofreader',
                   href: '/content-ai/capabilities/ai-toolkit/advanced-guides/proofreader',
+                },
+                {
+                  title: 'Selection awareness',
+                  href: '/content-ai/capabilities/ai-toolkit/advanced-guides/selection-awareness',
                 },
                 {
                   title: 'Style suggestions',

--- a/src/content/content-ai/sidebar.ts
+++ b/src/content/content-ai/sidebar.ts
@@ -28,7 +28,7 @@ export const sidebarConfig: SidebarConfig = {
         {
           title: 'AI Toolkit',
           href: '/content-ai/capabilities/ai-toolkit',
-          tags: ['Add on'],
+          tags: ['Add-on'],
           beta: true,
           children: [
             {

--- a/src/content/editor/extensions/functionality/ai-toolkit.mdx
+++ b/src/content/editor/extensions/functionality/ai-toolkit.mdx
@@ -1,0 +1,29 @@
+---
+title: Build AI features with document editing
+tags:
+  - type: addon
+meta:
+  category: Editor
+extension:
+  name: AI Toolkit
+  description: Add-on toolkit for AI-powered document editing and AI agents.
+  type: extension
+  icon: Sparkles
+sidebars:
+  hideSecondary: true
+---
+
+import { Callout } from '@/components/ui/Callout'
+import { CodeDemo } from '@/components/CodeDemo'
+
+Build AI agents with document-editing superpowers or add custom AI functionality to your Tiptap editor. The AI Toolkit provides flexible primitives and pre-built tools that enable your AI to read, edit, and manipulate Tiptap documents.
+
+<Callout title="More details" variant="hint">
+    For detailed information on installation, configuration, and comprehensive guides, please visit our [AI Toolkit feature page](/content-ai/capabilities/ai-toolkit/overview).
+</Callout>
+
+<CodeDemo
+    isScrollable
+    isLarge
+    src="https://template.tiptap.dev/page-ai-toolkit"
+/>

--- a/src/content/editor/extensions/functionality/pages.mdx
+++ b/src/content/editor/extensions/functionality/pages.mdx
@@ -1,0 +1,25 @@
+---
+title: Professional page-based layout
+tags:
+  - type: team
+meta:
+  category: Editor
+extension:
+  name: Pages
+  description: Transform your editor into a page-based document interface with margins and page breaks.
+  type: extension
+  icon: File
+sidebars:
+  hideSecondary: true
+---
+
+import { Callout } from '@/components/ui/Callout'
+import { CodeDemo } from '@/components/CodeDemo'
+
+Transform your editing experience from a traditional single-block editor into a sophisticated page-based interface. Tiptap Pages provides proper margins, page breaks, and layout controls for creating documents that maintain a professional, page-based structure.
+
+<Callout title="More details" variant="hint">
+  For detailed information on installation, configuration, and integration, please visit our [Pages feature page](/pages/getting-started/overview).
+</Callout>
+
+<CodeDemo isPro src="https://feature-pages-extension--tiptap-pro.netlify.app/preview/extensions/pages" />

--- a/src/content/editor/sidebar.ts
+++ b/src/content/editor/sidebar.ts
@@ -253,7 +253,7 @@ export const sidebarConfig: SidebarConfig = {
             {
               href: '/editor/extensions/functionality/ai-toolkit',
               title: 'AI Toolkit',
-              tags: ['Add on'],
+              tags: ['Add-on'],
               beta: true,
             },
             {

--- a/src/content/editor/sidebar.ts
+++ b/src/content/editor/sidebar.ts
@@ -251,9 +251,9 @@ export const sidebarConfig: SidebarConfig = {
               tags: ['Start'],
             },
             {
-              href: '/content-ai/capabilities/ai-toolkit',
+              href: '/editor/extensions/functionality/ai-toolkit',
               title: 'AI Toolkit',
-              tags: ['Business'],
+              tags: ['Add on'],
               beta: true,
             },
             {
@@ -355,6 +355,11 @@ export const sidebarConfig: SidebarConfig = {
               beta: true,
             },
             {
+              href: '/editor/extensions/functionality/pages',
+              title: 'Pages',
+              tags: ['Team'],
+            },
+            {
               href: '/editor/extensions/functionality/placeholder',
               title: 'Placeholder',
             },
@@ -365,7 +370,7 @@ export const sidebarConfig: SidebarConfig = {
             },
             {
               href: '/editor/extensions/functionality/snapshot-compare',
-              title: 'Version Compare',
+              title: 'Snapshot Compare',
               tags: ['Team'],
             },
             {

--- a/src/content/pages/getting-started/install.mdx
+++ b/src/content/pages/getting-started/install.mdx
@@ -1,6 +1,7 @@
 ---
 title: Install the Pages extension
 tags:
+  - type: team
   - type: alpha
 meta:
   title: Install Pages | Tiptap Pages Docs
@@ -9,16 +10,13 @@ meta:
 ---
 
 import { Requirements, RequirementItem } from '@/components/Requirements'
-import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 import { Link } from '@/components/Link'
-
-<EnterpriseCalloutAuto variant="pages" renderMode="sidebar" />
 
 Install and configure the Pages extension by following this guide.
 
 <Requirements>
     <RequirementItem label="1. Request access">
-        <a href="https://tiptap-suite.notion.site/1b601ffa3ebc80a281a8ea0b03b19bdd?pvs=105">Share your use case</a> to be considered for early access to Tiptap Pages.
+        Start a free [trial in your Account](https://cloud.tiptap.dev/v2/billing) or subscribe to a [Tiptap plan](https://cloud.tiptap.dev/v2/billing).
     </RequirementItem>
     <RequirementItem label="2. Access the private registry">
         The Pages extension is published in Tiptap’s private npm registry. Authenticate to Tiptap’s private npm registry by following the [setup guide](/guides/pro-extensions).
@@ -34,7 +32,7 @@ Install and configure the Pages extension by following this guide.
 npm install @tiptap-pro/extension-pages@alpha
 ```
 
-## Integrating the Pages extension
+## Integrating the Pages extensionis there
 
 After installing the `pages` extension, register it in your editor by adding the `Pages` extension to your editor’s `extensions` array.
 

--- a/src/content/pages/getting-started/overview.mdx
+++ b/src/content/pages/getting-started/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: Pages
 tags:
+  - type: team
   - type: alpha
 meta:
     title: Pages | Tiptap Pages
@@ -11,7 +12,6 @@ sidebars:
 ---
 
 import { CodeDemo } from '@/components/CodeDemo'
-import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
 Tiptap Pages is a powerful extension that transforms your editing experience from a traditional single-block editor into a sophisticated page-based interface.
 
@@ -27,5 +27,3 @@ Key features of Tiptap Pages include:
 - Familiar interface similar to popular word processors
 
 We are continuously improving the pages extension. Support for other more extensions and other complex features are in active development.
-
-<EnterpriseCalloutAuto variant="pages" renderMode="inline" />

--- a/src/server/getExtensions.ts
+++ b/src/server/getExtensions.ts
@@ -40,6 +40,10 @@ export const getExtensions = async (path: string = '') => {
         (tag: { type: string }) => typeof tag === 'object' && tag.type === 'team',
       )
 
+      const hasAddonTag = pageTags.some(
+        (tag: { type: string }) => typeof tag === 'object' && tag.type === 'addon',
+      )
+
       // Initialize tags array if it doesn't exist
       if (!extensionData.tags) {
         extensionData.tags = []
@@ -53,6 +57,11 @@ export const getExtensions = async (path: string = '') => {
       // Add "Team" tag if team type is present
       if (hasTeamTag && !extensionData.tags.includes('Team')) {
         extensionData.tags.push('Team')
+      }
+
+      // Add "Addon" tag if addon type is present
+      if (hasAddonTag && !extensionData.tags.includes('Addon')) {
+        extensionData.tags.push('Addon')
       }
 
       return [

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export type GeneralPageTag = {
     | 'start'
     | 'beginStart'
     | 'team'
+    | 'addon'
     | 'restricted'
     | 'mit'
     | 'business'


### PR DESCRIPTION
This commit includes comprehensive updates to the AI Toolkit and Pages documentation:
- Update AI Toolkit tag from Business to Add-on across all components
- Standardize contact sales links and onboarding flow
- Add Add-on filter to extension grid
- Update Pages installation requirements and documentation
- Reorder advanced guides in sidebar for better organization
- Improve live demo UI with enhanced caption and actions
- Clean up enterprise callouts and simplify messaging
- Add new extension pages for AI Toolkit and Pages