### PR TITLE
docs(ui-component): Include auto import style guide

### DIFF
--- a/.changeset/sixty-mammals-talk.md
+++ b/.changeset/sixty-mammals-talk.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Update UI component style guide to include documentation for auto import style

--- a/src/content/ui-components/getting-started/style.mdx
+++ b/src/content/ui-components/getting-started/style.mdx
@@ -12,44 +12,101 @@ import { Callout } from '@/components/ui/Callout'
 
 Component styles are written in SCSS. The SCSS compiler (`sass` or `sass-embedded`) is installed automatically when you install a component or template using the Tiptap CLI. If you follow a manual setup, you'll need to install it manually.
 
-<Callout title="Styles are only added when using the CLI" variant="info">
-  Styles are included only if you installed a component or template using the CLI. These styles come
-  bundled with whatever you add through the CLI.
+<Callout title="Styles are added automatically" variant="info">
+  When you install your first Tiptap UI Component, the CLI automatically injects the required{' '}
+  <code>.scss</code> imports into your project’s global stylesheet. In most cases,{' '}
+  <strong>no manual setup is needed</strong>.
 </Callout>
 
 <Callout title="Bun projects automatically convert SCSS to CSS" variant="warning">
-  If you’re using <strong>Bun</strong>, the CLI automatically converts all
-  <code>.scss</code> files into <code>.css</code>
-  files during installation. This means your imports should use <code>.css</code> instead of{' '}
-  <code>.scss</code>, for example: <br />
-  <br /> <code>@import &apos;./styles/_variables.css&apos;;</code>
-  <br /> <code>@import &apos;./styles/_keyframe-animations.css&apos;;</code>
+If you’re using <strong>Bun</strong>, the CLI converts all <code>.scss</code> files into <code>.css</code> files at install time and updates the imports accordingly. Your project will use:
+
+```css
+@import './styles/_variables.css';
+@import './styles/_keyframe-animations.css';
+```
+
 </Callout>
 
-#### For Next.js
+#### Where Styles Are Imported
 
-When a template or component is added to your Next.js project, global SCSS files are automatically added in the `styles` directory.
-
-Import the global SCSS styles in the main stylesheet:
-
-**File:** `app/globals.css`
+The CLI injects these imports into your global stylesheet:
 
 ```css
-@import '../styles/_variables.scss';
-@import '../styles/_keyframe-animations.scss';
+@import '<path-to-styles>/_variables.scss';
+@import '<path-to-styles>/_keyframe-animations.scss';
 ```
 
-#### For Vite + React
+If you use a custom entry stylesheet, make sure the imports exist there.
 
-When a template or component is added to your Vite + React project, global SCSS files are automatically added in the `src/styles` directory.
+#### Framework-Specific Setup
 
-Import the global SCSS styles in the main stylesheet:
+Below are the locations where the CLI adds the global stylesheet imports for each framework.
 
-**File:** `src/index.css`
+#### Next.js (App Router)
+
+Injected into one of:
+
+- `app/globals.css`
+- `src/app/globals.css`
+
+File: `app/globals.css` or `src/app/globals.css`
 
 ```css
-@import './styles/_variables.scss';
-@import './styles/_keyframe-animations.scss';
+@import '<path-to-styles>/_variables.scss';
+@import '<path-to-styles>/_keyframe-animations.scss';
 ```
 
-Make sure the SCSS files are in the correct path so the styles load properly in your project.
+#### Vite + React
+
+Injected into:
+
+- `src/index.css`
+
+File: `src/index.css`
+
+```css
+@import '<path-to-styles>/_variables.scss';
+@import '<path-to-styles>/_keyframe-animations.scss';
+```
+
+Paths may differ slightly depending on your project structure.
+
+#### Astro
+
+Injected into your global stylesheet, typically:
+
+- `src/styles/global.css` or whatever file you’ve designated as a global stylesheet
+
+File: `src/styles/global.css` (or your custom entry)
+
+```css
+@import '<path-to-styles>/_variables.scss';
+@import '<path-to-styles>/_keyframe-animations.scss';
+```
+
+#### Laravel (Vite)
+
+Injected into:
+
+- `resources/css/app.css`
+
+File: `resources/css/app.css`
+
+```css
+@import '<path-to-styles>/_variables.scss';
+@import '<path-to-styles>/_keyframe-animations.scss';
+```
+
+#### React Router (Vanilla React)
+
+Injected into:
+
+- `src/index.css`
+
+File: `src/index.css`
+
+```css
+@import '<path-to-styles>/_variables.scss';
+@import '<path-to-styles>/_keyframe-animations.scss';
+```

--- a/src/content/ui-components/install/astro.mdx
+++ b/src/content/ui-components/install/astro.mdx
@@ -76,7 +76,7 @@ The CLI automatically injects style imports into your global stylesheet, such as
 
 - `styles/global.css`
 
-**File:** `styles/globals.css` (depending on your project)
+**File:** `styles/global.css` (depending on your project)
 
 ```css
 @import '<path-to-styles>/_variables.scss';

--- a/src/content/ui-components/install/astro.mdx
+++ b/src/content/ui-components/install/astro.mdx
@@ -62,24 +62,21 @@ export default function EditorPage() {
 
 ## Add Styles
 
-<Callout title="Bun projects automatically convert SCSS to CSS" variant="warning">
-  If you’re using <strong>Bun</strong>, the CLI automatically converts all
-  <code>.scss</code> files into <code>.css</code>
-  files during installation. This means your imports should use <code>.css</code> instead of{' '}
-  <code>.scss</code>, for example: <br />
-  <br /> <code>@import &apos;./styles/_variables.css&apos;;</code>
-  <br /> <code>@import &apos;./styles/_keyframe-animations.css&apos;;</code>
+<Callout title="Styles are added automatically" variant="info">
+  When you install your first Tiptap UI Component, the CLI automatically adds the required{' '}
+  <code>.scss</code> imports to your main stylesheet. In most cases, **no manual setup is needed**.
 </Callout>
 
-Before proceeding, ensure that your project includes a CSS reset. If you're using Tailwind CSS, you can skip this step since it comes with a built-in reset.
+Before proceeding, ensure your project includes a CSS reset.
+If you are using Tailwind CSS, you already have one.
 
-To enable support for SCSS in React App, install the SCSS compiler:
+#### Where styles are imported
 
-```bash
-npm install -D sass-embedded
-```
+The CLI automatically injects style imports into your global stylesheet, such as:
 
-Then, to ensure the component and editor have the correct variables and animations, manually import the SCSS partials into your main stylesheet `src/index.css` or `src/App.css`:
+- `styles/global.css`
+
+**File:** `styles/globals.css` (depending on your project)
 
 ```css
 @import '<path-to-styles>/_variables.scss';

--- a/src/content/ui-components/install/laravel.mdx
+++ b/src/content/ui-components/install/laravel.mdx
@@ -46,24 +46,23 @@ export default function EditorPage() {
 
 ## Add Styles
 
-<Callout title="Bun projects automatically convert SCSS to CSS" variant="warning">
-  If you’re using <strong>Bun</strong>, the CLI automatically converts all
-  <code>.scss</code> files into <code>.css</code>
-  files during installation. This means your imports should use <code>.css</code> instead of{' '}
-  <code>.scss</code>, for example: <br />
-  <br /> <code>@import &apos;./styles/_variables.css&apos;;</code>
-  <br /> <code>@import &apos;./styles/_keyframe-animations.css&apos;;</code>
+<Callout title="Styles are added automatically" variant="info">
+  When you install your first Tiptap UI Component, the CLI automatically adds the required{' '}
+  <code>.scss</code> imports to your main stylesheet. In most cases, **no manual setup is needed**.
 </Callout>
 
-Before proceeding, ensure that your project includes a CSS reset. If you're using Tailwind CSS, you can skip this step since it comes with a built-in reset.
+Before proceeding, ensure your project includes a CSS reset.
+If you are using Tailwind CSS, you already have one.
 
-To enable support for SCSS in React App, install the SCSS compiler:
+#### Where styles are imported
 
-```bash
-npm install -D sass-embedded
-```
+The CLI automatically injects style imports into your global stylesheet, such as:
 
-Then, to ensure the component and editor have the correct variables and animations, manually import the SCSS partials into your main stylesheet `src/index.css` or `src/App.css`:
+- `resources/css/app.css`
+
+If you’ve customized your entry file, make sure this is present:
+
+**File:** `resources/css/app.css` (depending on your project)
 
 ```css
 @import '<path-to-styles>/_variables.scss';

--- a/src/content/ui-components/install/next.mdx
+++ b/src/content/ui-components/install/next.mdx
@@ -58,22 +58,28 @@ export default function App() {
 
 ## Add Styles
 
-<Callout title="Bun projects automatically convert SCSS to CSS" variant="warning">
-  If you’re using <strong>Bun</strong>, the CLI automatically converts all
-  <code>.scss</code> files into <code>.css</code>
-  files during installation. This means your imports should use <code>.css</code> instead of{' '}
-  <code>.scss</code>, for example: <br />
-  <br /> <code>@import &apos;./styles/_variables.css&apos;;</code>
-  <br /> <code>@import &apos;./styles/_keyframe-animations.css&apos;;</code>
+<Callout title="Styles are added automatically" variant="info">
+  When you install your first Tiptap UI Component, the CLI automatically adds the required{' '}
+  <code>.scss</code> imports to your main stylesheet. In most cases, **no manual setup is needed**.
 </Callout>
 
-Import the global SCSS styles in the main stylesheet:
+Before proceeding, ensure your project includes a CSS reset.
+If you are using Tailwind CSS, you already have one.
 
-**File:** `src/index.css`
+#### Where styles are imported
+
+The CLI automatically injects style imports into your global stylesheet, such as:
+
+- `app/globals.css`
+- `src/app/globals.css`
+
+If you’ve customized your entry file, make sure this is present:
+
+**File:** `app/globals.css` or `src/app/globals.css` (depending on your project)
 
 ```css
-@import './styles/_variables.scss';
-@import './styles/_keyframe-animations.scss';
+@import '<path-to-styles>/_variables.scss';
+@import '<path-to-styles>/_keyframe-animations.scss';
 ```
 
 Learn more about configuring styles in the [style setup guide](/ui-components/getting-started/style).

--- a/src/content/ui-components/install/react-router.mdx
+++ b/src/content/ui-components/install/react-router.mdx
@@ -46,24 +46,27 @@ export default function EditorPage() {
 
 ## Add Styles
 
-<Callout title="Bun projects automatically convert SCSS to CSS" variant="warning">
-  If you’re using <strong>Bun</strong>, the CLI automatically converts all
-  <code>.scss</code> files into <code>.css</code>
-  files during installation. This means your imports should use <code>.css</code> instead of{' '}
-  <code>.scss</code>, for example: <br />
-  <br /> <code>@import &apos;./styles/_variables.css&apos;;</code>
-  <br /> <code>@import &apos;./styles/_keyframe-animations.css&apos;;</code>
+<Callout title="Styles are added automatically" variant="info">
+  When you install your first Tiptap UI Component, the CLI automatically adds the required{' '}
+  <code>.scss</code> imports to your main stylesheet. In most cases, **no manual setup is needed**.
 </Callout>
 
-Before proceeding, ensure that your project includes a CSS reset. If you're using Tailwind CSS, you can skip this step since it comes with a built-in reset.
+Before proceeding, ensure your project includes a CSS reset.
+If you are using Tailwind CSS, you already have one.
 
-Import the global SCSS styles in the main stylesheet:
+#### Where styles are imported
 
-**File:** `app/globals.css`
+The CLI automatically injects style imports into your global stylesheet, such as:
+
+- `src/index.css` (depending on your project)
+
+If you’ve customized your entry file, make sure this is present:
+
+**File:** `src/index.css` (depending on your project)
 
 ```css
-@import '../styles/_variables.scss';
-@import '../styles/_keyframe-animations.scss';
+@import '<path-to-styles>/_variables.scss';
+@import '<path-to-styles>/_keyframe-animations.scss';
 ```
 
 Learn more about configuring styles in the [style setup guide](/ui-components/getting-started/style).

--- a/src/content/ui-components/install/vite.mdx
+++ b/src/content/ui-components/install/vite.mdx
@@ -100,28 +100,27 @@ export default function App() {
 
 ## Add Styles
 
-<Callout title="Bun projects automatically convert SCSS to CSS" variant="warning">
-  If you’re using <strong>Bun</strong>, the CLI automatically converts all
-  <code>.scss</code> files into <code>.css</code>
-  files during installation. This means your imports should use <code>.css</code> instead of{' '}
-  <code>.scss</code>, for example:
-
-```css
-@import './styles/_variables.css';
-@import './styles/_keyframe-animations.css';
-```
-
+<Callout title="Styles are added automatically" variant="info">
+  When you install your first Tiptap UI Component, the CLI automatically adds the required{' '}
+  <code>.scss</code> imports to your main stylesheet. In most cases, **no manual setup is needed**.
 </Callout>
 
-Before proceeding, ensure that your project includes a CSS reset. If you're using Tailwind CSS, you can skip this step since it comes with a built-in reset.
+Before proceeding, ensure your project includes a CSS reset.
+If you are using Tailwind CSS, you already have one.
 
-Import the global SCSS styles in the main stylesheet:
+#### Where styles are imported
 
-**File:** `app/globals.css`
+The CLI automatically injects style imports into your global stylesheet, such as:
+
+- `src/index.css` (depending on your project)
+
+If you’ve customized your entry file, make sure this is present:
+
+**File:** `src/index.css` (depending on your project)
 
 ```css
-@import '../styles/_variables.scss';
-@import '../styles/_keyframe-animations.scss';
+@import '<path-to-styles>/_variables.scss';
+@import '<path-to-styles>/_keyframe-animations.scss';
 ```
 
 Learn more about configuring styles in the [style setup guide](/ui-components/getting-started/style).


### PR DESCRIPTION
This PR updates the Style Tiptap UI Components guide to provide a clearer and more unified explanation of how global SCSS styles are added across all supported frameworks.