### PR TITLE
Fix naming inconsistencies in DOCX import docs

### DIFF
--- a/src/content/collaboration/documents/snapshot-compare.mdx
+++ b/src/content/collaboration/documents/snapshot-compare.mdx
@@ -578,7 +578,7 @@ declare module '@tiptap/core' {
 
 export type SnapshotCompareOptions = {
   /**
-   * The tiptap provider instance. This is required for the extension to compute the diffs, but not to display them.
+   * The Tiptap provider instance. This is required for the extension to compute the diffs, but not to display them.
    * It is also possible to pass a TiptapCollabProvider instance.
    */
   provider: TiptapCollabProvider | null

--- a/src/content/collaboration/documents/snapshot-compare.mdx
+++ b/src/content/collaboration/documents/snapshot-compare.mdx
@@ -90,7 +90,7 @@ For more complex integrations and control, you can customize this mapping with t
 SnapshotCompare.configure({
   mapDiffToDecorations: ({ diff, tr, editor, defaultMapDiffToDecorations }) => {
     if (diff.type === 'inline-insert') {
-      // return prosemirror decoration(s) or null
+      // return ProseMirror decoration(s) or null
       return Decoration.inline(
         diff.from,
         diff.to,

--- a/src/content/comments/core-concepts/manage-threads.mdx
+++ b/src/content/comments/core-concepts/manage-threads.mdx
@@ -183,7 +183,7 @@ To create a comment on a thread you can use the `createComment` command. This co
 ```js
 editor.commands.createComment({
   threadId: '123',
-  content: 'This is a new comment', // this could also be tiptap JSON or any other type of content
+  content: 'This is a new comment', // this could also be Tiptap JSON or any other type of content
   data: {
     user, // pass through any meta data you want - in this case the user
   },

--- a/src/content/conversion/import-export/docx/custom-mark-conversion.mdx
+++ b/src/content/conversion/import-export/docx/custom-mark-conversion.mdx
@@ -36,7 +36,7 @@ const editor = new Editor({
       // ATTENTION: This is for demo purposes only
       endpoint: 'https://your-endpoint.com',
       imageUploadCallbackUrl: 'https://your-endpoint.com/image-upload',
-      // Promisemirror custom mark mapping
+      // ProseMirror custom mark mapping
       prosemirrorMarks: {
         bold: 'strong',
         italic: 'em',
@@ -55,6 +55,6 @@ This option allows you to map custom nodes from the DOCX to your Tiptap schema. 
 By doing so, whenever the DOCX contains a `bold` or `italic` node, it will be converted to a `strong` or `italic` node in Tiptap when imported.
 
 <Callout title='DOCX, "prosemirrorNodes" and "prosemirrorMarks"' variant="info">
-  Please note that the `promisemirrorNodes` and `prosemirrorMarks` options will only work if you're importing a `.docx` file. If you're importing another type of file, eg: an `.odt` file, the `/import` endpoint will be used instead of the `/import` endpoint, and the `promisemirrorNodes` and `prosemirrorMarks` options will not be available.
+  Please note that the `prosemirrorNodes` and `prosemirrorMarks` options will only work if you're importing a `.docx` file. If you're importing another type of file, eg: an `.odt` file, the `/import` endpoint will be used instead of the `/import` endpoint, and the `prosemirrorNodes` and `prosemirrorMarks` options will not be available.
 </Callout>
 

--- a/src/content/conversion/import-export/docx/custom-node-conversion.mdx
+++ b/src/content/conversion/import-export/docx/custom-node-conversion.mdx
@@ -235,15 +235,15 @@ Import.configure({
   // ATTENTION: This is for demo purposes only
   endpoint: 'https://your-endpoint.com',
   imageUploadCallbackUrl: 'https://your-endpoint.com/image-upload',
-  // Promisemirror custom node mapping
-  promisemirrorNodes: {
+  // prosemirror custom node mapping
+  prosemirrorNodes: {
     Hintbox: 'hintbox',
   },
 }),
 ```
 
-The latest version of the `@tiptap-pro/extension-import-docx` has available the `promisemirrorNodes` configuration option. This option allows you to map custom nodes from the DOCX to your Tiptap schema. In the example above, we are mapping the `Hintbox` custom node from the DOCX to the `hintbox` custom node in our Tiptap schema. By doing so, whenever the DOCX contains a `Hintbox` custom node, it will be converted to a `hintbox` node in Tiptap when imported.
+The latest version of the `@tiptap-pro/extension-import-docx` has available the `prosemirrorNodes` configuration option. This option allows you to map custom nodes from the DOCX to your Tiptap schema. In the example above, we are mapping the `Hintbox` custom node from the DOCX to the `hintbox` custom node in our Tiptap schema. By doing so, whenever the DOCX contains a `Hintbox` custom node, it will be converted to a `hintbox` node in Tiptap when imported.
 
 <Callout title='DOCX, "prosemirrorNodes" and "prosemirrorMarks"' variant="info">
-  Please note that the `promisemirrorNodes` and `prosemirrorMarks` options will only work if you're importing a `.docx` file. If you're importing another type of file, eg: an `.odt` file, the `/import` endpoint will be used instead of the `/import-docx` endpoint, and the `promisemirrorNodes` and `prosemirrorMarks` options will not be available, and therefore you'd need to rely on the [custom node and mark mapping API](/conversion/import-export/docx/rest-api#custom-node-and-mark-mapping) for those endpoints.
+  Please note that the `prosemirrorNodes` and `prosemirrorMarks` options will only work if you're importing a `.docx` file. If you're importing another type of file, eg: an `.odt` file, the `/import` endpoint will be used instead of the `/import-docx` endpoint, and the `prosemirrorNodes` and `prosemirrorMarks` options will not be available, and therefore you'd need to rely on the [custom node and mark mapping API](/conversion/import-export/docx/rest-api#custom-node-and-mark-mapping) for those endpoints.
 </Callout>

--- a/src/content/conversion/import-export/docx/custom-node-conversion.mdx
+++ b/src/content/conversion/import-export/docx/custom-node-conversion.mdx
@@ -235,7 +235,7 @@ Import.configure({
   // ATTENTION: This is for demo purposes only
   endpoint: 'https://your-endpoint.com',
   imageUploadCallbackUrl: 'https://your-endpoint.com/image-upload',
-  // prosemirror custom node mapping
+  // ProseMirror custom node mapping
   prosemirrorNodes: {
     Hintbox: 'hintbox',
   },

--- a/src/content/conversion/import-export/docx/rest-api.mdx
+++ b/src/content/conversion/import-export/docx/rest-api.mdx
@@ -126,31 +126,31 @@ You can similarly adjust headings, lists, marks like bold or italic, and more.
 
 | Name             | Description                                                          |
 | ---------------- | -------------------------------------------------------------------- |
-| `paragraph`      | Defines which prosemirror type is used for paragraph conversion      |
-| `heading`        | Defines which prosemirror type is used for heading conversion        |
-| `blockquote`     | Defines which prosemirror type is used for blockquote conversion     |
-| `codeblock`      | Defines which prosemirror type is used for codeblock conversion      |
-| `bulletlist`     | Defines which prosemirror type is used for bulletList conversion     |
-| `orderedlist`    | Defines which prosemirror type is used for orderedList conversion    |
-| `listitem`       | Defines which prosemirror type is used for listItem conversion       |
-| `hardbreak`      | Defines which prosemirror type is used for hardbreak conversion      |
-| `horizontalrule` | Defines which prosemirror type is used for horizontalRule conversion |
-| `table`          | Defines which prosemirror type is used for table conversion          |
-| `tablecell`      | Defines which prosemirror type is used for tableCell conversion      |
-| `tableheader`    | Defines which prosemirror type is used for tableHeader conversion    |
-| `tablerow`       | Defines which prosemirror type is used for tableRow conversion       |
-| `image`          | Defines which prosemirror mark is used for image conversion          |
+| `paragraph`      | Defines which ProseMirror type is used for paragraph conversion      |
+| `heading`        | Defines which ProseMirror type is used for heading conversion        |
+| `blockquote`     | Defines which ProseMirror type is used for blockquote conversion     |
+| `codeblock`      | Defines which ProseMirror type is used for codeblock conversion      |
+| `bulletlist`     | Defines which ProseMirror type is used for bulletList conversion     |
+| `orderedlist`    | Defines which ProseMirror type is used for orderedList conversion    |
+| `listitem`       | Defines which ProseMirror type is used for listItem conversion       |
+| `hardbreak`      | Defines which ProseMirror type is used for hardbreak conversion      |
+| `horizontalrule` | Defines which ProseMirror type is used for horizontalRule conversion |
+| `table`          | Defines which ProseMirror type is used for table conversion          |
+| `tablecell`      | Defines which ProseMirror type is used for tableCell conversion      |
+| `tableheader`    | Defines which ProseMirror type is used for tableHeader conversion    |
+| `tablerow`       | Defines which ProseMirror type is used for tableRow conversion       |
+| `image`          | Defines which ProseMirror mark is used for image conversion          |
 
 #### Default marks
 
 | Name             | Description                                                          |
 | ---------------- | -------------------------------------------------------------------- |
-| `bold`           | Defines which prosemirror mark is used for bold conversion           |
-| `italic`         | Defines which prosemirror mark is used for italic conversion         |
-| `underline`      | Defines which prosemirror mark is used for underline conversion      |
-| `strikethrough`  | Defines which prosemirror mark is used for strikethrough conversion  |
-| `link`           | Defines which prosemirror mark is used for link conversion           |
-| `code`           | Defines which prosemirror mark is used for code conversion           |
+| `bold`           | Defines which ProseMirror mark is used for bold conversion           |
+| `italic`         | Defines which ProseMirror mark is used for italic conversion         |
+| `underline`      | Defines which ProseMirror mark is used for underline conversion      |
+| `strikethrough`  | Defines which ProseMirror mark is used for strikethrough conversion  |
+| `link`           | Defines which ProseMirror mark is used for link conversion           |
+| `code`           | Defines which ProseMirror mark is used for code conversion           |
 
 
 ## Export DOCX

--- a/src/content/conversion/import-export/docx/rest-api.mdx
+++ b/src/content/conversion/import-export/docx/rest-api.mdx
@@ -42,7 +42,7 @@ curl -X POST "https://api.tiptap.dev/v2/convert/import" \
     -H "X-App-Id: YOUR_APP_ID" \
     -F "file=@/path/to/your/file.docx" \
     -F "imageUploadCallbackUrl=https://your-image-upload-endpoint.com" \
-    -F "promisemirrorNodes={\"nodeKey\":\"nodeValue\"}" \
+    -F "prosemirrorNodes={\"nodeKey\":\"nodeValue\"}" \
     -F "prosemirrorMarks={\"markKey\":\"markValue\"}"
 ```
 

--- a/src/content/editor/api/utilities/html.mdx
+++ b/src/content/editor/api/utilities/html.mdx
@@ -22,7 +22,7 @@ The HTML Utility helps render JSON content as HTML and generate JSON from HTML w
 
 ## Generating HTML from JSON
 
-Given a JSON object, representing a prosemirror document, the `generateHTML` function will return a `string` object representing the JSON content. The function takes two arguments: the JSON object and a list of extensions.
+Given a JSON object, representing a ProseMirror document, the `generateHTML` function will return a `string` object representing the JSON content. The function takes two arguments: the JSON object and a list of extensions.
 
 ```js
 /* IN BROWSER ONLY - See below for server-side compatible package */
@@ -78,7 +78,7 @@ generateHTML(
 
 ## Generating JSON from HTML
 
-Given an HTML string, the `generateJSON` function will return a JSON object representing the HTML content as a prosemirror document. The function takes two arguments: the HTML string and a list of extensions.
+Given an HTML string, the `generateJSON` function will return a JSON object representing the HTML content as a ProseMirror document. The function takes two arguments: the HTML string and a list of extensions.
 
 ```js
 /* IN BROWSER ONLY - See below for server-side compatible package */

--- a/src/content/editor/api/utilities/static-renderer.mdx
+++ b/src/content/editor/api/utilities/static-renderer.mdx
@@ -370,7 +370,7 @@ import { renderToReactElement } from '@tiptap/static-renderer/pm/react'
 import { renderToHTMLString, renderToMarkdown, renderToReactElement } from '@tiptap/static-renderer'
 ```
 
-Packages in the `json` namespace are also available for statically rendering without a runtime dependency on any prosemirror packages. But, these packages cannot automatically map Prosemirror nodes and marks to the target format. You will need to provide custom mappings for every node and mark in these packages.
+Packages in the `json` namespace are also available for statically rendering without a runtime dependency on any ProseMirror packages. But, these packages cannot automatically map Prosemirror nodes and marks to the target format. You will need to provide custom mappings for every node and mark in these packages.
 
 ```ts
 // Just the HTML renderer
@@ -383,7 +383,7 @@ import { renderJSONContentToReactElement } from '@tiptap/static-renderer/json/re
 These packages have the same API as the `pm` namespace, but:
 
 - they require you to provide custom mappings for every node and mark
-- they do not require `extensions`, as they are not dependent on the prosemirror package
+- they do not require `extensions`, as they are not dependent on the ProseMirror package
 
 ### Custom mappings
 

--- a/src/content/editor/markdown/guides/create-a-admonition-block.mdx
+++ b/src/content/editor/markdown/guides/create-a-admonition-block.mdx
@@ -211,7 +211,7 @@ export const Admonition = Node.create({
     return {
       type: 'admonition',
       attrs: { type: token.admonitionType || 'note' },
-      // Parse nested tokens into tiptap content using the helpers
+      // Parse nested tokens into Tiptap content using the helpers
       content: helpers.parseChildren(token.tokens || []),
     }
   },
@@ -293,7 +293,7 @@ export const Admonition = Node.create({
     return {
       type: 'admonition',
       attrs: { type: token.admonitionType || 'note' },
-      // Parse nested tokens into tiptap content using the helpers
+      // Parse nested tokens into Tiptap content using the helpers
       content: helpers.parseChildren(token.tokens || []),
     }
   },
@@ -329,7 +329,7 @@ This will create an `admonition` node with `type: 'warning'` and the nested cont
 
 ## Testing and edge cases
 
-- Nested blocks: The tokenizer calls `lexer.blockTokens()` for inner content so the inner Markdown (lists, paragraphs, headings) will be parsed as regular block tokens and converted into tiptap content.
+- Nested blocks: The tokenizer calls `lexer.blockTokens()` for inner content so the inner Markdown (lists, paragraphs, headings) will be parsed as regular block tokens and converted into Tiptap content.
 - Inline formatting: Bold/italic/links inside the admonition content should be handled by your Markdown parser if `helpers.renderChildren` and `helpers.parseChildren` are wired to the same tokenset.
 - Trailing newlines: Pay attention to trailing newlines consumed by your tokenizer regex. Adjust the regex or the `renderMarkdown` output to match the expectations of your Markdown toolchain.
 - Types validation: If you want to enforce only specific types (e.g., `note | warning | tip | danger`) you can validate the `admonitionType` in `markdownTokenizer.tokenize` or in `parseMarkdown` and fall back to a default when required.

--- a/src/content/editor/markdown/guides/create-a-emoji-inline-block.mdx
+++ b/src/content/editor/markdown/guides/create-a-emoji-inline-block.mdx
@@ -188,7 +188,7 @@ export const Emoji = Node.create({
     },
   },
 
-  // Parse token into a tiptap node
+  // Parse token into a Tiptap node
   parseMarkdown: (token, helpers) => {
     return {
       type: 'emoji',
@@ -259,7 +259,7 @@ export const Emoji = Node.create({
     },
   },
 
-  // Parse token into a tiptap node
+  // Parse token into a Tiptap node
   parseMarkdown: (token, helpers) => {
     return {
       type: 'emoji',
@@ -267,7 +267,7 @@ export const Emoji = Node.create({
     }
   },
 
-  // Render tiptap node back to Markdown
+  // Render Tiptap node back to Markdown
   renderMarkdown: (node, helpers) => {
     // Serialize back to :name: shortcode. Use the stored name attribute.
     return `:${node.attrs?.name || 'unknown'}:`

--- a/src/content/guides/faq.mdx
+++ b/src/content/guides/faq.mdx
@@ -96,8 +96,8 @@ const TiptapEditor = ({ editor }) => {
 
 ## Why are there extra divs when I use a React Node View
 
-The reason that these divs exist is that prosemirror expects a node view to be generated synchronously, whereas React can only render asynchronously. So we inject an element, and later let React asynchronously render into that element. Causing there to be a wrapping div in the DOM.
+The reason that these divs exist is that ProseMirror expects a node view to be generated synchronously, whereas React can only render asynchronously. So we inject an element, and later let React asynchronously render into that element. Causing there to be a wrapping div in the DOM.
 
-Similarly, when using a `NodeViewContent` there is an element, which has created by React, and then Prosemirror renders into that element. This has to exist as a handoff from React to Prosemirror, because React's default behavior is to clear the element that it is rendering into, and we need to not have React destroy the element that prosemirror is trying to render the rich text into.
+Similarly, when using a `NodeViewContent` there is an element, which has created by React, and then Prosemirror renders into that element. This has to exist as a handoff from React to Prosemirror, because React's default behavior is to clear the element that it is rendering into, and we need to not have React destroy the element that ProseMirror is trying to render the rich text into.
 
 So, all of this to say, there is no good way to get rid of these intermediate elements because of how React works. You'd either have to use the JS NodeView API, or Vue because as either of those have more sane rendering approaches.

--- a/src/content/guides/legacy-conversion.mdx
+++ b/src/content/guides/legacy-conversion.mdx
@@ -128,7 +128,7 @@ editor
 
 - **Image upload** - Images are assumed to be inline within the document so, your editor should be setup with `Image.configure({ inline: true })` to display them correctly, otherwise they will be stripped from the document
 - **Unsupported docx elements on import** - Importing docx files currently does not support page breaks, page headers and footers, horizontal rules or text styles
-- **Content added via suggestion mode** - Content added via suggestion mode is not included in the imported prosemirror document
+- **Content added via suggestion mode** - Content added via suggestion mode is not included in the imported ProseMirror document
 - **PDF import & export** - Importing and exporting PDF files is not yet supported
 - **Inline styles** - Inline styles are currently not parsed and are not available in import & export
 
@@ -266,26 +266,26 @@ Specify how source document elements are mapped to ProseMirror nodes or marks, a
 
 | Name             | Default          | Description                                                          |
 | ---------------- | ---------------- | -------------------------------------------------------------------- |
-| `paragraph`      | `paragraph`      | Defines which prosemirror type is used for paragraph conversion      |
-| `heading`        | `heading`        | Defines which prosemirror type is used for heading conversion        |
-| `blockquote`     | `blockquote`     | Defines which prosemirror type is used for blockquote conversion     |
-| `codeblock`      | `codeblock`      | Defines which prosemirror type is used for codeblock conversion      |
-| `bulletlist`     | `bulletlist`     | Defines which prosemirror type is used for bulletList conversion     |
-| `orderedlist`    | `orderedlist`    | Defines which prosemirror type is used for orderedList conversion    |
-| `listitem`       | `listitem`       | Defines which prosemirror type is used for listItem conversion       |
-| `hardbreak`      | `hardbreak`      | Defines which prosemirror type is used for hardbreak conversion      |
-| `horizontalrule` | `horizontalrule` | Defines which prosemirror type is used for horizontalRule conversion |
-| `table`          | `table`          | Defines which prosemirror type is used for table conversion          |
-| `tablecell`      | `tablecell`      | Defines which prosemirror type is used for tableCell conversion      |
-| `tableheader`    | `tableheader`    | Defines which prosemirror type is used for tableHeader conversion    |
-| `tablerow`       | `tablerow`       | Defines which prosemirror type is used for tableRow conversion       |
-| `bold`           | `bold`           | Defines which prosemirror mark is used for bold conversion           |
-| `italic`         | `italic`         | Defines which prosemirror mark is used for italic conversion         |
-| `underline`      | `underline`      | Defines which prosemirror mark is used for underline conversion      |
-| `strikethrough`  | `strike`         | Defines which prosemirror mark is used for strikethrough conversion  |
-| `link`           | `link`           | Defines which prosemirror mark is used for link conversion           |
-| `code`           | `code`           | Defines which prosemirror mark is used for code conversion           |
-| `image`          | `image`          | Defines which prosemirror mark is used for image conversion          |
+| `paragraph`      | `paragraph`      | Defines which ProseMirror type is used for paragraph conversion      |
+| `heading`        | `heading`        | Defines which ProseMirror type is used for heading conversion        |
+| `blockquote`     | `blockquote`     | Defines which ProseMirror type is used for blockquote conversion     |
+| `codeblock`      | `codeblock`      | Defines which ProseMirror type is used for codeblock conversion      |
+| `bulletlist`     | `bulletlist`     | Defines which ProseMirror type is used for bulletList conversion     |
+| `orderedlist`    | `orderedlist`    | Defines which ProseMirror type is used for orderedList conversion    |
+| `listitem`       | `listitem`       | Defines which ProseMirror type is used for listItem conversion       |
+| `hardbreak`      | `hardbreak`      | Defines which ProseMirror type is used for hardbreak conversion      |
+| `horizontalrule` | `horizontalrule` | Defines which ProseMirror type is used for horizontalRule conversion |
+| `table`          | `table`          | Defines which ProseMirror type is used for table conversion          |
+| `tablecell`      | `tablecell`      | Defines which ProseMirror type is used for tableCell conversion      |
+| `tableheader`    | `tableheader`    | Defines which ProseMirror type is used for tableHeader conversion    |
+| `tablerow`       | `tablerow`       | Defines which ProseMirror type is used for tableRow conversion       |
+| `bold`           | `bold`           | Defines which ProseMirror mark is used for bold conversion           |
+| `italic`         | `italic`         | Defines which ProseMirror mark is used for italic conversion         |
+| `underline`      | `underline`      | Defines which ProseMirror mark is used for underline conversion      |
+| `strikethrough`  | `strike`         | Defines which ProseMirror mark is used for strikethrough conversion  |
+| `link`           | `link`           | Defines which ProseMirror mark is used for link conversion           |
+| `code`           | `code`           | Defines which ProseMirror mark is used for code conversion           |
+| `image`          | `image`          | Defines which ProseMirror mark is used for image conversion          |
 
 ### /import-docx endpoint (experimental)
 
@@ -313,26 +313,26 @@ Specify how source document elements are mapped to ProseMirror nodes or marks, a
 
 | Name             | Default          | Description                                                          |
 | ---------------- | ---------------- | -------------------------------------------------------------------- |
-| `paragraph`      | `paragraph`      | Defines which prosemirror type is used for paragraph conversion      |
-| `heading`        | `heading`        | Defines which prosemirror type is used for heading conversion        |
-| `blockquote`     | `blockquote`     | Defines which prosemirror type is used for blockquote conversion     |
-| `codeblock`      | `codeblock`      | Defines which prosemirror type is used for codeblock conversion      |
-| `bulletlist`     | `bulletlist`     | Defines which prosemirror type is used for bulletList conversion     |
-| `orderedlist`    | `orderedlist`    | Defines which prosemirror type is used for orderedList conversion    |
-| `listitem`       | `listitem`       | Defines which prosemirror type is used for listItem conversion       |
-| `hardbreak`      | `hardbreak`      | Defines which prosemirror type is used for hardbreak conversion      |
-| `horizontalrule` | `horizontalrule` | Defines which prosemirror type is used for horizontalRule conversion |
-| `table`          | `table`          | Defines which prosemirror type is used for table conversion          |
-| `tablecell`      | `tablecell`      | Defines which prosemirror type is used for tableCell conversion      |
-| `tableheader`    | `tableheader`    | Defines which prosemirror type is used for tableHeader conversion    |
-| `tablerow`       | `tablerow`       | Defines which prosemirror type is used for tableRow conversion       |
-| `bold`           | `bold`           | Defines which prosemirror mark is used for bold conversion           |
-| `italic`         | `italic`         | Defines which prosemirror mark is used for italic conversion         |
-| `underline`      | `underline`      | Defines which prosemirror mark is used for underline conversion      |
-| `strikethrough`  | `strike`         | Defines which prosemirror mark is used for strikethrough conversion  |
-| `link`           | `link`           | Defines which prosemirror mark is used for link conversion           |
-| `code`           | `code`           | Defines which prosemirror mark is used for code conversion           |
-| `image`          | `image`          | Defines which prosemirror mark is used for image conversion          |
+| `paragraph`      | `paragraph`      | Defines which ProseMirror type is used for paragraph conversion      |
+| `heading`        | `heading`        | Defines which ProseMirror type is used for heading conversion        |
+| `blockquote`     | `blockquote`     | Defines which ProseMirror type is used for blockquote conversion     |
+| `codeblock`      | `codeblock`      | Defines which ProseMirror type is used for codeblock conversion      |
+| `bulletlist`     | `bulletlist`     | Defines which ProseMirror type is used for bulletList conversion     |
+| `orderedlist`    | `orderedlist`    | Defines which ProseMirror type is used for orderedList conversion    |
+| `listitem`       | `listitem`       | Defines which ProseMirror type is used for listItem conversion       |
+| `hardbreak`      | `hardbreak`      | Defines which ProseMirror type is used for hardbreak conversion      |
+| `horizontalrule` | `horizontalrule` | Defines which ProseMirror type is used for horizontalRule conversion |
+| `table`          | `table`          | Defines which ProseMirror type is used for table conversion          |
+| `tablecell`      | `tablecell`      | Defines which ProseMirror type is used for tableCell conversion      |
+| `tableheader`    | `tableheader`    | Defines which ProseMirror type is used for tableHeader conversion    |
+| `tablerow`       | `tablerow`       | Defines which ProseMirror type is used for tableRow conversion       |
+| `bold`           | `bold`           | Defines which ProseMirror mark is used for bold conversion           |
+| `italic`         | `italic`         | Defines which ProseMirror mark is used for italic conversion         |
+| `underline`      | `underline`      | Defines which ProseMirror mark is used for underline conversion      |
+| `strikethrough`  | `strike`         | Defines which ProseMirror mark is used for strikethrough conversion  |
+| `link`           | `link`           | Defines which ProseMirror mark is used for link conversion           |
+| `code`           | `code`           | Defines which ProseMirror mark is used for code conversion           |
+| `image`          | `image`          | Defines which ProseMirror mark is used for image conversion          |
 
 ### /export endpoint
 
@@ -361,22 +361,22 @@ Convert a Tiptap document to a different format.
 | Name             | Default          | Description                                                          |
 | ---------------- | ---------------- | -------------------------------------------------------------------- |
 | `gfm`            | `0`              | Use Github Flavored Markdown for markdown export                     |
-| `paragraph`      | `paragraph`      | Defines which prosemirror type is used for paragraph conversion      |
-| `heading`        | `heading`        | Defines which prosemirror type is used for heading conversion        |
-| `blockquote`     | `blockquote`     | Defines which prosemirror type is used for blockquote conversion     |
-| `codeblock`      | `codeblock`      | Defines which prosemirror type is used for codeblock conversion      |
-| `bulletlist`     | `bulletlist`     | Defines which prosemirror type is used for bulletList conversion     |
-| `orderedlist`    | `orderedlist`    | Defines which prosemirror type is used for orderedList conversion    |
-| `listitem`       | `listitem`       | Defines which prosemirror type is used for listItem conversion       |
-| `hardbreak`      | `hardbreak`      | Defines which prosemirror type is used for hardbreak conversion      |
-| `horizontalrule` | `horizontalrule` | Defines which prosemirror type is used for horizontalRule conversion |
-| `table`          | `table`          | Defines which prosemirror type is used for table conversion          |
-| `tablecell`      | `tablecell`      | Defines which prosemirror type is used for tableCell conversion      |
-| `tableheader`    | `tableheader`    | Defines which prosemirror type is used for tableHeader conversion    |
-| `tablerow`       | `tablerow`       | Defines which prosemirror type is used for tableRow conversion       |
-| `bold`           | `bold`           | Defines which prosemirror mark is used for bold conversion           |
-| `italic`         | `italic`         | Defines which prosemirror mark is used for italic conversion         |
-| `underline`      | `underline`      | Defines which prosemirror mark is used for underline conversion      |
-| `strikethrough`  | `strike`         | Defines which prosemirror mark is used for strikethrough conversion  |
-| `link`           | `link`           | Defines which prosemirror mark is used for link conversion           |
-| `code`           | `code`           | Defines which prosemirror mark is used for code conversion           |
+| `paragraph`      | `paragraph`      | Defines which ProseMirror type is used for paragraph conversion      |
+| `heading`        | `heading`        | Defines which ProseMirror type is used for heading conversion        |
+| `blockquote`     | `blockquote`     | Defines which ProseMirror type is used for blockquote conversion     |
+| `codeblock`      | `codeblock`      | Defines which ProseMirror type is used for codeblock conversion      |
+| `bulletlist`     | `bulletlist`     | Defines which ProseMirror type is used for bulletList conversion     |
+| `orderedlist`    | `orderedlist`    | Defines which ProseMirror type is used for orderedList conversion    |
+| `listitem`       | `listitem`       | Defines which ProseMirror type is used for listItem conversion       |
+| `hardbreak`      | `hardbreak`      | Defines which ProseMirror type is used for hardbreak conversion      |
+| `horizontalrule` | `horizontalrule` | Defines which ProseMirror type is used for horizontalRule conversion |
+| `table`          | `table`          | Defines which ProseMirror type is used for table conversion          |
+| `tablecell`      | `tablecell`      | Defines which ProseMirror type is used for tableCell conversion      |
+| `tableheader`    | `tableheader`    | Defines which ProseMirror type is used for tableHeader conversion    |
+| `tablerow`       | `tablerow`       | Defines which ProseMirror type is used for tableRow conversion       |
+| `bold`           | `bold`           | Defines which ProseMirror mark is used for bold conversion           |
+| `italic`         | `italic`         | Defines which ProseMirror mark is used for italic conversion         |
+| `underline`      | `underline`      | Defines which ProseMirror mark is used for underline conversion      |
+| `strikethrough`  | `strike`         | Defines which ProseMirror mark is used for strikethrough conversion  |
+| `link`           | `link`           | Defines which ProseMirror mark is used for link conversion           |
+| `code`           | `code`           | Defines which ProseMirror mark is used for code conversion           |


### PR DESCRIPTION
There have been some naming mistakes for the prosemirrorNodes mapping usage in the docx import documentation. 