### PR TITLE
[DOCX Import] Fix confusion related to prosemirrorNodes/prosemirrorMarks mapping

### DIFF
--- a/src/content/conversion/import-export/docx/custom-mark-conversion.mdx
+++ b/src/content/conversion/import-export/docx/custom-mark-conversion.mdx
@@ -38,8 +38,8 @@ const editor = new Editor({
       imageUploadCallbackUrl: 'https://your-endpoint.com/image-upload',
       // ProseMirror custom mark mapping
       prosemirrorMarks: {
-        bold: 'strong',
-        italic: 'em',
+        strong: 'bold',
+        em: 'italic',
       }
     }),
     // Other extensions ...
@@ -50,11 +50,11 @@ const editor = new Editor({
 
 The latest version of the `@tiptap-pro/extension-import-docx` has the `prosemirrorMarks` configuration option available.
 
-This option allows you to map custom nodes from the DOCX to your Tiptap schema. In the example above, we are mapping the `bold` and `italic` nodes from the DOCX to the `strong` and `em` nodes in our Tiptap schema.
+This option allows you to map custom nodes from the DOCX to your Tiptap schema. In the example above, we are mapping the `strong` and `em` nodes from the DOCX to the `bold` and `italic` nodes in our Tiptap schema.
 
-By doing so, whenever the DOCX contains a `bold` or `italic` node, it will be converted to a `strong` or `italic` node in Tiptap when imported.
+By doing so, whenever the DOCX contains a `strong` or `em` node, it will be converted to a `bold` or `italic` node in Tiptap when imported.
 
 <Callout title='DOCX, "prosemirrorNodes" and "prosemirrorMarks"' variant="info">
-  Please note that the `prosemirrorNodes` and `prosemirrorMarks` options will only work if you're importing a `.docx` file. If you're importing another type of file, eg: an `.odt` file, the `/import` endpoint will be used instead of the `/import` endpoint, and the `prosemirrorNodes` and `prosemirrorMarks` options will not be available.
+  Please note that the `prosemirrorNodes` and `prosemirrorMarks` options will only work if you're importing a `.docx` file. If you're importing another type of file, eg: an `.odt` file, the `/import` endpoint will be used instead of the `/import-docx` endpoint, and the `prosemirrorNodes` and `prosemirrorMarks` options will not be available.
 </Callout>
 

--- a/src/content/conversion/import-export/docx/rest-api.mdx
+++ b/src/content/conversion/import-export/docx/rest-api.mdx
@@ -118,7 +118,7 @@ The verbose output will give you, along the `data` property, one more property c
 
 You can override the default `node/mark` types used during import by specifying them in the body of your request within `prosemirrorNodes` and `prosemirrorMarks` respectively. You would need to provide these if your editor uses custom `nodes/marks` and you want the imported `JSON` to use those.
 
-For example, if your schema uses a custom node type called `textBlock` instead of the default paragraph, you can include `"{\"paragraph\":\"textBlock\"}"` in the request body.
+For example, if your schema uses a custom node type called `textBlock` instead of the default paragraph, you can include `"{\"textBlock\":\"paragraph\"}"` in the request body.
 
 You can similarly adjust headings, lists, marks like bold or italic, and more.
 


### PR DESCRIPTION
This pull request fixes some mistakes in the examples and explanations of how to map nodes/marks.

It should always behave like this:

{
    docxNode: tiptapNode,
}