### PR TITLE
Update `mention.mdx` / `emoji.mdx` to remove `tippy.js` instructions

### DIFF
--- a/src/content/editor/extensions/nodes/emoji.mdx
+++ b/src/content/editor/extensions/nodes/emoji.mdx
@@ -35,14 +35,6 @@ The `Emoji` extension renders emojis as an inline node. All inserted (typed, pas
 npm install @tiptap/extension-emoji
 ```
 
-## Dependencies
-
-To place the popups correctly, we’re using [tippy.js](https://atomiks.github.io/tippyjs/) in all our examples. You are free to bring your own library, but if you’re fine with it, just install what we use:
-
-```bash
-npm install tippy.js
-```
-
 ## Settings
 
 ### HTMLAttributes

--- a/src/content/editor/extensions/nodes/mention.mdx
+++ b/src/content/editor/extensions/nodes/mention.mdx
@@ -37,12 +37,6 @@ npm install @tiptap/extension-mention
 
 ## Dependencies
 
-To place the popups correctly, we’re using [tippy.js](https://atomiks.github.io/tippyjs/) in all our examples. You are free to bring your own library, but if you’re fine with it, just install what we use:
-
-```bash
-npm install tippy.js
-```
-
 Since 2.0.0-beta.193 we marked the `@tiptap/suggestion` as a peer dependency. That means, you will need to install it manually.
 
 ```bash


### PR DESCRIPTION
tippy.js was replaced with Floating UI https://github.com/ueberdosis/tiptap-docs/blob/554d7c02ebbbd53145ecc7947812765979d111c4/src/content/guides/upgrade-tiptap-v2.mdx?plain=1#L74

Closes https://github.com/ueberdosis/tiptap-docs/issues/200