### PR TITLE
Update AI Toolkit docs for simplified suggestions API

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/compare-documents.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/compare-documents.mdx
@@ -56,17 +56,23 @@ The diff is displayed as [suggestions](/content-ai/capabilities/ai-toolkit/primi
 }
 ```
 
-Call `getSuggestions` to get a list of each individual change between the documents, stored as [suggestions](/content-ai/capabilities/ai-toolkit/primitives/display-suggestions). Then, call `acceptChange` or `rejectChange` to accept or reject them individually.
+Call `getSuggestions` to get a list of each individual change between the documents, stored as [suggestions](/content-ai/capabilities/ai-toolkit/primitives/display-suggestions). Then, call `acceptSuggestion` or `rejectSuggestion` to accept or reject them individually.
 
 ```ts
 // Get all changes (as suggestions)
 const suggestions = toolkit.getSuggestions()
 
 // Accept the first change
-toolkit.acceptChange(suggestions[0].id)
+toolkit.acceptSuggestion(suggestions[0].id)
 
 // Reject the first change
-toolkit.rejectChange(suggestions[0].id)
+toolkit.rejectSuggestion(suggestions[0].id)
+
+// Accept all changes
+toolkit.acceptAllSuggestions()
+
+// Reject all changes
+toolkit.rejectAllSuggestions()
 ```
 
 To stop comparing documents, use the `stopComparingDocuments` method. It hides the diff view and clears the suggestions.

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,14 +8,26 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
-## 3.0.0-alpha.49
+## 3.0.0-alpha.50
+
+### Major Changes
+
+- Simplify the suggestions API by unifying regular suggestions and compare-documents changes into a single set of methods.
+- Remove `acceptChange`, `rejectChange`, and `rejectAllChanges` methods from the compare-documents feature. Use `acceptSuggestion`, `rejectSuggestion`, `acceptAllSuggestions`, and `rejectAllSuggestions` instead. These methods now handle both regular suggestions and changes from the compare-documents feature.
+- Rename `applySuggestion` to `acceptSuggestion` and `applyAllSuggestions` to `acceptAllSuggestions` for clarity and consistency with the new `rejectSuggestion` and `rejectAllSuggestions` methods.
 
 ### Minor Changes
 
 - Add `reviewMode` field to `Suggestion` interface. This field indicates whether a suggestion is in 'preview' mode (preview of a change before applying) or 'review' mode (review of a change that has already been made, allowing the user to undo it). The field is automatically set based on `reviewOptions.mode` when suggestions are created.
 - Add `rejectSuggestion` and `rejectAllSuggestions` methods to reject suggestions without applying them. These methods return AI feedback about the rejected changes.
-- Modify `applySuggestion` and `applyAllSuggestions` methods to return `aiFeedback` property. The `aiFeedback` contains events with information about changes that were accepted or rejected by the user, including the deleted content, inserted content, and acceptance status. This feedback can be used to inform the AI about user preferences and improve future suggestions.
-- Modify `acceptChange`, `rejectChange`, and `rejectAllChanges` methods to return `aiFeedback` property. The `aiFeedback` contains events with information about changes that were accepted or rejected by the user, including the deleted content, inserted content, and acceptance status. This feedback can be used to inform the AI about user preferences and improve future suggestions when comparing documents.
+- Modify `acceptSuggestion` and `acceptAllSuggestions` methods to return `aiFeedback` property. The `aiFeedback` contains events with information about changes that were accepted or rejected by the user, including the deleted content, inserted content, and acceptance status. This feedback can be used to inform the AI about user preferences and improve future suggestions.
+
+## 3.0.0-alpha.49
+
+### Patch Changes
+
+- Replace deprecated dependency `moize` with `micro-memoize`.
+- Remove unused dependency `debounce`.
 
 ## 3.0.0-alpha.48
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -20,7 +20,7 @@ meta:
 
 - Add `reviewMode` field to `Suggestion` interface. This field indicates whether a suggestion is in 'preview' mode (preview of a change before applying) or 'review' mode (review of a change that has already been made, allowing the user to undo it). The field is automatically set based on `reviewOptions.mode` when suggestions are created.
 - Add `rejectSuggestion` and `rejectAllSuggestions` methods to reject suggestions without applying them. These methods return AI feedback about the rejected changes.
-- Modify `acceptSuggestion` and `acceptAllSuggestions` methods to return `aiFeedback` property. The `aiFeedback` contains events with information about changes that were accepted or rejected by the user, including the deleted content, inserted content, and acceptance status. This feedback can be used to inform the AI about user preferences and improve future suggestions.
+- Modify `acceptSuggestion` and `acceptAllSuggestions` methods to return `aiFeedback` property. The `aiFeedback` contains events with information about changes that were accepted or rejected by the user.
 
 ## 3.0.0-alpha.49
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -15,6 +15,7 @@ meta:
 - Add `reviewMode` field to `Suggestion` interface. This field indicates whether a suggestion is in 'preview' mode (preview of a change before applying) or 'review' mode (review of a change that has already been made, allowing the user to undo it). The field is automatically set based on `reviewOptions.mode` when suggestions are created.
 - Add `rejectSuggestion` and `rejectAllSuggestions` methods to reject suggestions without applying them. These methods return AI feedback about the rejected changes.
 - Modify `applySuggestion` and `applyAllSuggestions` methods to return `aiFeedback` property. The `aiFeedback` contains events with information about changes that were accepted or rejected by the user, including the deleted content, inserted content, and acceptance status. This feedback can be used to inform the AI about user preferences and improve future suggestions.
+- Modify `acceptChange`, `rejectChange`, and `rejectAllChanges` methods to return `aiFeedback` property. The `aiFeedback` contains events with information about changes that were accepted or rejected by the user, including the deleted content, inserted content, and acceptance status. This feedback can be used to inform the AI about user preferences and improve future suggestions when comparing documents.
 
 ## 3.0.0-alpha.48
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,14 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.49
+
+### Minor Changes
+
+- Add `reviewMode` field to `Suggestion` interface. This field indicates whether a suggestion is in 'preview' mode (preview of a change before applying) or 'review' mode (review of a change that has already been made, allowing the user to undo it). The field is automatically set based on `reviewOptions.mode` when suggestions are created.
+- Add `rejectSuggestion` and `rejectAllSuggestions` methods to reject suggestions without applying them. These methods return AI feedback about the rejected changes.
+- Modify `applySuggestion` and `applyAllSuggestions` methods to return `aiFeedback` property. The `aiFeedback` contains events with information about changes that were accepted or rejected by the user, including the deleted content, inserted content, and acceptance status. This feedback can be used to inform the AI about user preferences and improve future suggestions.
+
 ## 3.0.0-alpha.48
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot.mdx
@@ -97,9 +97,34 @@ To access the OpenAI API, create an API key in the [OpenAI Dashboard](https://pl
 OPENAI_API_KEY=your-api-key
 ```
 
+When the AI model receives a request, it will decide to call the available tools to read the document and edit it. See the [list of available tools](/content-ai/capabilities/ai-toolkit/tools/available-tools) for more details.
+
 ## Client-side setup
 
-Create a client-side React component that renders the Tiptap Editor and a simple chat UI. This component leverages the [useChat hook](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat) from the Vercel AI SDK to call the API endpoint and manage the chat conversation. When the AI model outputs a tool call, it uses the Tiptap AI Toolkit to execute the tool.
+When the AI model decides to call a tool, it needs to be executed on the client. This is done with the [`executeTool` method](/content-ai/capabilities/ai-toolkit/primitives/execute-tool):
+
+```ts
+import { Editor } from '@tiptap/react'
+import { getAiToolkit } from '@tiptap-pro/ai-toolkit'
+
+// Create a Tiptap Editor instance
+const editor = new Editor()
+
+// Get the Tiptap AI Toolkit instance
+const toolkit = getAiToolkit(editor)
+
+// The AI decides to call the `tiptapRead` tool to read the document
+// Use the `executeTool` method to execute the tool and get the result
+const result = toolkit.executeTool({
+  // The name of the tool to execute
+  toolName: 'tiptapRead',
+  // AI-generated input
+  input: {},
+})
+// Send the result back to the AI model
+```
+
+To implement this in your app, create a client-side React component that renders the Tiptap Editor and a simple chat UI. This component leverages the [useChat hook](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat) from the Vercel AI SDK to call the API endpoint and manage the chat conversation.
 
 ```tsx
 // app/page.tsx

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/review-changes-as-summary.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/review-changes-as-summary.mdx
@@ -78,12 +78,12 @@ const toolkit = getAiToolkit(editor)
 toolkit.stopComparingDocuments()
 ```
 
-To reject all changes, call the `rejectAllChanges` method. This will reset the editor content to how it was before the AI made changes. The method returns AI feedback that you can collect and include in the next user message. Then, call `stopComparingDocuments` to stop the real-time document comparison.
+To reject all changes, call the `rejectAllSuggestions` method. This will reset the editor content to how it was before the AI made changes. The method returns AI feedback that you can collect and include in the next user message. Then, call `stopComparingDocuments` to stop the real-time document comparison.
 
 ```ts
-const result = toolkit.rejectAllChanges()
+const result = toolkit.rejectAllSuggestions()
 // Collect feedback events to include in next user message
-const allFeedbackEvents = result.aiFeedback.events
+const userFeedback = result.aiFeedback.events
 toolkit.stopComparingDocuments()
 ```
 
@@ -93,7 +93,7 @@ You can also display buttons or a popover over a suggestion, with actions to acc
 
 To render custom elements in the UI, set the `displayOptions` parameter. There, you can set the `renderDecorations` option. It's a function that returns a list of [ProseMirror decorations](https://prosemirror.net/docs/ref/#view.Decorations).
 
-The `acceptChange` and `rejectChange` methods return AI feedback that you can collect and send to the AI to improve future suggestions:
+The `acceptSuggestion` and `rejectSuggestion` methods return AI feedback that you can collect and send to the AI to improve future suggestions.
 
 ```tsx
 toolkit.startComparingDocuments({
@@ -107,12 +107,15 @@ toolkit.startComparingDocuments({
           const element = document.createElement('button')
           element.textContent = 'Accept'
           element.addEventListener('click', () => {
-            const result = toolkit.acceptChange(options.suggestion.id)
+            const result = toolkit.acceptSuggestion(options.suggestion.id)
             // Collect feedback events
             setReviewState((prev) => ({
               ...prev,
-              feedbackEvents: [...prev.feedbackEvents, ...result.aiFeedback.events],
+              userFeedback: [...prev.userFeedback, ...result.aiFeedback.events],
             }))
+            if (toolkit.getSuggestions().length === 0) {
+              stopComparing()
+            }
           })
           return element
         }),
@@ -122,12 +125,15 @@ toolkit.startComparingDocuments({
           const element = document.createElement('button')
           element.textContent = 'Reject'
           element.addEventListener('click', () => {
-            const result = toolkit.rejectChange(options.suggestion.id)
+            const result = toolkit.rejectSuggestion(options.suggestion.id)
             // Collect feedback events
             setReviewState((prev) => ({
               ...prev,
-              feedbackEvents: [...prev.feedbackEvents, ...result.aiFeedback.events],
+              userFeedback: [...prev.userFeedback, ...result.aiFeedback.events],
             }))
+            if (toolkit.getSuggestions().length === 0) {
+              stopComparing()
+            }
           })
           return element
         }),
@@ -143,13 +149,13 @@ toolkit.startComparingDocuments({
 // app/page.tsx
 'use client'
 
-import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from 'ai'
 import { useChat } from '@ai-sdk/react'
+import { Decoration } from '@tiptap/pm/view'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import { useRef, useState } from 'react'
 import { AiToolkit, getAiToolkit, type SuggestionFeedbackEvent } from '@tiptap-pro/ai-toolkit'
-import { Decoration } from '@tiptap/pm/view'
+import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from 'ai'
+import { useRef, useState } from 'react'
 import './suggestions.css'
 
 export default function Page() {
@@ -163,11 +169,6 @@ export default function Page() {
   const editorRef = useRef(editor)
   editorRef.current = editor
 
-  const [reviewState, setReviewState] = useState({
-    isComparing: false,
-    feedbackEvents: [] as SuggestionFeedbackEvent[],
-  })
-
   const { messages, sendMessage, addToolOutput, status } = useChat({
     transport: new DefaultChatTransport({ api: '/api/chat' }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
@@ -178,7 +179,7 @@ export default function Page() {
       const { toolName, input, toolCallId } = toolCall
 
       // Reset feedback events when a new tool call starts
-      setReviewState((prev) => ({ ...prev, feedbackEvents: [] }))
+      setReviewState((prev) => ({ ...prev, userFeedback: [] }))
 
       // Use the AI Toolkit to execute the tool
       const toolkit = getAiToolkit(editor)
@@ -192,10 +193,19 @@ export default function Page() {
   })
 
   const [input, setInput] = useState('Replace the last paragraph with a short story about Tiptap')
+  const [reviewState, setReviewState] = useState({
+    isComparing: false,
+    userFeedback: [] as SuggestionFeedbackEvent[],
+  })
 
   if (!editor) return null
 
   const toolkit = getAiToolkit(editor)
+
+  function stopComparing() {
+    toolkit.stopComparingDocuments()
+    setReviewState((prev) => ({ ...prev, isComparing: false }))
+  }
 
   const showReviewUI = reviewState.isComparing && status === 'ready'
 
@@ -221,9 +231,9 @@ export default function Page() {
 
             // Build message text with feedback if available
             let messageText = input.trim()
-            if (reviewState.feedbackEvents.length > 0) {
-              const feedbackOutput = JSON.stringify(reviewState.feedbackEvents)
-              messageText = `${messageText}\n\n<user_feedback>${feedbackOutput}</user_feedback>`
+            if (reviewState.userFeedback.length > 0) {
+              const feedbackOutput = JSON.stringify(reviewState.userFeedback)
+              messageText += `\n\n<user_feedback>${feedbackOutput}</user_feedback>`
             }
 
             toolkit.startComparingDocuments({
@@ -237,11 +247,14 @@ export default function Page() {
                       const element = document.createElement('button')
                       element.textContent = 'Accept'
                       element.addEventListener('click', () => {
-                        const result = toolkit.acceptChange(options.suggestion.id)
+                        const result = toolkit.acceptSuggestion(options.suggestion.id)
                         setReviewState((prev) => ({
                           ...prev,
-                          feedbackEvents: [...prev.feedbackEvents, ...result.aiFeedback.events],
+                          userFeedback: [...prev.userFeedback, ...result.aiFeedback.events],
                         }))
+                        if (toolkit.getSuggestions().length === 0) {
+                          stopComparing()
+                        }
                       })
                       return element
                     }),
@@ -251,11 +264,14 @@ export default function Page() {
                       const element = document.createElement('button')
                       element.textContent = 'Reject'
                       element.addEventListener('click', () => {
-                        const result = toolkit.rejectChange(options.suggestion.id)
+                        const result = toolkit.rejectSuggestion(options.suggestion.id)
                         setReviewState((prev) => ({
                           ...prev,
-                          feedbackEvents: [...prev.feedbackEvents, ...result.aiFeedback.events],
+                          userFeedback: [...prev.userFeedback, ...result.aiFeedback.events],
                         }))
+                        if (toolkit.getSuggestions().length === 0) {
+                          stopComparing()
+                        }
                       })
                       return element
                     }),
@@ -268,7 +284,7 @@ export default function Page() {
             if (messageText) {
               sendMessage({ text: messageText })
               setInput('')
-              setReviewState((prev) => ({ ...prev, feedbackEvents: [] }))
+              setReviewState((prev) => ({ ...prev, userFeedback: [] }))
             }
           }}
         >
@@ -284,12 +300,12 @@ export default function Page() {
           <h2>Reviewing Changes</h2>
           <button
             onClick={() => {
-              const result = toolkit.acceptAllChanges()
+              const result = toolkit.acceptAllSuggestions()
               // Collect all feedback events
-              const allFeedbackEvents = [...reviewState.feedbackEvents, ...result.aiFeedback.events]
+              const userFeedback = [...reviewState.userFeedback, ...result.aiFeedback.events]
               setReviewState({
                 isComparing: false,
-                feedbackEvents: allFeedbackEvents,
+                userFeedback,
               })
               toolkit.stopComparingDocuments()
             }}
@@ -298,12 +314,12 @@ export default function Page() {
           </button>
           <button
             onClick={() => {
-              const result = toolkit.rejectAllChanges()
+              const result = toolkit.rejectAllSuggestions()
               // Collect all feedback events
-              const allFeedbackEvents = [...reviewState.feedbackEvents, ...result.aiFeedback.events]
+              const userFeedback = [...reviewState.userFeedback, ...result.aiFeedback.events]
               setReviewState({
                 isComparing: false,
-                feedbackEvents: allFeedbackEvents,
+                userFeedback,
               })
               toolkit.stopComparingDocuments()
             }}

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/review-changes-as-summary.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/review-changes-as-summary.mdx
@@ -78,10 +78,12 @@ const toolkit = getAiToolkit(editor)
 toolkit.stopComparingDocuments()
 ```
 
-To reject all changes, call the `rejectAllChanges` method. This will reset the editor content to how it was before the AI made changes. Then, call `stopComparingDocuments` to stop the real-time document comparison.
+To reject all changes, call the `rejectAllChanges` method. This will reset the editor content to how it was before the AI made changes. The method returns AI feedback that you can collect and include in the next user message. Then, call `stopComparingDocuments` to stop the real-time document comparison.
 
 ```ts
-toolkit.rejectAllChanges()
+const result = toolkit.rejectAllChanges()
+// Collect feedback events to include in next user message
+const allFeedbackEvents = result.aiFeedback.events
 toolkit.stopComparingDocuments()
 ```
 
@@ -90,6 +92,8 @@ toolkit.stopComparingDocuments()
 You can also display buttons or a popover over a suggestion, with actions to accept or reject its associated change.
 
 To render custom elements in the UI, set the `displayOptions` parameter. There, you can set the `renderDecorations` option. It's a function that returns a list of [ProseMirror decorations](https://prosemirror.net/docs/ref/#view.Decorations).
+
+The `acceptChange` and `rejectChange` methods return AI feedback that you can collect and send to the AI to improve future suggestions:
 
 ```tsx
 toolkit.startComparingDocuments({
@@ -103,7 +107,12 @@ toolkit.startComparingDocuments({
           const element = document.createElement('button')
           element.textContent = 'Accept'
           element.addEventListener('click', () => {
-            toolkit.acceptChange(options.suggestion.id)
+            const result = toolkit.acceptChange(options.suggestion.id)
+            // Collect feedback events
+            setReviewState((prev) => ({
+              ...prev,
+              feedbackEvents: [...prev.feedbackEvents, ...result.aiFeedback.events],
+            }))
           })
           return element
         }),
@@ -113,7 +122,12 @@ toolkit.startComparingDocuments({
           const element = document.createElement('button')
           element.textContent = 'Reject'
           element.addEventListener('click', () => {
-            toolkit.rejectChange(options.suggestion.id)
+            const result = toolkit.rejectChange(options.suggestion.id)
+            // Collect feedback events
+            setReviewState((prev) => ({
+              ...prev,
+              feedbackEvents: [...prev.feedbackEvents, ...result.aiFeedback.events],
+            }))
           })
           return element
         }),
@@ -134,7 +148,7 @@ import { useChat } from '@ai-sdk/react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import { useRef, useState } from 'react'
-import { AiToolkit, getAiToolkit } from '@tiptap-pro/ai-toolkit'
+import { AiToolkit, getAiToolkit, type SuggestionFeedbackEvent } from '@tiptap-pro/ai-toolkit'
 import { Decoration } from '@tiptap/pm/view'
 import './suggestions.css'
 
@@ -149,7 +163,12 @@ export default function Page() {
   const editorRef = useRef(editor)
   editorRef.current = editor
 
-  const { messages, sendMessage, addtoolOutput, status } = useChat({
+  const [reviewState, setReviewState] = useState({
+    isComparing: false,
+    feedbackEvents: [] as SuggestionFeedbackEvent[],
+  })
+
+  const { messages, sendMessage, addToolOutput, status } = useChat({
     transport: new DefaultChatTransport({ api: '/api/chat' }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     async onToolCall({ toolCall }) {
@@ -158,6 +177,9 @@ export default function Page() {
 
       const { toolName, input, toolCallId } = toolCall
 
+      // Reset feedback events when a new tool call starts
+      setReviewState((prev) => ({ ...prev, feedbackEvents: [] }))
+
       // Use the AI Toolkit to execute the tool
       const toolkit = getAiToolkit(editor)
       const result = toolkit.executeTool({
@@ -165,18 +187,17 @@ export default function Page() {
         input,
       })
 
-      addtoolOutput({ tool: toolName, toolCallId, output: result.output })
+      addToolOutput({ tool: toolName, toolCallId, output: result.output })
     },
   })
 
   const [input, setInput] = useState('Replace the last paragraph with a short story about Tiptap')
-  const [isComparing, setIsComparing] = useState(false)
 
   if (!editor) return null
 
   const toolkit = getAiToolkit(editor)
 
-  const showReviewUI = isComparing && status === 'ready'
+  const showReviewUI = reviewState.isComparing && status === 'ready'
 
   return (
     <div>
@@ -196,7 +217,14 @@ export default function Page() {
           onSubmit={(e) => {
             e.preventDefault()
 
-            if (isComparing) return
+            if (reviewState.isComparing) return
+
+            // Build message text with feedback if available
+            let messageText = input.trim()
+            if (reviewState.feedbackEvents.length > 0) {
+              const feedbackOutput = JSON.stringify(reviewState.feedbackEvents)
+              messageText = `${messageText}\n\n<user_feedback>${feedbackOutput}</user_feedback>`
+            }
 
             toolkit.startComparingDocuments({
               displayOptions: {
@@ -209,7 +237,11 @@ export default function Page() {
                       const element = document.createElement('button')
                       element.textContent = 'Accept'
                       element.addEventListener('click', () => {
-                        toolkit.acceptChange(options.suggestion.id)
+                        const result = toolkit.acceptChange(options.suggestion.id)
+                        setReviewState((prev) => ({
+                          ...prev,
+                          feedbackEvents: [...prev.feedbackEvents, ...result.aiFeedback.events],
+                        }))
                       })
                       return element
                     }),
@@ -219,7 +251,11 @@ export default function Page() {
                       const element = document.createElement('button')
                       element.textContent = 'Reject'
                       element.addEventListener('click', () => {
-                        toolkit.rejectChange(options.suggestion.id)
+                        const result = toolkit.rejectChange(options.suggestion.id)
+                        setReviewState((prev) => ({
+                          ...prev,
+                          feedbackEvents: [...prev.feedbackEvents, ...result.aiFeedback.events],
+                        }))
                       })
                       return element
                     }),
@@ -227,13 +263,20 @@ export default function Page() {
                 },
               },
             })
-            setIsComparing(true)
+            setReviewState((prev) => ({ ...prev, isComparing: true }))
 
-            sendMessage({ text: input })
-            setInput('')
+            if (messageText) {
+              sendMessage({ text: messageText })
+              setInput('')
+              setReviewState((prev) => ({ ...prev, feedbackEvents: [] }))
+            }
           }}
         >
-          <input disabled={isComparing} value={input} onChange={(e) => setInput(e.target.value)} />
+          <input
+            disabled={reviewState.isComparing}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+          />
         </form>
       )}
       {showReviewUI && (
@@ -241,17 +284,28 @@ export default function Page() {
           <h2>Reviewing Changes</h2>
           <button
             onClick={() => {
+              const result = toolkit.acceptAllChanges()
+              // Collect all feedback events
+              const allFeedbackEvents = [...reviewState.feedbackEvents, ...result.aiFeedback.events]
+              setReviewState({
+                isComparing: false,
+                feedbackEvents: allFeedbackEvents,
+              })
               toolkit.stopComparingDocuments()
-              setIsComparing(false)
             }}
           >
             Accept all
           </button>
           <button
             onClick={() => {
-              toolkit.rejectAllChanges()
+              const result = toolkit.rejectAllChanges()
+              // Collect all feedback events
+              const allFeedbackEvents = [...reviewState.feedbackEvents, ...result.aiFeedback.events]
+              setReviewState({
+                isComparing: false,
+                feedbackEvents: allFeedbackEvents,
+              })
               toolkit.stopComparingDocuments()
-              setIsComparing(false)
             }}
           >
             Reject all

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/review-changes.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/review-changes.mdx
@@ -46,7 +46,7 @@ const [reviewState, setReviewState] = useState({
   toolCallId: '',
   output: '',
   // Feedback events collected from user actions
-  feedbackEvents: [] as SuggestionFeedbackEvent[],
+  userFeedback: [] as SuggestionFeedbackEvent[],
 })
 
 const { messages, sendMessage, addtoolOutput } = useChat({
@@ -76,7 +76,7 @@ const { messages, sendMessage, addtoolOutput } = useChat({
         tool: toolName,
         toolCallId,
         output: result.output,
-        feedbackEvents: [],
+        userFeedback: [],
       })
     } else {
       // Continue the conversation
@@ -130,21 +130,26 @@ Then, in the React component, display a button to reject/accept the changes:
       <button
         onClick={() => {
           const toolkit = getAiToolkit(editor)
-          const result = toolkit.applyAllSuggestions()
+          const result = toolkit.acceptAllSuggestions()
           // Combine all feedback events (previous + new)
-          const allFeedbackEvents = [...reviewState.feedbackEvents, ...result.aiFeedback.events]
-          // Combine original output with feedback in XML tags
-          const outputWithFeedback = `${reviewState.output}\n\n<user_feedback>\n${JSON.stringify({ events: allFeedbackEvents }, null, 2)}\n</user_feedback>`
+          const userFeedback = [...reviewState.userFeedback, ...result.aiFeedback.events]
+          let output = reviewState.output
+
+          // Add feedback to tool output if there are any changes that were not accepted
+          if (userFeedback.length > 0 && userFeedback.some((event) => !event.accepted)) {
+            output += `\n\n<user_feedback>\n${JSON.stringify(userFeedback)}\n</user_feedback>`
+          }
+
           addtoolOutput({
             tool: reviewState.tool,
             toolCallId: reviewState.toolCallId,
-            output: outputWithFeedback,
+            output,
           })
           // Reset feedback events and close review UI
           setReviewState({
             ...reviewState,
             isReviewing: false,
-            feedbackEvents: [],
+            userFeedback: [],
           })
         }}
       >
@@ -155,11 +160,11 @@ Then, in the React component, display a button to reject/accept the changes:
           const toolkit = getAiToolkit(editor)
           const result = toolkit.rejectAllSuggestions()
           // Combine all feedback events (previous + new)
-          const allFeedbackEvents = [...reviewState.feedbackEvents, ...result.aiFeedback.events]
+          const userFeedback = [...reviewState.userFeedback, ...result.aiFeedback.events]
           // Combine rejection message with feedback in XML tags
           const rejectionMessage =
-            'The changes you made were rejected by the user. Do not edit the document again. Ask the user why, and what you can do to improve them.'
-          const outputWithFeedback = `${rejectionMessage}\n\n<user_feedback>\n${JSON.stringify({ events: allFeedbackEvents }, null, 2)}\n</user_feedback>`
+            'Some changes you made were rejected by the user. Ask the user why, and what you can do to improve them.'
+          const outputWithFeedback = `${rejectionMessage}\n\n<user_feedback>\n${JSON.stringify(userFeedback)}\n</user_feedback>`
           addtoolOutput({
             tool: reviewState.tool,
             toolCallId: reviewState.toolCallId,
@@ -169,7 +174,7 @@ Then, in the React component, display a button to reject/accept the changes:
           setReviewState({
             ...reviewState,
             isReviewing: false,
-            feedbackEvents: [],
+            userFeedback: [],
           })
         }}
       >
@@ -182,14 +187,14 @@ Then, in the React component, display a button to reject/accept the changes:
 
 ## Collecting AI feedback
 
-When users accept or reject suggestions, the AI Toolkit provides feedback that you can send back to the AI to help it learn from user preferences. The `applySuggestion`, `applyAllSuggestions`, `rejectSuggestion`, and `rejectAllSuggestions` methods all return an `aiFeedback` property containing events with information about what was changed.
+When users accept or reject suggestions, the AI Toolkit provides feedback that you can send back to the AI to help it learn from user preferences. The `acceptSuggestion`, `acceptAllSuggestions`, `rejectSuggestion`, and `rejectAllSuggestions` methods all return an `aiFeedback` property containing events with information about what was changed.
 
 ```ts
-const result = toolkit.applySuggestion('suggestion-1')
+const result = toolkit.acceptSuggestion('suggestion-1')
 console.log(result.aiFeedback.events)
 ```
 
-In the example above, feedback events are collected in the `reviewState.feedbackEvents` array and then sent to the AI wrapped in XML tags when the user accepts or rejects all changes. This allows the AI to understand which changes were accepted or rejected and improve future suggestions.
+In the example above, feedback events are collected in the `reviewState.userFeedback` array and then sent to the AI wrapped in XML tags when the user accepts or rejects all changes. This allows the AI to understand which changes were accepted or rejected and improve future suggestions.
 
 ## Accept/reject individual suggestions
 
@@ -213,11 +218,11 @@ const result = toolkit.executeTool({
             const element = document.createElement('button')
             element.textContent = 'Accept'
             element.addEventListener('click', () => {
-              const result = toolkit.applySuggestion(options.suggestion.id)
+              const result = toolkit.acceptSuggestion(options.suggestion.id)
               // Collect feedback events using functional update
               setReviewState((prev) => ({
                 ...prev,
-                feedbackEvents: [...prev.feedbackEvents, ...result.aiFeedback.events],
+                userFeedback: [...prev.userFeedback, ...result.aiFeedback.events],
               }))
             })
             return element
@@ -232,7 +237,7 @@ const result = toolkit.executeTool({
               // Collect feedback events using functional update
               setReviewState((prev) => ({
                 ...prev,
-                feedbackEvents: [...prev.feedbackEvents, ...result.aiFeedback.events],
+                userFeedback: [...prev.userFeedback, ...result.aiFeedback.events],
               }))
             })
             return element
@@ -251,10 +256,10 @@ const result = toolkit.executeTool({
 'use client'
 
 import { useChat } from '@ai-sdk/react'
-import { AiToolkit, getAiToolkit, type SuggestionFeedbackEvent } from '@tiptap-pro/ai-toolkit'
 import { Decoration } from '@tiptap/pm/view'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
+import { AiToolkit, getAiToolkit, type SuggestionFeedbackEvent } from '@tiptap-pro/ai-toolkit'
 import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from 'ai'
 import { useRef, useState } from 'react'
 import './suggestions.css'
@@ -278,10 +283,13 @@ export default function Page() {
     toolCallId: '',
     output: '',
     // Feedback events collected from user actions
-    feedbackEvents: [] as SuggestionFeedbackEvent[],
+    userFeedback: [] as SuggestionFeedbackEvent[],
   })
 
-  const { messages, sendMessage, addtoolOutput } = useChat({
+  const acceptButtonRef = useRef<HTMLButtonElement>(null)
+  const rejectButtonRef = useRef<HTMLButtonElement>(null)
+
+  const { messages, sendMessage, addToolOutput } = useChat({
     transport: new DefaultChatTransport({ api: '/api/chat' }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     async onToolCall({ toolCall }) {
@@ -307,12 +315,15 @@ export default function Page() {
                   const element = document.createElement('button')
                   element.textContent = 'Accept'
                   element.addEventListener('click', () => {
-                    const result = toolkit.applySuggestion(options.suggestion.id)
+                    const result = toolkit.acceptSuggestion(options.suggestion.id)
                     // Collect feedback events using functional update
                     setReviewState((prev) => ({
                       ...prev,
-                      feedbackEvents: [...prev.feedbackEvents, ...result.aiFeedback.events],
+                      userFeedback: [...prev.userFeedback, ...result.aiFeedback.events],
                     }))
+                    if (toolkit.getSuggestions().length === 0) {
+                      acceptButtonRef.current?.click()
+                    }
                   })
                   return element
                 }),
@@ -326,8 +337,11 @@ export default function Page() {
                     // Collect feedback events using functional update
                     setReviewState((prev) => ({
                       ...prev,
-                      feedbackEvents: [...prev.feedbackEvents, ...result.aiFeedback.events],
+                      userFeedback: [...prev.userFeedback, ...result.aiFeedback.events],
                     }))
+                    if (toolkit.getSuggestions().length === 0) {
+                      rejectButtonRef.current?.click()
+                    }
                   })
                   return element
                 }),
@@ -345,11 +359,11 @@ export default function Page() {
           tool: toolName,
           toolCallId,
           output: result.output,
-          feedbackEvents: [],
+          userFeedback: [],
         })
       } else {
         // Continue the conversation
-        addtoolOutput({ tool: toolName, toolCallId, output: result.output })
+        addToolOutput({ tool: toolName, toolCallId, output: result.output })
       }
     },
   })
@@ -375,8 +389,10 @@ export default function Page() {
         <form
           onSubmit={(e) => {
             e.preventDefault()
-            sendMessage({ text: input })
-            setInput('')
+            if (input.trim()) {
+              sendMessage({ text: input })
+              setInput('')
+            }
           }}
         >
           <input value={input} onChange={(e) => setInput(e.target.value)} />
@@ -386,39 +402,46 @@ export default function Page() {
         <div>
           <h2>Reviewing Changes</h2>
           <button
+            ref={acceptButtonRef}
             onClick={() => {
               const toolkit = getAiToolkit(editor)
-              const result = toolkit.applyAllSuggestions()
+              const result = toolkit.acceptAllSuggestions()
               // Combine all feedback events (previous + new)
-              const allFeedbackEvents = [...reviewState.feedbackEvents, ...result.aiFeedback.events]
-              // Combine original output with feedback in XML tags
-              const outputWithFeedback = `${reviewState.output}\n\n<user_feedback>\n${JSON.stringify({ events: allFeedbackEvents }, null, 2)}\n</user_feedback>`
-              addtoolOutput({
+              const userFeedback = [...reviewState.userFeedback, ...result.aiFeedback.events]
+              let output = reviewState.output
+
+              // Add feedback to tool output if there are any changes that were not accepted
+              if (userFeedback.length > 0 && userFeedback.some((event) => !event.accepted)) {
+                output += `\n\n<user_feedback>\n${JSON.stringify(userFeedback)}\n</user_feedback>`
+              }
+
+              addToolOutput({
                 tool: reviewState.tool,
                 toolCallId: reviewState.toolCallId,
-                output: outputWithFeedback,
+                output,
               })
               // Reset feedback events and close review UI
               setReviewState({
                 ...reviewState,
                 isReviewing: false,
-                feedbackEvents: [],
+                userFeedback: [],
               })
             }}
           >
             Accept all
           </button>
           <button
+            ref={rejectButtonRef}
             onClick={() => {
               const toolkit = getAiToolkit(editor)
               const result = toolkit.rejectAllSuggestions()
               // Combine all feedback events (previous + new)
-              const allFeedbackEvents = [...reviewState.feedbackEvents, ...result.aiFeedback.events]
+              const userFeedback = [...reviewState.userFeedback, ...result.aiFeedback.events]
               // Combine rejection message with feedback in XML tags
               const rejectionMessage =
-                'The changes you made were rejected by the user. Do not edit the document again. Ask the user why, and what you can do to improve them.'
-              const outputWithFeedback = `${rejectionMessage}\n\n<user_feedback>\n${JSON.stringify({ events: allFeedbackEvents }, null, 2)}\n</user_feedback>`
-              addtoolOutput({
+                'Some changes you made were rejected by the user. Ask the user why, and what you can do to improve them.'
+              const outputWithFeedback = `${rejectionMessage}\n\n<user_feedback>\n${JSON.stringify(userFeedback)}\n</user_feedback>`
+              addToolOutput({
                 tool: reviewState.tool,
                 toolCallId: reviewState.toolCallId,
                 output: outputWithFeedback,
@@ -427,7 +450,7 @@ export default function Page() {
               setReviewState({
                 ...reviewState,
                 isReviewing: false,
-                feedbackEvents: [],
+                userFeedback: [],
               })
             }}
           >

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/review-changes.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/review-changes.mdx
@@ -45,6 +45,8 @@ const [reviewState, setReviewState] = useState({
   tool: '',
   toolCallId: '',
   output: '',
+  // Feedback events collected from user actions
+  feedbackEvents: [] as SuggestionFeedbackEvent[],
 })
 
 const { messages, sendMessage, addtoolOutput } = useChat({
@@ -74,6 +76,7 @@ const { messages, sendMessage, addtoolOutput } = useChat({
         tool: toolName,
         toolCallId,
         output: result.output,
+        feedbackEvents: [],
       })
     } else {
       // Continue the conversation
@@ -127,11 +130,21 @@ Then, in the React component, display a button to reject/accept the changes:
       <button
         onClick={() => {
           const toolkit = getAiToolkit(editor)
-          toolkit.applyAllSuggestions()
-          addtoolOutput(reviewState)
-          return setReviewState({
+          const result = toolkit.applyAllSuggestions()
+          // Combine all feedback events (previous + new)
+          const allFeedbackEvents = [...reviewState.feedbackEvents, ...result.aiFeedback.events]
+          // Combine original output with feedback in XML tags
+          const outputWithFeedback = `${reviewState.output}\n\n<user_feedback>\n${JSON.stringify({ events: allFeedbackEvents }, null, 2)}\n</user_feedback>`
+          addtoolOutput({
+            tool: reviewState.tool,
+            toolCallId: reviewState.toolCallId,
+            output: outputWithFeedback,
+          })
+          // Reset feedback events and close review UI
+          setReviewState({
             ...reviewState,
             isReviewing: false,
+            feedbackEvents: [],
           })
         }}
       >
@@ -140,15 +153,23 @@ Then, in the React component, display a button to reject/accept the changes:
       <button
         onClick={() => {
           const toolkit = getAiToolkit(editor)
-          toolkit.setSuggestions([])
+          const result = toolkit.rejectAllSuggestions()
+          // Combine all feedback events (previous + new)
+          const allFeedbackEvents = [...reviewState.feedbackEvents, ...result.aiFeedback.events]
+          // Combine rejection message with feedback in XML tags
+          const rejectionMessage =
+            'The changes you made were rejected by the user. Do not edit the document again. Ask the user why, and what you can do to improve them.'
+          const outputWithFeedback = `${rejectionMessage}\n\n<user_feedback>\n${JSON.stringify({ events: allFeedbackEvents }, null, 2)}\n</user_feedback>`
           addtoolOutput({
-            ...reviewState,
-            output:
-              'The changes were rejected. Ask the user why, and what you can do to improve them.',
+            tool: reviewState.tool,
+            toolCallId: reviewState.toolCallId,
+            output: outputWithFeedback,
           })
-          return setReviewState({
+          // Reset feedback events and close review UI
+          setReviewState({
             ...reviewState,
             isReviewing: false,
+            feedbackEvents: [],
           })
         }}
       >
@@ -158,6 +179,17 @@ Then, in the React component, display a button to reject/accept the changes:
   )
 }
 ```
+
+## Collecting AI feedback
+
+When users accept or reject suggestions, the AI Toolkit provides feedback that you can send back to the AI to help it learn from user preferences. The `applySuggestion`, `applyAllSuggestions`, `rejectSuggestion`, and `rejectAllSuggestions` methods all return an `aiFeedback` property containing events with information about what was changed.
+
+```ts
+const result = toolkit.applySuggestion('suggestion-1')
+console.log(result.aiFeedback.events)
+```
+
+In the example above, feedback events are collected in the `reviewState.feedbackEvents` array and then sent to the AI wrapped in XML tags when the user accepts or rejects all changes. This allows the AI to understand which changes were accepted or rejected and improve future suggestions.
 
 ## Accept/reject individual suggestions
 
@@ -181,7 +213,12 @@ const result = toolkit.executeTool({
             const element = document.createElement('button')
             element.textContent = 'Accept'
             element.addEventListener('click', () => {
-              toolkit.applySuggestion(options.suggestion.id)
+              const result = toolkit.applySuggestion(options.suggestion.id)
+              // Collect feedback events using functional update
+              setReviewState((prev) => ({
+                ...prev,
+                feedbackEvents: [...prev.feedbackEvents, ...result.aiFeedback.events],
+              }))
             })
             return element
           }),
@@ -191,7 +228,12 @@ const result = toolkit.executeTool({
             const element = document.createElement('button')
             element.textContent = 'Reject'
             element.addEventListener('click', () => {
-              toolkit.removeSuggestion(options.suggestion.id)
+              const result = toolkit.rejectSuggestion(options.suggestion.id)
+              // Collect feedback events using functional update
+              setReviewState((prev) => ({
+                ...prev,
+                feedbackEvents: [...prev.feedbackEvents, ...result.aiFeedback.events],
+              }))
             })
             return element
           }),
@@ -209,7 +251,7 @@ const result = toolkit.executeTool({
 'use client'
 
 import { useChat } from '@ai-sdk/react'
-import { AiToolkit, getAiToolkit } from '@tiptap-pro/ai-toolkit'
+import { AiToolkit, getAiToolkit, type SuggestionFeedbackEvent } from '@tiptap-pro/ai-toolkit'
 import { Decoration } from '@tiptap/pm/view'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
@@ -235,6 +277,8 @@ export default function Page() {
     tool: '',
     toolCallId: '',
     output: '',
+    // Feedback events collected from user actions
+    feedbackEvents: [] as SuggestionFeedbackEvent[],
   })
 
   const { messages, sendMessage, addtoolOutput } = useChat({
@@ -263,7 +307,12 @@ export default function Page() {
                   const element = document.createElement('button')
                   element.textContent = 'Accept'
                   element.addEventListener('click', () => {
-                    toolkit.applySuggestion(options.suggestion.id)
+                    const result = toolkit.applySuggestion(options.suggestion.id)
+                    // Collect feedback events using functional update
+                    setReviewState((prev) => ({
+                      ...prev,
+                      feedbackEvents: [...prev.feedbackEvents, ...result.aiFeedback.events],
+                    }))
                   })
                   return element
                 }),
@@ -273,7 +322,12 @@ export default function Page() {
                   const element = document.createElement('button')
                   element.textContent = 'Reject'
                   element.addEventListener('click', () => {
-                    toolkit.removeSuggestion(options.suggestion.id)
+                    const result = toolkit.rejectSuggestion(options.suggestion.id)
+                    // Collect feedback events using functional update
+                    setReviewState((prev) => ({
+                      ...prev,
+                      feedbackEvents: [...prev.feedbackEvents, ...result.aiFeedback.events],
+                    }))
                   })
                   return element
                 }),
@@ -291,6 +345,7 @@ export default function Page() {
           tool: toolName,
           toolCallId,
           output: result.output,
+          feedbackEvents: [],
         })
       } else {
         // Continue the conversation
@@ -333,11 +388,21 @@ export default function Page() {
           <button
             onClick={() => {
               const toolkit = getAiToolkit(editor)
-              toolkit.applyAllSuggestions()
-              addtoolOutput(reviewState)
-              return setReviewState({
+              const result = toolkit.applyAllSuggestions()
+              // Combine all feedback events (previous + new)
+              const allFeedbackEvents = [...reviewState.feedbackEvents, ...result.aiFeedback.events]
+              // Combine original output with feedback in XML tags
+              const outputWithFeedback = `${reviewState.output}\n\n<user_feedback>\n${JSON.stringify({ events: allFeedbackEvents }, null, 2)}\n</user_feedback>`
+              addtoolOutput({
+                tool: reviewState.tool,
+                toolCallId: reviewState.toolCallId,
+                output: outputWithFeedback,
+              })
+              // Reset feedback events and close review UI
+              setReviewState({
                 ...reviewState,
                 isReviewing: false,
+                feedbackEvents: [],
               })
             }}
           >
@@ -346,15 +411,23 @@ export default function Page() {
           <button
             onClick={() => {
               const toolkit = getAiToolkit(editor)
-              toolkit.setSuggestions([])
+              const result = toolkit.rejectAllSuggestions()
+              // Combine all feedback events (previous + new)
+              const allFeedbackEvents = [...reviewState.feedbackEvents, ...result.aiFeedback.events]
+              // Combine rejection message with feedback in XML tags
+              const rejectionMessage =
+                'The changes you made were rejected by the user. Do not edit the document again. Ask the user why, and what you can do to improve them.'
+              const outputWithFeedback = `${rejectionMessage}\n\n<user_feedback>\n${JSON.stringify({ events: allFeedbackEvents }, null, 2)}\n</user_feedback>`
               addtoolOutput({
-                ...reviewState,
-                output:
-                  'The changes were rejected. Ask the user why, and what you can do to improve them.',
+                tool: reviewState.tool,
+                toolCallId: reviewState.toolCallId,
+                output: outputWithFeedback,
               })
-              return setReviewState({
+              // Reset feedback events and close review UI
+              setReviewState({
                 ...reviewState,
                 isReviewing: false,
+                feedbackEvents: [],
               })
             }}
           >

--- a/src/content/content-ai/capabilities/ai-toolkit/migration-guides/ai-suggestion.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/migration-guides/ai-suggestion.mdx
@@ -24,7 +24,7 @@ It's recommended to have a look at the [API reference](/content-ai/capabilities/
 
 To learn more about how suggestions are stored and managed, have a look at the [API reference](/content-ai/capabilities/ai-toolkit/primitives/display-suggestions) of the suggestions utilities.
 
-In particular, use the `applySuggestion` method to accept a suggestion.
+In particular, use the `acceptSuggestion` method to accept a suggestion.
 
 ## Customizing the appearance of the suggestions
 

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/compare-documents.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/compare-documents.mdx
@@ -69,28 +69,16 @@ Stops the real-time comparison and clears all suggestions, so the diff view is n
 toolkit.stopComparingDocuments()
 ```
 
-## `acceptChange`
+## Accepting and rejecting changes
 
-Accepts a change so that it is no longer visible in the diff when comparing documents in real-time.
+When comparing documents, changes are displayed as suggestions. To accept or reject individual changes or all changes at once, use the suggestion methods:
 
-This is equivalent to applying a specific suggestion by its ID to the other document. The "other document" or `otherDoc` is the document that is being compared to the current document.
+- [`acceptSuggestion`](/content-ai/capabilities/ai-toolkit/primitives/display-suggestions#acceptsuggestion): Accept a specific change
+- [`rejectSuggestion`](/content-ai/capabilities/ai-toolkit/primitives/display-suggestions#rejectsuggestion): Reject a specific change
+- [`acceptAllSuggestions`](/content-ai/capabilities/ai-toolkit/primitives/display-suggestions#acceptallsuggestions): Accept all changes
+- [`rejectAllSuggestions`](/content-ai/capabilities/ai-toolkit/primitives/display-suggestions#rejectallsuggestions): Reject all changes
 
-To accept all changes, call `stopComparingDocuments`. This will hide the diff view, as if all changes had been accepted.
-
-The method returns AI feedback that can be used to inform the AI about changes that were accepted or rejected by the user. This feedback helps improve future AI suggestions based on user preferences.
-
-### Parameters
-
-- `suggestionId` (`string`): The unique identifier of the suggestion that represents the change to accept
-
-### Returns
-
-`AcceptChangeResult`: An object containing:
-
-- `aiFeedback` (`AiFeedback`): AI feedback containing events for the accepted change. Each event includes:
-  - `delete` (`string`): HTML content that was deleted (or would be deleted)
-  - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
-  - `accepted` (`boolean`): Whether the suggestion was accepted by the user (always `true` for `acceptChange`)
+These methods work with both regular suggestions and changes from the compare-documents feature.
 
 ### Example
 
@@ -104,73 +92,13 @@ toolkit.startComparingDocuments({
 const suggestions = toolkit.getSuggestions()
 
 // Accept the first change and get feedback
-const result = toolkit.acceptChange(suggestions[0].id)
+if (suggestions.length > 0) {
+  const result = toolkit.acceptSuggestion(suggestions[0].id)
+  console.log(result.aiFeedback.events)
+}
+
+// Or reject all changes at once
+const result = toolkit.rejectAllSuggestions()
 console.log(result.aiFeedback.events)
-```
-
-## `rejectChange`
-
-Rejects a change so that it is no longer visible in the diff when comparing documents in real-time.
-
-This is equivalent to applying a specific suggestion by its ID to the current document.
-
-The method returns AI feedback that can be used to inform the AI about changes that were accepted or rejected by the user. This feedback helps improve future AI suggestions based on user preferences.
-
-### Parameters
-
-- `suggestionId` (`string`): The unique identifier of the suggestion that represents the change to reject
-
-### Returns
-
-`RejectChangeResult`: An object containing:
-
-- `aiFeedback` (`AiFeedback`): AI feedback containing events for the rejected change. Each event includes:
-  - `delete` (`string`): HTML content that was deleted (or would be deleted)
-  - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
-  - `accepted` (`boolean`): Whether the suggestion was accepted by the user (always `false` for `rejectChange`)
-
-### Example
-
-```ts
-// Start comparing documents
-toolkit.startComparingDocuments({
-  otherDoc: otherDoc,
-})
-
-// Get all changes (as suggestions)
-const suggestions = toolkit.getSuggestions()
-
-// Reject the first change and get feedback
-const result = toolkit.rejectChange(suggestions[0].id)
-console.log(result.aiFeedback.events)
-```
-
-## `rejectAllChanges`
-
-Rejects all changes so that they are no longer visible in the diff when comparing documents in real-time.
-
-This is equivalent to setting the current document to the `otherDoc`.
-
-The method returns AI feedback that can be used to inform the AI about changes that were accepted or rejected by the user. This feedback helps improve future AI suggestions based on user preferences.
-
-### Returns
-
-`RejectAllChangesResult`: An object containing:
-
-- `aiFeedback` (`AiFeedback`): AI feedback containing events for all rejected changes. Each event includes:
-  - `delete` (`string`): HTML content that was deleted (or would be deleted)
-  - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
-  - `accepted` (`boolean`): Whether the suggestion was accepted by the user (always `false` for `rejectAllChanges`)
-
-### Example
-
-```ts
-// Start comparing documents
-toolkit.startComparingDocuments({
-  otherDoc: otherDoc,
-})
-
-// Reject all changes and get feedback
-const result = toolkit.rejectAllChanges()
-console.log(result.aiFeedback.events)
+toolkit.stopComparingDocuments()
 ```

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/compare-documents.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/compare-documents.mdx
@@ -77,13 +77,20 @@ This is equivalent to applying a specific suggestion by its ID to the other docu
 
 To accept all changes, call `stopComparingDocuments`. This will hide the diff view, as if all changes had been accepted.
 
+The method returns AI feedback that can be used to inform the AI about changes that were accepted or rejected by the user. This feedback helps improve future AI suggestions based on user preferences.
+
 ### Parameters
 
 - `suggestionId` (`string`): The unique identifier of the suggestion that represents the change to accept
 
 ### Returns
 
-`void`
+`AcceptChangeResult`: An object containing:
+
+- `aiFeedback` (`AiFeedback`): AI feedback containing events for the accepted change. Each event includes:
+  - `delete` (`string`): HTML content that was deleted (or would be deleted)
+  - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
+  - `accepted` (`boolean`): Whether the suggestion was accepted by the user (always `true` for `acceptChange`)
 
 ### Example
 
@@ -96,8 +103,9 @@ toolkit.startComparingDocuments({
 // Get all changes (as suggestions)
 const suggestions = toolkit.getSuggestions()
 
-// Accept the first change
-toolkit.acceptChange(suggestions[0].id)
+// Accept the first change and get feedback
+const result = toolkit.acceptChange(suggestions[0].id)
+console.log(result.aiFeedback.events)
 ```
 
 ## `rejectChange`
@@ -106,13 +114,20 @@ Rejects a change so that it is no longer visible in the diff when comparing docu
 
 This is equivalent to applying a specific suggestion by its ID to the current document.
 
+The method returns AI feedback that can be used to inform the AI about changes that were accepted or rejected by the user. This feedback helps improve future AI suggestions based on user preferences.
+
 ### Parameters
 
 - `suggestionId` (`string`): The unique identifier of the suggestion that represents the change to reject
 
 ### Returns
 
-`void`
+`RejectChangeResult`: An object containing:
+
+- `aiFeedback` (`AiFeedback`): AI feedback containing events for the rejected change. Each event includes:
+  - `delete` (`string`): HTML content that was deleted (or would be deleted)
+  - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
+  - `accepted` (`boolean`): Whether the suggestion was accepted by the user (always `false` for `rejectChange`)
 
 ### Example
 
@@ -125,8 +140,9 @@ toolkit.startComparingDocuments({
 // Get all changes (as suggestions)
 const suggestions = toolkit.getSuggestions()
 
-// Reject the first change
-toolkit.rejectChange(suggestions[0].id)
+// Reject the first change and get feedback
+const result = toolkit.rejectChange(suggestions[0].id)
+console.log(result.aiFeedback.events)
 ```
 
 ## `rejectAllChanges`
@@ -135,9 +151,16 @@ Rejects all changes so that they are no longer visible in the diff when comparin
 
 This is equivalent to setting the current document to the `otherDoc`.
 
+The method returns AI feedback that can be used to inform the AI about changes that were accepted or rejected by the user. This feedback helps improve future AI suggestions based on user preferences.
+
 ### Returns
 
-`void`
+`RejectAllChangesResult`: An object containing:
+
+- `aiFeedback` (`AiFeedback`): AI feedback containing events for all rejected changes. Each event includes:
+  - `delete` (`string`): HTML content that was deleted (or would be deleted)
+  - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
+  - `accepted` (`boolean`): Whether the suggestion was accepted by the user (always `false` for `rejectAllChanges`)
 
 ### Example
 
@@ -147,6 +170,7 @@ toolkit.startComparingDocuments({
   otherDoc: otherDoc,
 })
 
-// Reject all changes
-toolkit.rejectAllChanges()
+// Reject all changes and get feedback
+const result = toolkit.rejectAllChanges()
+console.log(result.aiFeedback.events)
 ```

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/display-suggestions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/display-suggestions.mdx
@@ -153,19 +153,14 @@ Returns an object containing:
   - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
   - `accepted` (`boolean`): Whether the suggestion was accepted by the user (`true`) or rejected (`false`)
 
-The `accepted` field is determined by the suggestion's `reviewMode`:
-
-- Preview mode + accept = `accepted: true` (user accepts the change)
-- Review mode + accept = `accepted: false` (user undoes/rejects the change)
-
-This feedback can be used to inform the AI about user preferences and improve future suggestions.
+This feedback can be used to inform the AI about what changes were accepted or rejected by the user.
 
 ### Example
 
 ```ts
 // Accept a suggestion by id and get feedback
 const result = toolkit.acceptSuggestion('suggestion-1')
-console.log(result.aiFeedback.events)
+result.aiFeedback.events
 ```
 
 ## `acceptAllSuggestions`
@@ -191,19 +186,14 @@ Returns an object containing:
   - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
   - `accepted` (`boolean`): Whether the suggestion was accepted by the user (`true`) or rejected (`false`)
 
-The `accepted` field is determined by each suggestion's `reviewMode`:
-
-- Preview mode + accept = `accepted: true` (user accepts the change)
-- Review mode + accept = `accepted: false` (user undoes/rejects the change)
-
-This feedback can be used to inform the AI about user preferences and improve future suggestions.
+This feedback can be used to inform the AI about what changes were accepted by the user.
 
 ### Example
 
 ```ts
 // Accept all suggestions at once and get feedback
 const result = toolkit.acceptAllSuggestions()
-console.log(result.aiFeedback.events)
+result.aiFeedback.events
 ```
 
 ## `rejectSuggestion`
@@ -229,19 +219,14 @@ Returns an object containing:
   - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
   - `accepted` (`boolean`): Whether the suggestion was accepted by the user (`true`) or rejected (`false`)
 
-The `accepted` field is determined by the suggestion's `reviewMode`:
-
-- Preview mode + reject = `accepted: false` (user rejects the change)
-- Review mode + reject = `accepted: true` (user keeps/accepts the change)
-
-This feedback can be used to inform the AI about user preferences and improve future suggestions.
+This feedback can be used to inform the AI about what changes were rejected by the user.
 
 ### Example
 
 ```ts
 // Reject a suggestion by id and get feedback
 const result = toolkit.rejectSuggestion('suggestion-1')
-console.log(result.aiFeedback.events)
+result.aiFeedback.events
 ```
 
 ## `rejectAllSuggestions`
@@ -267,19 +252,14 @@ Returns an object containing:
   - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
   - `accepted` (`boolean`): Whether the suggestion was accepted by the user (`true`) or rejected (`false`)
 
-The `accepted` field is determined by each suggestion's `reviewMode`:
-
-- Preview mode + reject = `accepted: false` (user rejects the change)
-- Review mode + reject = `accepted: true` (user keeps/accepts the change)
-
-This feedback can be used to inform the AI about user preferences and improve future suggestions.
+This feedback can be used to inform the AI about what changes were rejected by the user.
 
 ### Example
 
 ```ts
 // Reject all suggestions and get feedback
 const result = toolkit.rejectAllSuggestions()
-console.log(result.aiFeedback.events)
+result.aiFeedback.events
 ```
 
 ## `removeSuggestion`

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/display-suggestions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/display-suggestions.mdx
@@ -39,6 +39,7 @@ A `Suggestion` represents a proposed change to a range of content in the editor,
   - `attributes?` (`Record<string, any>`): Attributes added to rendered elements
   - `diffAttributes?` (`Record<string, any>`): Extra HTML attributes to be added to the diff decoration of the suggestion
   - `renderDecorations?` (`RenderDecorations<{ suggestion: Suggestion }>`): Custom rendering function. Defaults to a function renders the suggestion as a diff.
+- `reviewMode?` (`'preview' | 'review'`): The review mode of the suggestion. `'preview'` indicates the suggestion is a preview of a change before applying (default). `'review'` indicates the suggestion reviews a change that has already been made, allowing the user to undo it by applying the suggestion. This field is automatically set based on `reviewOptions.mode` when suggestions are created.
 - `metadata?` (`Record<string, any>`): Optional extra metadata for the suggestion. This can be used to store additional information such as the source, category, or any custom data. It is not used internally by the extension but can help customize UI rendering.
 
 ## Style suggestions
@@ -141,13 +142,26 @@ Applies a specific suggestion.
 
 ### Returns
 
-`void`
+`ApplySuggestionResult`
+
+Returns an object containing:
+- `aiFeedback` (`{ events: SuggestionFeedbackEvent[] }`): AI feedback containing events for the applied suggestion. Each event contains:
+  - `delete` (`string`): HTML content that was deleted (or would be deleted)
+  - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
+  - `accepted` (`boolean`): Whether the suggestion was accepted by the user (`true`) or rejected (`false`)
+
+The `accepted` field is determined by the suggestion's `reviewMode`:
+- Preview mode + apply = `accepted: true` (user accepts the change)
+- Review mode + apply = `accepted: false` (user undoes/rejects the change)
+
+This feedback can be used to inform the AI about user preferences and improve future suggestions.
 
 ### Example
 
 ```ts
-// Apply a suggestion by id
-toolkit.applySuggestion('suggestion-1')
+// Apply a suggestion by id and get feedback
+const result = toolkit.applySuggestion('suggestion-1')
+console.log(result.aiFeedback.events)
 ```
 
 ## `applyAllSuggestions`
@@ -162,13 +176,94 @@ None
 
 ### Returns
 
-`void`
+`ApplyAllSuggestionsResult`
+
+Returns an object containing:
+- `aiFeedback` (`{ events: SuggestionFeedbackEvent[] }`): AI feedback containing events for all applied suggestions. Each event contains:
+  - `delete` (`string`): HTML content that was deleted (or would be deleted)
+  - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
+  - `accepted` (`boolean`): Whether the suggestion was accepted by the user (`true`) or rejected (`false`)
+
+The `accepted` field is determined by each suggestion's `reviewMode`:
+- Preview mode + apply = `accepted: true` (user accepts the change)
+- Review mode + apply = `accepted: false` (user undoes/rejects the change)
+
+This feedback can be used to inform the AI about user preferences and improve future suggestions.
 
 ### Example
 
 ```ts
-// Apply all suggestions at once
-toolkit.applyAllSuggestions()
+// Apply all suggestions at once and get feedback
+const result = toolkit.applyAllSuggestions()
+console.log(result.aiFeedback.events)
+```
+
+## `rejectSuggestion`
+
+Rejects a specific suggestion without applying it.
+
+This method removes a suggestion from the active suggestions list without applying it to the document. It returns feedback about what was rejected.
+
+### Parameters
+
+- `suggestionId` (`string`): The suggestion to reject
+
+### Returns
+
+`RejectSuggestionResult`
+
+Returns an object containing:
+- `aiFeedback` (`{ events: SuggestionFeedbackEvent[] }`): AI feedback containing events for the rejected suggestion. Each event contains:
+  - `delete` (`string`): HTML content that was deleted (or would be deleted)
+  - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
+  - `accepted` (`boolean`): Whether the suggestion was accepted by the user (`true`) or rejected (`false`)
+
+The `accepted` field is determined by the suggestion's `reviewMode`:
+- Preview mode + reject = `accepted: false` (user rejects the change)
+- Review mode + reject = `accepted: true` (user keeps/accepts the change)
+
+This feedback can be used to inform the AI about user preferences and improve future suggestions.
+
+### Example
+
+```ts
+// Reject a suggestion by id and get feedback
+const result = toolkit.rejectSuggestion('suggestion-1')
+console.log(result.aiFeedback.events)
+```
+
+## `rejectAllSuggestions`
+
+Rejects all active suggestions without applying them.
+
+This method removes all suggestions from the active suggestions list without applying them to the document. It returns feedback about what was rejected.
+
+### Parameters
+
+None
+
+### Returns
+
+`RejectAllSuggestionsResult`
+
+Returns an object containing:
+- `aiFeedback` (`{ events: SuggestionFeedbackEvent[] }`): AI feedback containing events for all rejected suggestions. Each event contains:
+  - `delete` (`string`): HTML content that was deleted (or would be deleted)
+  - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
+  - `accepted` (`boolean`): Whether the suggestion was accepted by the user (`true`) or rejected (`false`)
+
+The `accepted` field is determined by each suggestion's `reviewMode`:
+- Preview mode + reject = `accepted: false` (user rejects the change)
+- Review mode + reject = `accepted: true` (user keeps/accepts the change)
+
+This feedback can be used to inform the AI about user preferences and improve future suggestions.
+
+### Example
+
+```ts
+// Reject all suggestions and get feedback
+const result = toolkit.rejectAllSuggestions()
+console.log(result.aiFeedback.events)
 ```
 
 ## `removeSuggestion`

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/display-suggestions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/display-suggestions.mdx
@@ -130,45 +130,51 @@ If two generated suggestions have overlapping ranges, only the first suggestion 
 toolkit.setSuggestions([{ type: 'suggestions', suggestions: [] }])
 ```
 
-## `applySuggestion`
+## `acceptSuggestion`
 
-Applies a specific suggestion.
+Accepts a specific suggestion.
+
+This method works with both regular suggestions and changes from the [compare-documents](/content-ai/capabilities/ai-toolkit/primitives/compare-documents) feature.
 
 ### Parameters
 
-- `suggestionId` (`string`): The suggestion to apply
-- `options?` (`ApplySuggestionOptions`): Options for the `applySuggestion` method
+- `suggestionId` (`string`): The suggestion to accept
+- `options?` (`AcceptSuggestionOptions`): Options for the `acceptSuggestion` method
   - `replacementOptionId?` (`string`): The ID of the replacement option to apply. If not provided, the first replacement option will be applied
 
 ### Returns
 
-`ApplySuggestionResult`
+`AcceptSuggestionResult`
 
 Returns an object containing:
-- `aiFeedback` (`{ events: SuggestionFeedbackEvent[] }`): AI feedback containing events for the applied suggestion. Each event contains:
+
+- `aiFeedback` (`{ events: SuggestionFeedbackEvent[] }`): AI feedback containing events for the accepted suggestion. Each event contains:
   - `delete` (`string`): HTML content that was deleted (or would be deleted)
   - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
   - `accepted` (`boolean`): Whether the suggestion was accepted by the user (`true`) or rejected (`false`)
 
 The `accepted` field is determined by the suggestion's `reviewMode`:
-- Preview mode + apply = `accepted: true` (user accepts the change)
-- Review mode + apply = `accepted: false` (user undoes/rejects the change)
+
+- Preview mode + accept = `accepted: true` (user accepts the change)
+- Review mode + accept = `accepted: false` (user undoes/rejects the change)
 
 This feedback can be used to inform the AI about user preferences and improve future suggestions.
 
 ### Example
 
 ```ts
-// Apply a suggestion by id and get feedback
-const result = toolkit.applySuggestion('suggestion-1')
+// Accept a suggestion by id and get feedback
+const result = toolkit.acceptSuggestion('suggestion-1')
 console.log(result.aiFeedback.events)
 ```
 
-## `applyAllSuggestions`
+## `acceptAllSuggestions`
 
-Applies all active suggestions to the document at once.
+Accepts all active suggestions at once.
 
-This method applies all suggestions by replacing the content at each suggestion's range with the first replacement option. After applying all suggestions, the list of active suggestions is cleared.
+This method accepts all suggestions by replacing the content at each suggestion's range with the first replacement option. After accepting all suggestions, the list of active suggestions is cleared.
+
+This method works with both regular suggestions and changes from the [compare-documents](/content-ai/capabilities/ai-toolkit/primitives/compare-documents) feature.
 
 ### Parameters
 
@@ -176,25 +182,27 @@ None
 
 ### Returns
 
-`ApplyAllSuggestionsResult`
+`AcceptAllSuggestionsResult`
 
 Returns an object containing:
-- `aiFeedback` (`{ events: SuggestionFeedbackEvent[] }`): AI feedback containing events for all applied suggestions. Each event contains:
+
+- `aiFeedback` (`{ events: SuggestionFeedbackEvent[] }`): AI feedback containing events for all accepted suggestions. Each event contains:
   - `delete` (`string`): HTML content that was deleted (or would be deleted)
   - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
   - `accepted` (`boolean`): Whether the suggestion was accepted by the user (`true`) or rejected (`false`)
 
 The `accepted` field is determined by each suggestion's `reviewMode`:
-- Preview mode + apply = `accepted: true` (user accepts the change)
-- Review mode + apply = `accepted: false` (user undoes/rejects the change)
+
+- Preview mode + accept = `accepted: true` (user accepts the change)
+- Review mode + accept = `accepted: false` (user undoes/rejects the change)
 
 This feedback can be used to inform the AI about user preferences and improve future suggestions.
 
 ### Example
 
 ```ts
-// Apply all suggestions at once and get feedback
-const result = toolkit.applyAllSuggestions()
+// Accept all suggestions at once and get feedback
+const result = toolkit.acceptAllSuggestions()
 console.log(result.aiFeedback.events)
 ```
 
@@ -203,6 +211,8 @@ console.log(result.aiFeedback.events)
 Rejects a specific suggestion without applying it.
 
 This method removes a suggestion from the active suggestions list without applying it to the document. It returns feedback about what was rejected.
+
+This method works with both regular suggestions and changes from the [compare-documents](/content-ai/capabilities/ai-toolkit/primitives/compare-documents) feature.
 
 ### Parameters
 
@@ -213,12 +223,14 @@ This method removes a suggestion from the active suggestions list without applyi
 `RejectSuggestionResult`
 
 Returns an object containing:
+
 - `aiFeedback` (`{ events: SuggestionFeedbackEvent[] }`): AI feedback containing events for the rejected suggestion. Each event contains:
   - `delete` (`string`): HTML content that was deleted (or would be deleted)
   - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
   - `accepted` (`boolean`): Whether the suggestion was accepted by the user (`true`) or rejected (`false`)
 
 The `accepted` field is determined by the suggestion's `reviewMode`:
+
 - Preview mode + reject = `accepted: false` (user rejects the change)
 - Review mode + reject = `accepted: true` (user keeps/accepts the change)
 
@@ -238,6 +250,8 @@ Rejects all active suggestions without applying them.
 
 This method removes all suggestions from the active suggestions list without applying them to the document. It returns feedback about what was rejected.
 
+This method works with both regular suggestions and changes from the [compare-documents](/content-ai/capabilities/ai-toolkit/primitives/compare-documents) feature.
+
 ### Parameters
 
 None
@@ -247,12 +261,14 @@ None
 `RejectAllSuggestionsResult`
 
 Returns an object containing:
+
 - `aiFeedback` (`{ events: SuggestionFeedbackEvent[] }`): AI feedback containing events for all rejected suggestions. Each event contains:
   - `delete` (`string`): HTML content that was deleted (or would be deleted)
   - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
   - `accepted` (`boolean`): Whether the suggestion was accepted by the user (`true`) or rejected (`false`)
 
 The `accepted` field is determined by each suggestion's `reviewMode`:
+
 - Preview mode + reject = `accepted: false` (user rejects the change)
 - Review mode + reject = `accepted: true` (user keeps/accepts the change)
 

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/proofreader.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/proofreader.mdx
@@ -188,7 +188,7 @@ export default function Page() {
           <button
             onClick={() => {
               const toolkit = getAiToolkit(editor)
-              toolkit.applyAllSuggestions()
+              toolkit.acceptAllSuggestions()
               setIsReviewing(false)
             }}
           >
@@ -197,7 +197,7 @@ export default function Page() {
           <button
             onClick={() => {
               const toolkit = getAiToolkit(editor)
-              toolkit.setSuggestions([])
+              toolkit.rejectAllSuggestions()
               setIsReviewing(false)
             }}
           >


### PR DESCRIPTION
## Intent

This PR updates the AI Toolkit documentation to reflect the simplified suggestions API that unifies regular suggestions and compare-documents changes.

## Documentation Changes

### API Reference Updates

#### display-suggestions.mdx
- **Renamed `applySuggestion` to `acceptSuggestion`**: Updated method name, description, and examples.
- **Renamed `applyAllSuggestions` to `acceptAllSuggestions`**: Updated method name, description, and examples.
- **Updated `rejectSuggestion` and `rejectAllSuggestions`**: Added notes that these methods work with both regular suggestions and compare-documents changes.

#### compare-documents.mdx
- **Removed `acceptChange`, `rejectChange`, `rejectAllChanges` sections**: These methods no longer exist.
- **Added new section**: Explains that users should use `acceptSuggestion`, `rejectSuggestion`, `acceptAllSuggestions`, and `rejectAllSuggestions` instead, with links to the display-suggestions API reference.

### Guide Updates

#### review-changes.mdx
- Replaced all `applySuggestion` calls with `acceptSuggestion`
- Replaced all `applyAllSuggestions` calls with `acceptAllSuggestions`
- Updated full demo code to match the current implementation

#### review-changes-as-summary.mdx
- Replaced `acceptChange` and `rejectChange` with `acceptSuggestion` and `rejectSuggestion`
- Replaced `acceptAllChanges` and `rejectAllChanges` with `acceptAllSuggestions` and `rejectAllSuggestions`
- Updated full demo code to match the current implementation

#### proofreader.mdx
- Replaced `applyAllSuggestions` with `acceptAllSuggestions`
- Replaced `setSuggestions([])` with `rejectAllSuggestions()` for consistency

#### advanced-guides/compare-documents.mdx
- Replaced `acceptChange` and `rejectChange` with `acceptSuggestion` and `rejectSuggestion`

#### migration-guides/ai-suggestion.mdx
- Replaced `applySuggestion` with `acceptSuggestion`

### Changelog Updates
- Added `3.0.0-alpha.50` entry documenting the breaking changes and new features
- Added `3.0.0-alpha.49` patch changes for dependency updates

## Related PRs

- [tiptap-pro#498](https://github.com/ueberdosis/tiptap-pro/pull/498): refactor: simplify suggestions API by unifying suggestion and compare-documents methods
