### PR TITLE
fix(docs): remove deprecated smartypants option

### DIFF
--- a/.changeset/gentle-ways-build.md
+++ b/.changeset/gentle-ways-build.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+The smartypants option was removed from the example because it has been deprecated in marked.js and is no longer supported.

--- a/src/content/editor/markdown/getting-started/installation.mdx
+++ b/src/content/editor/markdown/getting-started/installation.mdx
@@ -108,7 +108,6 @@ Markdown.configure({
     gfm: true, // GitHub Flavored Markdown
     breaks: false, // Convert \n to <br>
     pedantic: false, // Strict Markdown mode
-    smartypants: false, // Smart quotes and dashes
   },
 })
 ```


### PR DESCRIPTION
This pull request removes the deprecated `smartypants` option from the Markdown configuration example in the documentation, as it is no longer supported in `marked.js`.

Reference: https://marked.js.org/using_advanced#options