### PR TITLE
Upgrade to Vercel AI SDK V6: Use ToolLoopAgent and createAgentUIStreamResponse

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/ai-engineering.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/ai-engineering.mdx
@@ -58,18 +58,17 @@ You can adjust how the AI model acts and generates content by providing a custom
 // app/api/chat/route.ts
 import { openai } from '@ai-sdk/openai'
 import { toolDefinitions } from '@tiptap-pro/ai-toolkit-ai-sdk'
-import { convertToModelMessages, streamText, UIMessage } from 'ai'
+import { createAgentUIStreamResponse, ToolLoopAgent, UIMessage } from 'ai'
 
 export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
-  const result = streamText({
+  const agent = new ToolLoopAgent({
     model: openai('gpt-5-mini'),
-    system: `You are an assistant that edits rich text documents in the style of Shakespeare. 
+    instructions: `You are an assistant that edits rich text documents in the style of Shakespeare. 
     You should respond in the style of Shakespeare, and when editing the document, 
     the content you generate and add to the document should be written in the style
     of Shakespeare's plays.`,
-    messages: convertToModelMessages(messages),
     tools: toolDefinitions(),
     providerOptions: {
       openai: {
@@ -78,7 +77,10 @@ export async function POST(req: Request) {
     },
   })
 
-  return result.toUIMessageStreamResponse()
+  return createAgentUIStreamResponse({
+    agent,
+    uiMessages: messages,
+  })
 }
 ```
 
@@ -90,20 +92,19 @@ However, in the system prompt, you can reference the [available tools](/content-
 // app/api/chat/route.ts
 import { openai } from '@ai-sdk/openai'
 import { toolDefinitions } from '@tiptap-pro/ai-toolkit-ai-sdk'
-import { convertToModelMessages, streamText, UIMessage } from 'ai'
+import { createAgentUIStreamResponse, ToolLoopAgent, UIMessage } from 'ai'
 
 export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
-  const result = streamText({
+  const agent = new ToolLoopAgent({
     model: openai('gpt-5-mini'),
-    system: `You are an assistant that can edit rich text documents. 
+    instructions: `You are an assistant that can edit rich text documents. 
     Before calling the document editing tools like tiptapEdit,
     you should first read the document to get a sense of the content and context.
     Then, you should inform the user of the plan of action you will take to edit
     the document, in a very detailed step-by-step description. Only after planning
     in detail, you should call the document editing tools.`,
-    messages: convertToModelMessages(messages),
     tools: toolDefinitions(),
     providerOptions: {
       openai: {
@@ -112,7 +113,10 @@ export async function POST(req: Request) {
     },
   })
 
-  return result.toUIMessageStreamResponse()
+  return createAgentUIStreamResponse({
+    agent,
+    uiMessages: messages,
+  })
 }
 ```
 
@@ -145,15 +149,14 @@ Reasoning increases token consumption and latency. If you don't need it for your
 // app/api/chat/route.ts
 import { openai } from '@ai-sdk/openai'
 import { toolDefinitions } from '@tiptap-pro/ai-toolkit-ai-sdk'
-import { convertToModelMessages, streamText, UIMessage } from 'ai'
+import { createAgentUIStreamResponse, ToolLoopAgent, UIMessage } from 'ai'
 
 export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
-  const result = streamText({
+  const agent = new ToolLoopAgent({
     model: openai('gpt-5-mini'),
-    system: `You are an assistant that can edit rich text documents.`,
-    messages: convertToModelMessages(messages),
+    instructions: `You are an assistant that can edit rich text documents.`,
     tools: toolDefinitions(),
     // Set the reasoning effort to 'minimal'
     providerOptions: {
@@ -163,7 +166,10 @@ export async function POST(req: Request) {
     },
   })
 
-  return result.toUIMessageStreamResponse()
+  return createAgentUIStreamResponse({
+    agent,
+    uiMessages: messages,
+  })
 }
 ```
 

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/comments.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/comments.mdx
@@ -32,15 +32,14 @@ Optionally, you can disable the `tiptapEdit` tool to prevent the AI from making 
 // app/api/chat/route.ts
 import { anthropic } from '@ai-sdk/anthropic'
 import { toolDefinitions } from '@tiptap-pro/ai-toolkit-ai-sdk'
-import { convertToModelMessages, streamText, UIMessage } from 'ai'
+import { createAgentUIStreamResponse, ToolLoopAgent, UIMessage } from 'ai'
 
 export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
-  const result = streamText({
+  const agent = new ToolLoopAgent({
     model: anthropic('claude-haiku-4-5-20251001'),
-    system: 'You are an assistant that can add comments to a rich text document.',
-    messages: convertToModelMessages(messages),
+    instructions: 'You are an assistant that can add comments to a rich text document.',
     tools: toolDefinitions({
       tools: {
         // Enable the tools for reading and editing comments
@@ -52,7 +51,10 @@ export async function POST(req: Request) {
     }),
   })
 
-  return result.toUIMessageStreamResponse()
+  return createAgentUIStreamResponse({
+    agent,
+    uiMessages: messages,
+  })
 }
 ```
 

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/multi-document.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/multi-document.mdx
@@ -90,22 +90,21 @@ Include the [tool definitions](/content-ai/capabilities/ai-toolkit/tools/ai-sdk)
 // app/api/chat/route.ts
 import { openai } from '@ai-sdk/openai'
 import { toolDefinitions } from '@tiptap-pro/ai-toolkit-ai-sdk'
-import { convertToModelMessages, streamText, tool, UIMessage } from 'ai'
+import { createAgentUIStreamResponse, ToolLoopAgent, tool, UIMessage } from 'ai'
 import { z } from 'zod'
 
 export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
-  const result = streamText({
+  const agent = new ToolLoopAgent({
     model: openai('gpt-5-mini'),
-    system: `You are an assistant that can edit rich text documents. 
+    instructions: `You are an assistant that can edit rich text documents. 
     You have access to multiple documents and can switch between them. 
     At any point in time, the "active document" is the document that is open in the editor.
     When you call the tools to read and edit the document, they will read and edit the active document.
     To read and edit another document, you should use the tools to switch to that document and then read and edit it.
     Before making any edits, you should always list the documents and see which is the active document.
     `,
-    messages: convertToModelMessages(messages),
     tools: {
       ...toolDefinitions(),
       createDocument: tool({
@@ -139,7 +138,10 @@ export async function POST(req: Request) {
     },
   })
 
-  return result.toUIMessageStreamResponse()
+  return createAgentUIStreamResponse({
+    agent,
+    uiMessages: messages,
+  })
 }
 ```
 

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/multi-document.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/multi-document.mdx
@@ -111,6 +111,7 @@ export async function POST(req: Request) {
         description: 'Create a new document',
         inputSchema: z.object({
           documentName: z.string(),
+          content: z.string().describe('The HTML content of the document'),
         }),
       }),
       listDocuments: tool({
@@ -226,7 +227,7 @@ export default function Page() {
    * @param documentName The name of the new document
    * @returns A message indicating the result of the operation
    */
-  const createDocument = (documentName: string) => {
+  const createDocument = (documentName: string, content: string) => {
     saveActiveDocument()
     const existingDocument = findDocument(documentName)
     if (existingDocument) {
@@ -235,7 +236,7 @@ export default function Page() {
     }
     const newDocument = {
       name: documentName,
-      content: '<p></p>',
+      content: content,
     }
     setDocuments((documents) => [...documents, newDocument])
     setActiveDocumentName(documentName)
@@ -296,7 +297,14 @@ export default function Page() {
     const { toolName, input } = toolCall
 
     if (toolName === 'createDocument') {
-      return createDocument((input as { documentName: string }).documentName)
+      const createDocumentInput = input as {
+        documentName: string
+        content: string
+      }
+      return createDocument(
+        createDocumentInput.documentName,
+        createDocumentInput.content,
+      )
     } else if (toolName === 'listDocuments') {
       return listDocuments()
     } else if (toolName === 'setActiveDocument') {
@@ -328,7 +336,11 @@ export default function Page() {
     async onToolCall({ toolCall }) {
       const output = handleToolCallRef.current(toolCall)
       if (output) {
-        addtoolOutput({ tool: toolCall.toolName, toolCallId: toolCall.toolCallId, output })
+        addtoolOutput({
+          tool: toolCall.toolName,
+          toolCallId: toolCall.toolCallId,
+          output: output as unknown as undefined,
+        })
       }
     },
   })

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/schema-awareness.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/schema-awareness.mdx
@@ -121,11 +121,17 @@ export async function POST(req: Request) {
     await req.json()
 
   const agent = new ToolLoopAgent({
-    model: openai('gpt-5'),
+    model: openai('gpt-5-mini'),
     // Add the schema awareness string to end of the system prompt
     instructions: `You are an assistant that can edit rich text documents.
 ${schemaAwareness}`,
     tools: toolDefinitions(),
+    // Set the reasoning effort to 'minimal' for faster response times
+    providerOptions: {
+      openai: {
+        reasoningEffort: 'minimal',
+      },
+    },
   })
 
   return createAgentUIStreamResponse({

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/schema-awareness.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/schema-awareness.mdx
@@ -113,23 +113,25 @@ Then, inside the API endpoint handler, add the schema awareness string to the en
 // app/api/chat/route.ts
 import { openai } from '@ai-sdk/openai'
 import { toolDefinitions } from '@tiptap-pro/ai-toolkit-ai-sdk'
-import { convertToModelMessages, streamText, UIMessage } from 'ai'
+import { createAgentUIStreamResponse, ToolLoopAgent, UIMessage } from 'ai'
 
 export async function POST(req: Request) {
   // Get the schema awareness string from the request body
   const { messages, schemaAwareness }: { messages: UIMessage[]; schemaAwareness: string } =
     await req.json()
 
-  const result = streamText({
+  const agent = new ToolLoopAgent({
     model: openai('gpt-5'),
     // Add the schema awareness string to end of the system prompt
-    system: `You are an assistant that can edit rich text documents.
+    instructions: `You are an assistant that can edit rich text documents.
 ${schemaAwareness}`,
-    messages: convertToModelMessages(messages),
     tools: toolDefinitions(),
   })
 
-  return result.toUIMessageStreamResponse()
+  return createAgentUIStreamResponse({
+    agent,
+    uiMessages: messages,
+  })
 }
 ```
 

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/selection-awareness.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/selection-awareness.mdx
@@ -34,9 +34,9 @@ Configure the AI so that it can read and edit the selected content in the editor
 
 See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
 
-## The `readSelection` tool
+## The `tiptapReadSelection` tool
 
-The `readSelection` tool allows the AI agent to read the selected content in the editor.
+The `tiptapReadSelection` tool allows the AI agent to read the selected content in the editor.
 
 It is included by default in the list of tool definitions that are passed to the AI model.
 
@@ -45,9 +45,9 @@ It is included by default in the list of tool definitions that are passed to the
 import { toolDefinitions } from '@tiptap-pro/ai-toolkit-ai-sdk'
 
 const definitions = toolDefinitions({
-  // Enable the readSelection tool.
-  // The readSelection tool is enabled by default.
-  readSelection: true,
+  // Enable the tiptapReadSelection tool.
+  // The tiptapReadSelection tool is enabled by default.
+  tiptapReadSelection: true,
 })
 ```
 
@@ -57,7 +57,7 @@ The tool can then be executed in the client-side using the `executeTool` method.
 // Client-side code
 const toolkit = getAiToolkit(editor)
 const result = await toolkit.executeTool({
-  toolName: 'readSelection',
+  toolName: 'tiptapReadSelection',
 })
 ```
 
@@ -68,15 +68,15 @@ The output of the tool contains the following information:
 
 This information lets the AI know what content is selected, and where it is located in the document, so that it can edit it later.
 
-If reading and writing the selection is not a requirement of your app, you can disable the tool by passing `false` to the `readSelection` option in the tool definitions.
+If reading and writing the selection is not a requirement of your app, you can disable the tool by passing `false` to the `tiptapReadSelection` option in the tool definitions.
 
 ```ts
 // Server-side code
 import { toolDefinitions } from '@tiptap-pro/ai-toolkit-ai-sdk'
 
 const definitions = toolDefinitions({
-  // Disable the readSelection tool.
-  readSelection: false,
+  // Disable the tiptapReadSelection tool.
+  tiptapReadSelection: false,
 })
 ```
 

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/selection-awareness.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/selection-awareness.mdx
@@ -12,7 +12,8 @@ import { Requirements, RequirementItem } from '@/components/Requirements'
 
 <Requirements>
   <RequirementItem label="1. Get access">
-      Access the AI Toolkit extension by purchasing the paid AI Toolkit add-on. <a href="https://tiptap.dev/contact-sales?form=ai-toolkit">Contact our team</a>.
+    Access the AI Toolkit extension by purchasing the paid AI Toolkit add-on.{' '}
+    <a href="https://tiptap.dev/contact-sales?form=ai-toolkit">Contact our team</a>.
   </RequirementItem>
   <RequirementItem label="2. Access the private registry">
     The AI Toolkit extension is published in Tiptap&apos;s private npm registry. Authenticate to

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 3.0.0-alpha.22
+
+### Major Changes
+
+- Upgrade to Vercel AI SDK v6.
+
 ## 3.0.0-alpha.21
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 3.0.0-alpha.18
+
+### Patch Changes
+
+- Upgrade LangChain.js version to fix vulnerability.
+
 ## 3.0.0-alpha.17
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 3.0.0-alpha.17
+
+### Major Changes
+
+- Upgrade to OpenAI SDK v6.
+
 ## 3.0.0-alpha.16
 
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 3.0.0-alpha.21
+
+### Minor Changes
+
+- Include Zod schemas in tool definitions, in the `zodInputSchema` property.
+
+## 3.0.0-alpha.20
+
+### Minor Changes
+
+- Add `createInsertContentWorkflow` method. This method creates the prompt for a built-in workflow that allows the AI to insert or replace content in the document.
+
 ## 3.0.0-alpha.19
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.49
+
+### Patch Changes
+
+- Replace deprecated dependency `moize` with `micro-memoize`.
+- Remove unused dependency `debounce`.
+
 ## 3.0.0-alpha.48
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot.mdx
@@ -69,15 +69,14 @@ Create an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to cal
 // app/api/chat/route.ts
 import { openai } from '@ai-sdk/openai'
 import { toolDefinitions } from '@tiptap-pro/ai-toolkit-ai-sdk'
-import { convertToModelMessages, streamText, UIMessage } from 'ai'
+import { createAgentUIStreamResponse, ToolLoopAgent, UIMessage } from 'ai'
 
 export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
-  const result = streamText({
+  const agent = new ToolLoopAgent({
     model: openai('gpt-5-mini'),
-    system: 'You are an assistant that can edit rich text documents.',
-    messages: convertToModelMessages(messages),
+    instructions: 'You are an assistant that can edit rich text documents.',
     tools: toolDefinitions(),
     providerOptions: {
       openai: {
@@ -86,7 +85,10 @@ export async function POST(req: Request) {
     },
   })
 
-  return result.toUIMessageStreamResponse()
+  return createAgentUIStreamResponse({
+    agent,
+    uiMessages: messages,
+  })
 }
 ```
 

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/execute-tool.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/execute-tool.mdx
@@ -121,7 +121,7 @@ For a complete hands-on tutorial on tool streaming, see the [AI agent chatbot wi
 
 Returns the value of the `activeSelection` variable.
 
-The active selection is the range that has been set by the AI Toolkit. When set, this range is used instead of the current editor selection in operations like `readSelection`. The range is automatically mapped through transactions to maintain correct positions as the document changes.
+The active selection is the range that has been set by the AI Toolkit. When set, this range is used instead of the current editor selection in operations like `tiptapReadSelection`. The range is automatically mapped through transactions to maintain correct positions as the document changes.
 
 ### Returns
 
@@ -136,7 +136,7 @@ const activeSelection = toolkit.getActiveSelection()
 
 ## `setActiveSelection`
 
-Sets the `activeSelection` variable. This variable is used when executing tool calls with the `executeTool` or `streamTool` methods, to determine what range the AI will use instead of the current editor selection in operations like `readSelection`.
+Sets the `activeSelection` variable. This variable is used when executing tool calls with the `executeTool` or `streamTool` methods, to determine what range the AI will use instead of the current editor selection in operations like `tiptapReadSelection`.
 
 The active selection is the range that the AI should use instead of the current editor selection. The range is automatically mapped through transactions to maintain correct positions as the document changes.
 

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/workflows.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/workflows.mdx
@@ -55,6 +55,13 @@ const result = streamText({
     task: 'Correct all grammar and spelling mistakes',
   }),
   output: Output.object({ schema: workflow.zodOutputSchema }),
+  // If you use gpt-5-mini, set the reasoning effort to minimal to improve the
+  // response time.
+  providerOptions: {
+    openai: {
+      reasoningEffort: 'minimal',
+    },
+  },
 })
 ```
 

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/workflows.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/workflows.mdx
@@ -36,7 +36,7 @@ The `systemPrompt` field contains an example ready-to-use prompt with sensible d
 
 ```ts
 import { createProofreaderWorkflow } from '@tiptap-pro/ai-toolkit-tool-definitions'
-import { streamObject } from 'ai'
+import { Output, streamText } from 'ai'
 import { openai } from '@ai-sdk/openai'
 
 // Get the nodes from the API endpoint request
@@ -45,7 +45,7 @@ const { nodes } = apiEndpointRequest
 // Create and configure the workflow
 const workflow = createProofreaderWorkflow()
 
-const result = streamObject({
+const result = streamText({
   model: openai('gpt-5-mini'),
   // System prompt
   system: workflow.systemPrompt,
@@ -54,8 +54,7 @@ const result = streamObject({
     nodes,
     task: 'Correct all grammar and spelling mistakes',
   }),
-  // Validate the AI output
-  schema: workflow.zodOutputSchema,
+  output: Output.object({ schema: workflow.zodOutputSchema }),
 })
 ```
 

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/ai-sdk.mdx
@@ -20,50 +20,67 @@ Install the package.
 npm install @tiptap-pro/ai-toolkit-ai-sdk
 ```
 
-Supply the tool definitions to the `tools` parameter of the `generateText` or `streamText` functions.
+Supply the tool definitions to the `tools` parameter of the `ToolLoopAgent` class.
 
 ```ts
 import { openai } from '@ai-sdk/openai'
-import { streamText } from 'ai'
+import { createAgentUIStreamResponse, ToolLoopAgent, UIMessage } from 'ai'
 import { toolDefinitions } from '@tiptap-pro/ai-toolkit-ai-sdk'
 
-const result = streamText({
-  model: openai('gpt-5-mini'),
-  tools: toolDefinitions(),
-})
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json()
+
+  const agent = new ToolLoopAgent({
+    model: openai('gpt-5-mini'),
+    tools: toolDefinitions(),
+  })
+
+  return createAgentUIStreamResponse({
+    agent,
+    uiMessages: messages,
+  })
+}
 ```
 
 Combine the tool definitions with your custom tools.
 
 ```ts
 import { openai } from '@ai-sdk/openai'
-import { streamText, tool } from 'ai'
+import { createAgentUIStreamResponse, ToolLoopAgent, tool, UIMessage } from 'ai'
 import { toolDefinitions } from '@tiptap-pro/ai-toolkit-ai-sdk'
 import { z } from 'zod'
 
-const result = streamText({
-  model: openai('gpt-5-mini'),
-  tools: {
-    // Tool definitions from the AI Toolkit
-    ...toolDefinitions(),
-    // Custom weather tool
-    weather: tool({
-      description: 'Get the weather in a location',
-      inputSchema: z.object({
-        location: z.string(),
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json()
+
+  const agent = new ToolLoopAgent({
+    model: openai('gpt-5-mini'),
+    tools: {
+      // Tool definitions from the AI Toolkit
+      ...toolDefinitions(),
+      // Custom weather tool
+      weather: tool({
+        description: 'Get the weather in a location',
+        inputSchema: z.object({
+          location: z.string(),
+        }),
+        execute: async () => ({
+          temperature: 72,
+        }),
       }),
-      execute: async () => ({
-        temperature: 72,
-      }),
-    }),
-  },
-})
+    },
+  })
+
+  return createAgentUIStreamResponse({
+    agent,
+    uiMessages: messages,
+  })
+}
 ```
 
 <Callout title="Type error with Zod 3" variant="warning">
   If your app uses version 3 of the [Zod validation library](https://zod.dev/), you might get a type
-  error when you pass the tool definitions to the `tools` parameter of the `generateText` or
-  `streamText` functions. You can fix it by upgrading to Zod 4 or by type casting the tool
+  error when you pass the tool definitions to the `tools` parameter of the `ToolLoopAgent` class. You can fix it by upgrading to Zod 4 or by type casting the tool
   definitions to the `ToolSet` type of the AI SDK.
 </Callout>
 

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/proofreader.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/proofreader.mdx
@@ -67,7 +67,7 @@ As the AI model generates its response, the API endpoint streams the suggestions
 // app/api/proofreader/route.ts
 import { openai } from '@ai-sdk/openai'
 import { createProofreaderWorkflow } from '@tiptap-pro/ai-toolkit-tool-definitions'
-import { streamObject } from 'ai'
+import { Output, streamText } from 'ai'
 
 export async function POST(req: Request) {
   const { nodes } = await req.json()
@@ -76,7 +76,7 @@ export async function POST(req: Request) {
   // It includes the ready-to-use system prompt and the output schema.
   const workflow = createProofreaderWorkflow()
 
-  const result = streamObject({
+  const result = streamText({
     model: openai('gpt-5-mini'),
     // System prompt
     system: workflow.systemPrompt,
@@ -85,8 +85,7 @@ export async function POST(req: Request) {
       nodes,
       task: 'Correct all grammar and spelling mistakes',
     }),
-    // Ensure the output follows the schema.
-    schema: workflow.zodOutputSchema,
+    output: Output.object({ schema: workflow.zodOutputSchema }),
     // If you use gpt-5-mini, set the reasoning effort to minimal to improve the
     // response time.
     providerOptions: {


### PR DESCRIPTION
## Changes

This PR upgrades all AI toolkit guides to use Vercel AI SDK V6 patterns:

### Key Updates:
- ✅ Replaced `streamText` with `ToolLoopAgent` class for all agent routes (routes with tools)
- ✅ Replaced `agent.run()` + `toUIMessageStreamResponse()` with `createAgentUIStreamResponse()` API
- ✅ Made `convertToModelMessages` async everywhere (now handled internally by `createAgentUIStreamResponse`)

### Files Updated:
- `ai-agent-chatbot.mdx` - Main guide
- `schema-awareness.mdx` - Schema awareness guide  
- `multi-document.mdx` - Multi-document guide
- `ai-engineering.mdx` - 3 examples updated
- `comments.mdx` - Comments guide
- `tools/ai-sdk.mdx` - 2 examples updated

### Benefits:
- Cleaner API: `createAgentUIStreamResponse` handles message conversion internally
- Better type safety with the new agent-based approach
- Follows Vercel AI SDK V6 best practices

Learn more: https://ai-sdk.dev/docs/agents/building-agents