### PR TITLE
chore(ui-component): add `resetTextSelectionOnClose` arg doc

### DIFF
--- a/src/content/ui-components/utils-components/floating-element.mdx
+++ b/src/content/ui-components/utils-components/floating-element.mdx
@@ -88,17 +88,18 @@ export const FloatingElementExample = () => {
 
 #### Props
 
-| Name                    | Type                                  | Default                    | Description                                                                                                                   |
-| ----------------------- | ------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `editor`                | `Editor \| null`                      | `undefined`                | The Tiptap editor instance to attach to                                                                                       |
-| `shouldShow`            | `boolean`                             | `undefined`                | Controls whether the floating element should be visible                                                                       |
-| `floatingOptions`       | `Partial<UseFloatingOptions>`         | `undefined`                | Additional options to pass to the floating UI                                                                                 |
-| `zIndex`                | `number`                              | `50`                       | Z-index for the floating element                                                                                              |
-| `onOpenChange`          | `(open: boolean) => void`             | `undefined`                | Callback fired when the visibility state changes                                                                              |
-| `referenceElement`      | `HTMLElement \| null`                 | `undefined`                | Reference element to position the floating element relative to. If provided, this takes precedence over getBoundingClientRect |
-| `getBoundingClientRect` | `(editor: Editor) => DOMRect \| null` | `getSelectionBoundingRect` | Custom function to determine the position of the floating element. Only used if referenceElement is not provided              |
-| `closeOnEscape`         | `boolean`                             | `true`                     | Whether to close the floating element when Escape key is pressed                                                              |
-| `children`              | `React.ReactNode`                     | `undefined`                | Content to display inside the floating element                                                                                |
+| Name                        | Type                                  | Default                    | Description                                                                                                                   |
+| --------------------------- | ------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `editor`                    | `Editor \| null`                      | `undefined`                | The Tiptap editor instance to attach to                                                                                       |
+| `shouldShow`                | `boolean`                             | `undefined`                | Controls whether the floating element should be visible                                                                       |
+| `floatingOptions`           | `Partial<UseFloatingOptions>`         | `undefined`                | Additional options to pass to the floating UI                                                                                 |
+| `zIndex`                    | `number`                              | `50`                       | Z-index for the floating element                                                                                              |
+| `onOpenChange`              | `(open: boolean) => void`             | `undefined`                | Callback fired when the visibility state changes                                                                              |
+| `referenceElement`          | `HTMLElement \| null`                 | `undefined`                | Reference element to position the floating element relative to. If provided, this takes precedence over getBoundingClientRect |
+| `getBoundingClientRect`     | `(editor: Editor) => DOMRect \| null` | `getSelectionBoundingRect` | Custom function to determine the position of the floating element. Only used if referenceElement is not provided              |
+| `closeOnEscape`             | `boolean`                             | `true`                     | Whether to close the floating element when Escape key is pressed                                                              |
+| `resetTextSelectionOnClose` | `boolean`                             | `true`                     | Whether to reset the text selection in the editor when the floating element closes                                            |
+| `children`                  | `React.ReactNode`                     | `undefined`                | Content to display inside the floating element                                                                                |
 
 ## Advanced Usage Examples
 

--- a/src/content/ui-components/utils-components/floating-element.mdx
+++ b/src/content/ui-components/utils-components/floating-element.mdx
@@ -98,7 +98,7 @@ export const FloatingElementExample = () => {
 | `referenceElement`          | `HTMLElement \| null`                 | `undefined`                | Reference element to position the floating element relative to. If provided, this takes precedence over getBoundingClientRect |
 | `getBoundingClientRect`     | `(editor: Editor) => DOMRect \| null` | `getSelectionBoundingRect` | Custom function to determine the position of the floating element. Only used if referenceElement is not provided              |
 | `closeOnEscape`             | `boolean`                             | `true`                     | Whether to close the floating element when Escape key is pressed                                                              |
-| `resetTextSelectionOnClose` | `boolean`                             | `true`                     | Whether to reset the text selection in the editor when the floating element closes                                            |
+| `resetTextSelectionOnClose` | `boolean`                             | `true`                     | When `true` (default), reset/clear the editor's text selection when the floating element closes; when `false`, preserve it    |
 | `children`                  | `React.ReactNode`                     | `undefined`                | Content to display inside the floating element                                                                                |
 
 ## Advanced Usage Examples


### PR DESCRIPTION
This PR adds documentation for `resetTextSelectionOnClose` argument to preserve the current editor selection when the editor loses focus.