### PR TITLE
Markdown paste: Error handling in the code snippet 

### DIFF
--- a/src/content/editor/markdown/examples.mdx
+++ b/src/content/editor/markdown/examples.mdx
@@ -51,6 +51,7 @@ const PasteMarkdown = Extension.create({
   name: 'pasteMarkdown',
 
   addProseMirrorPlugins() {
+    const { editor } = this;
     return [
       new Plugin({
         props: {
@@ -62,7 +63,7 @@ const PasteMarkdown = Extension.create({
             }
 
             // Check if text looks like Markdown
-            if (looksLikeMarkdown(text)) {
+            if (editor.markdown && looksLikeMarkdown(text)) {
               const { state, dispatch } = view
               // Parse the Markdown text to Tiptap JSON using the Markdown manager
               const json = editor.markdown.parse(text)


### PR DESCRIPTION
Fix for editor is not defined and processing if editor is markdown