### PR TITLE
Document new updatePosition floating menu option

### DIFF
--- a/src/content/editor/extensions/functionality/floatingmenu.mdx
+++ b/src/content/editor/extensions/functionality/floatingmenu.mdx
@@ -52,7 +52,7 @@ The `FloatingMenuPlugin` will come with a default delay of 250ms. This can be de
 
 Type: `Number`
 
-Default: `undefined`
+Default: `250`
 
 ### resizeDelay
 

--- a/src/content/editor/extensions/functionality/floatingmenu.mdx
+++ b/src/content/editor/extensions/functionality/floatingmenu.mdx
@@ -45,6 +45,23 @@ Type: `HTMLElement`
 
 Default: `null`
 
+### updateDelay
+
+The `FloatingMenu` debounces the `update` method to allow the floating menu to not be updated on every selection update. This can be controlled in milliseconds.
+The `FloatingMenuPlugin` will come with a default delay of 250ms. This can be deactivated, by setting the delay to `0` which deactivates the debounce.
+
+Type: `Number`
+
+Default: `undefined`
+
+### resizeDelay
+
+The `FloatingMenu` debounces the resize and scroll event handlers to allow the floating menu to not be updated on every resize or scroll event. This can be controlled in milliseconds.
+
+Type: `Number`
+
+Default: `60`
+
 ### appendTo
 
 The element to which the bubble menu should be appended to in the DOM. Can be a `HTMLElement` or a callback function that returns a `HTMLElement`.
@@ -169,4 +186,12 @@ new Editor({
     }),
   ],
 })
+```
+
+### Force update the position of the floating menu
+
+If the floating menu changes size after the initial render, its position will not be adjusted automatically. To fix this, you can force update the position of the floating menu by emitting an `'updatePosition'` event.
+
+```ts
+editor.commands.setMeta('floatingMenu', 'updatePosition')
 ```

--- a/src/content/editor/extensions/functionality/floatingmenu.mdx
+++ b/src/content/editor/extensions/functionality/floatingmenu.mdx
@@ -64,7 +64,7 @@ Default: `60`
 
 ### appendTo
 
-The element to which the bubble menu should be appended to in the DOM. Can be a `HTMLElement` or a callback function that returns a `HTMLElement`.
+The element to which the floating menu should be appended to in the DOM. Can be a `HTMLElement` or a callback function that returns a `HTMLElement`.
 
 Type: `HTMLElement | (() => HTMLElement) | undefined`
 

--- a/src/content/editor/extensions/functionality/floatingmenu.mdx
+++ b/src/content/editor/extensions/functionality/floatingmenu.mdx
@@ -190,7 +190,13 @@ new Editor({
 
 ### Force update the position of the floating menu
 
-If the floating menu changes size after the initial render, its position will not be adjusted automatically. To fix this, you can force update the position of the floating menu by emitting an `'updatePosition'` event.
+If the floating menu changes size after the initial render, its position will not be adjusted automatically. To fix this, you can force update the position of the floating menu using the `updateFloatingMenuPosition` command:
+
+```ts
+editor.commands.updateFloatingMenuPosition()
+```
+
+Alternatively, you can emit an `'updatePosition'` event via transaction metadata:
 
 ```ts
 editor.commands.setMeta('floatingMenu', 'updatePosition')


### PR DESCRIPTION
Add documentation for new FloatingMenu features from tiptap PR #7403:
- updateDelay setting for debouncing menu updates
- resizeDelay setting for debouncing resize/scroll events
- Force update position via transaction meta

See https://github.com/ueberdosis/tiptap/pull/7403