### PR TITLE
Update changelogs for editThreads tool format change

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 3.0.0-alpha.24
+
+### Major Changes
+
+- **Breaking**: Change `editThreads` tool to use a new, more efficient format. The new format is faster, more efficient, uses fewer tokens, and avoids diff mismatch errors completely, significantly improving the accuracy of the tool.
+
+## 3.0.0-alpha.23
+
+### Patch Changes
+
+- Enable structured outputs by default for `tiptapRead` and `tiptapEdit` tools. This fixes a bug where Claude Haiku 4.5 would sometimes not call the tools correctly.
+
 ## 3.0.0-alpha.22
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 3.0.0-alpha.14
+
+### Major Changes
+
+- **Breaking**: Change `editThreads` tool to use a new, more efficient format. The new format is faster, more efficient, uses fewer tokens, and avoids diff mismatch errors completely, significantly improving the accuracy of the tool.
+
 ## 3.0.0-alpha.13
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 3.0.0-alpha.19
+
+### Major Changes
+
+- **Breaking**: Change `editThreads` tool to use a new, more efficient format. The new format is faster, more efficient, uses fewer tokens, and avoids diff mismatch errors completely, significantly improving the accuracy of the tool.
+
 ## 3.0.0-alpha.18
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 3.0.0-alpha.18
+
+### Major Changes
+
+- **Breaking**: Change `editThreads` tool to use a new, more efficient format. The new format is faster, more efficient, uses fewer tokens, and avoids diff mismatch errors completely, significantly improving the accuracy of the tool.
+
 ## 3.0.0-alpha.17
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 3.0.0-alpha.22
+
+### Major Changes
+
+- **Breaking**: Change `editThreads` tool to use a new, more efficient format. The new format is faster, more efficient, uses fewer tokens, and avoids diff mismatch errors completely, significantly improving the accuracy of the tool.
+
 ## 3.0.0-alpha.21
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.51
+
+### Major Changes
+
+- **Breaking**: Change `editThreads` tool to use a new, more efficient format. The new format is faster, more efficient, uses fewer tokens, and avoids diff mismatch errors completely, significantly improving the accuracy of the tool.
+
 ## 3.0.0-alpha.50
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/tools/available-tools.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/tools/available-tools.mdx
@@ -47,7 +47,7 @@ Edit the document at a given position.
 
 ### Parameters
 
-A list of operations to perform on the document. We provide customers with more comprehensive information about the format of this tool.
+- `operations` (`array`): A list of operations to perform on the document. We provide customers with more comprehensive information about the format of this tool.
 
 ### Result
 


### PR DESCRIPTION
## Summary

This PR updates the changelog documentation to reflect the breaking changes made to the `editThreads` tool format.

## Changes

- Updated all AI Toolkit package changelogs:
  - `ai-toolkit.mdx`
  - `ai-toolkit-tool-definitions.mdx`
  - `ai-toolkit-ai-sdk.mdx`
  - `ai-toolkit-openai.mdx`
  - `ai-toolkit-langchain.mdx`
  - `ai-toolkit-anthropic.mdx`

## Changelog Updates

All changelogs now document that:
- The `editThreads` tool uses a new, more efficient format (breaking change)
- The new format is faster, more efficient, and uses fewer tokens
- The new format avoids diff mismatch errors completely, significantly improving accuracy

This documentation update corresponds to the changes made in the tiptap-pro repository where the `editThreads` tool was refactored to use a tuple-based format instead of object-based format.