### PR TITLE
Add documentation for Tiptap Edit and Comments workflows

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -13,7 +13,7 @@ meta:
 ### Minor Changes
 
 - Add `createTiptapEditWorkflow` method. This method creates the prompt and schema for a built-in workflow that allows the AI to edit the document.
-- Add `createCommentsWorkflow` method. This method creates the prompt and schema for a built-in workflow that allows the AI to manage comments and threads.
+- Add `createThreadsWorkflow` method. This method creates the prompt and schema for a built-in workflow that allows the AI to manage comments and threads.
 
 ## 3.0.0-alpha.22
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -13,7 +13,7 @@ meta:
 ### Minor Changes
 
 - Add `createTiptapEditWorkflow` method. This method creates the prompt and schema for a built-in workflow that allows the AI to edit the document.
-- Add `createThreadsWorkflow` method. This method creates the prompt and schema for a built-in workflow that allows the AI to manage comments and threads.
+- Add `createEditThreadsWorkflow` method. This method creates the prompt and schema for a built-in workflow that allows the AI to manage comments and threads.
 
 ## 3.0.0-alpha.22
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 3.0.0-alpha.23
+
+### Minor Changes
+
+- Add `createTiptapEditWorkflow` method. This method creates the prompt and schema for a built-in workflow that allows the AI to edit the document.
+- Add `createCommentsWorkflow` method. This method creates the prompt and schema for a built-in workflow that allows the AI to manage comments and threads.
+
 ## 3.0.0-alpha.22
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,14 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.52
+
+### Minor Changes
+
+- Add `tiptapEditWorkflow` method. This method executes a workflow that allows the AI to edit the document with precise, efficient operations.
+- Add `editThreadsWorkflow` method. This method executes a workflow that allows the AI to manage comments and threads in the document.
+- Add `getThreads` method. This method retrieves all threads in the document with their comments and location information.
+
 ## 3.0.0-alpha.51
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,13 +8,19 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
-## 3.0.0-alpha.52
+## 3.0.0-alpha.53
 
 ### Minor Changes
 
 - Add `tiptapEditWorkflow` method. This method executes a workflow that allows the AI to edit the document with precise, efficient operations.
 - Add `editThreadsWorkflow` method. This method executes a workflow that allows the AI to manage comments and threads in the document.
 - Add `getThreads` method. This method retrieves all threads in the document with their comments and location information.
+
+## 3.0.0-alpha.52
+
+### Patch Changes
+
+- Fix bug where the position of the other suggestions was not updated correctly when a suggestion was accepted or rejected.
 
 ## 3.0.0-alpha.51
 
@@ -34,7 +40,7 @@ meta:
 
 - Add `reviewMode` field to `Suggestion` interface. This field indicates whether a suggestion is in 'preview' mode (preview of a change before applying) or 'review' mode (review of a change that has already been made, allowing the user to undo it). The field is automatically set based on `reviewOptions.mode` when suggestions are created.
 - Add `rejectSuggestion` and `rejectAllSuggestions` methods to reject suggestions without applying them. These methods return AI feedback about the rejected changes.
-- Modify `acceptSuggestion` and `acceptAllSuggestions` methods to return `aiFeedback` property. The `aiFeedback` contains events with information about changes that were accepted or rejected by the user.
+- Modify `acceptSuggestion` and `acceptAllSuggestions` methods to return `aiFeedback` property. The `aiFeedback` contains events with information about changes that were accepted or rejected by the user, including the deleted content, inserted content, and acceptance status. This feedback can be used to inform the AI about user preferences and improve future suggestions.
 
 ## 3.0.0-alpha.49
 

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/workflows.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/workflows.mdx
@@ -249,7 +249,7 @@ const result = toolkit.tiptapEditWorkflow({
 })
 ```
 
-## `createThreadsWorkflow` (server-side utility)
+## `createEditThreadsWorkflow` (server-side utility)
 
 Creates a ready-made workflow configuration for managing comments and threads. Returns a system prompt and schemas for validating AI output.
 
@@ -268,7 +268,7 @@ The workflow expects a user prompt as a JSON object with:
 ### Example
 
 ```ts
-import { createThreadsWorkflow } from '@tiptap-pro/ai-toolkit-tool-definitions'
+import { createEditThreadsWorkflow } from '@tiptap-pro/ai-toolkit-tool-definitions'
 import { Output, streamText } from 'ai'
 import { openai } from '@ai-sdk/openai'
 
@@ -276,7 +276,7 @@ import { openai } from '@ai-sdk/openai'
 const { nodes, threads, task } = apiEndpointRequest
 
 // Create and configure the workflow
-const workflow = createThreadsWorkflow()
+const workflow = createEditThreadsWorkflow()
 
 const result = streamText({
   model: openai('gpt-5-mini'),

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/workflows.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/workflows.mdx
@@ -249,7 +249,7 @@ const result = toolkit.tiptapEditWorkflow({
 })
 ```
 
-## `createCommentsWorkflow` (server-side utility)
+## `createThreadsWorkflow` (server-side utility)
 
 Creates a ready-made workflow configuration for managing comments and threads. Returns a system prompt and schemas for validating AI output.
 
@@ -268,7 +268,7 @@ The workflow expects a user prompt as a JSON object with:
 ### Example
 
 ```ts
-import { createCommentsWorkflow } from '@tiptap-pro/ai-toolkit-tool-definitions'
+import { createThreadsWorkflow } from '@tiptap-pro/ai-toolkit-tool-definitions'
 import { Output, streamText } from 'ai'
 import { openai } from '@ai-sdk/openai'
 
@@ -276,7 +276,7 @@ import { openai } from '@ai-sdk/openai'
 const { nodes, threads, task } = apiEndpointRequest
 
 // Create and configure the workflow
-const workflow = createCommentsWorkflow()
+const workflow = createThreadsWorkflow()
 
 const result = streamText({
   model: openai('gpt-5-mini'),

--- a/src/content/content-ai/capabilities/ai-toolkit/primitives/workflows.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/primitives/workflows.mdx
@@ -10,8 +10,8 @@ Workflows are scenarios where the AI model has a single, well-defined task. The 
 
 - [Insert content](/content-ai/capabilities/ai-toolkit/workflows/insert-content).
 - [Proofreader](/content-ai/capabilities/ai-toolkit/workflows/proofreader).
-- Replace editor content (coming soon).
-- Add comments (coming soon).
+- [Tiptap Edit](/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit).
+- [Comments](/content-ai/capabilities/ai-toolkit/workflows/comments).
 
 Below is the API reference for the methods that support these built-in workflows.
 
@@ -171,4 +171,191 @@ const result = toolkit.proofreaderWorkflow({
     mode: 'preview',
   },
 })
+```
+
+## `createTiptapEditWorkflow` (server-side utility)
+
+Creates a ready-made workflow configuration for editing documents. Returns a system prompt and schemas for validating AI output.
+
+The workflow expects a user prompt as a JSON object with:
+
+- `nodes`: The nodes of the document to be edited (obtained from `tiptapRead`)
+- `task`: A string describing the editing task to complete
+
+### Returns
+
+- `systemPrompt` (`string`): Ready-to-use system prompt that instructs the AI model on how to generate edit operations
+- `zodOutputSchema` (`ZodObject`): Zod schema for validating the AI output
+- `jsonOutputSchema` (`object`): JSON schema for validating the AI output
+
+### Example
+
+```ts
+import { createTiptapEditWorkflow } from '@tiptap-pro/ai-toolkit-tool-definitions'
+import { Output, streamText } from 'ai'
+import { openai } from '@ai-sdk/openai'
+
+// Get the nodes and task from the API endpoint request
+const { nodes, task } = apiEndpointRequest
+
+// Create and configure the workflow
+const workflow = createTiptapEditWorkflow()
+
+const result = streamText({
+  model: openai('gpt-5-mini'),
+  system: workflow.systemPrompt,
+  prompt: JSON.stringify({ nodes, task }),
+  output: Output.object({ schema: workflow.zodOutputSchema }),
+})
+```
+
+## `tiptapEditWorkflow`
+
+Applies a list of edit operations to the document.
+
+### Parameters
+
+- `options` (`TiptapEditWorkflowOptions`): Configuration options
+  - `operations` (`PartialTiptapEditOperation[]`): Array of edit operations. Each operation is a tuple `[type, target, content]`:
+    - `type`: `'replace'` | `'insertBefore'` | `'insertAfter'`
+    - `target`: The 6-character hash of the node (from `tiptapRead`) or `'doc'` for entire document
+    - `content`: HTML string with the content to insert
+  - `workflowId` (`unknown`): Unique ID for this workflow run
+  - `reviewOptions?` (`ReviewOptions`): Control preview/review behavior (same options as `proofreaderWorkflow`)
+
+### Returns (`TiptapEditWorkflowResult`)
+
+- `doc` (`Node`): The modified document after applying operations
+- `successful` (`string[]`): Array of successfully processed target hashes
+- `failed` (`{ target: string; error?: string }[]`): Array of failed operations with error messages
+
+### Example
+
+```ts
+const toolkit = getAiToolkit(editor)
+
+// Get the document with hashes
+const { nodes } = toolkit.tiptapRead()
+
+const operations = await callApiEndpoint({ nodes, task: 'Make the text more formal' })
+
+// Apply edit operations
+const result = toolkit.tiptapEditWorkflow({
+  operations,
+  workflowId: 'edit-123',
+  reviewOptions: {
+    mode: 'preview',
+  },
+})
+```
+
+## `createCommentsWorkflow` (server-side utility)
+
+Creates a ready-made workflow configuration for managing comments and threads. Returns a system prompt and schemas for validating AI output.
+
+The workflow expects a user prompt as a JSON object with:
+
+- `nodes`: The nodes of the document (obtained from `tiptapRead`)
+- `threads`: The existing threads in the document (obtained from `getThreads`)
+- `task`: A string describing the comment management task to complete
+
+### Returns
+
+- `systemPrompt` (`string`): Ready-to-use system prompt that instructs the AI model on how to manage comments
+- `zodOutputSchema` (`ZodObject`): Zod schema for validating the AI output
+- `jsonOutputSchema` (`object`): JSON schema for validating the AI output
+
+### Example
+
+```ts
+import { createCommentsWorkflow } from '@tiptap-pro/ai-toolkit-tool-definitions'
+import { Output, streamText } from 'ai'
+import { openai } from '@ai-sdk/openai'
+
+// Get the nodes, threads, and task from the API endpoint request
+const { nodes, threads, task } = apiEndpointRequest
+
+// Create and configure the workflow
+const workflow = createCommentsWorkflow()
+
+const result = streamText({
+  model: openai('gpt-5-mini'),
+  system: workflow.systemPrompt,
+  prompt: JSON.stringify({ nodes, threads, task }),
+  output: Output.object({ schema: workflow.zodOutputSchema }),
+})
+```
+
+## `getThreads`
+
+Retrieves all threads in the document with their comments and location information.
+
+### Returns (`GetThreadsResult`)
+
+- `threadCount` (`number`): The number of threads in the document
+- `threads` (`ThreadInfo[]`): Array of thread information, each containing:
+  - `id` (`string`): The unique identifier of the thread
+  - `comments` (`{ id: string; content: string }[]`): Array of comments in the thread
+  - `nodeRange?` (`string`): The range of nodes where the thread is located
+  - `documentContent?` (`string`): The HTML content where the thread is applied
+
+### Example
+
+```ts
+const toolkit = getAiToolkit(editor)
+
+// Get all threads in the document
+const result = toolkit.getThreads()
+
+console.log(`Found ${result.threadCount} threads`)
+
+result.threads.forEach(thread => {
+  console.log(`Thread ${thread.id}: ${thread.comments.length} comments`)
+})
+```
+
+## `editThreadsWorkflow`
+
+Applies comment and thread operations to the document.
+
+### Parameters
+
+- `options` (`EditThreadsWorkflowOptions`): Configuration options
+  - `operations` (`string[][]`): Array of comment operations as tuples. Supported operations:
+    - `['createThread', nodeHash, htmlContent]`: Create a new thread
+    - `['createComment', threadId, content]`: Add a comment to a thread
+    - `['updateComment', threadId, commentId, content]`: Update a comment
+    - `['removeComment', threadId, commentId]`: Remove a comment
+    - `['removeThread', threadId]`: Remove a thread
+    - `['resolveThread', threadId]`: Resolve a thread
+    - `['unresolveThread', threadId]`: Unresolve a thread
+  - `commentsOptions?` (`CommentsOptions`): Options for comment operations
+    - `threadData?` (`Record<string, any>`): Extra metadata for created threads
+    - `commentData?` (`Record<string, any>`): Extra metadata for created comments
+
+### Returns (`EditThreadsWorkflowResult`)
+
+- `operations` (`EditThreadsOperationResult[]`): Array of operation results
+- `docChanged` (`boolean`): Whether any operation changed the document
+- `success` (`boolean`): Whether all operations were successful
+
+### Example
+
+```ts
+const toolkit = getAiToolkit(editor)
+
+// Get document and threads
+const { nodes } = toolkit.tiptapRead()
+const { threads } = toolkit.getThreads()
+
+const operations = await callApiEndpoint({ nodes, threads, task: 'Add review comments' })
+
+// Apply comment operations
+const result = toolkit.editThreadsWorkflow({
+  operations,
+})
+
+if (result.success) {
+  console.log('All comment operations completed successfully')
+}
 ```

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/comments.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/comments.mdx
@@ -229,7 +229,7 @@ With additional CSS styles, the result is a polished comments management applica
   isLarge
   path=""
   isScrollable
-- [Comments extension](/comments/getting-started/overview): Learn more about the Comments extension.
+  src="https://ai-toolkit-demos.vercel.app/comments-workflow"
 />
 
 See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
@@ -239,4 +239,4 @@ See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
 - [API reference](/content-ai/capabilities/ai-toolkit/primitives/read-the-document#tiptapread) of the `tiptapRead` method
 - [API reference](/content-ai/capabilities/ai-toolkit/primitives/workflows#getthreads) of the `getThreads` method
 - [API reference](/content-ai/capabilities/ai-toolkit/primitives/workflows#editthreadsworkflow) of the `editThreadsWorkflow` method
-- [Comments extension](/comments/getting-started/overview): Learn more about the Comments extension.
+- [Comments extension](/collaboration/comments/overview): Learn more about the Comments extension.

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/comments.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/comments.mdx
@@ -60,7 +60,7 @@ npm install @tiptap-pro/ai-toolkit @tiptap-pro/ai-toolkit-tool-definitions @tipt
 
 Create an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to call the OpenAI model.
 
-Inside the API endpoint, create and configure the Comments workflow using the `createCommentsWorkflow` function. The workflow includes a ready-to-use system prompt that instructs the AI model on how to manage comments.
+Inside the API endpoint, create and configure the Comments workflow using the `createThreadsWorkflow` function. The workflow includes a ready-to-use system prompt that instructs the AI model on how to manage comments.
 
 The user message should include:
 
@@ -71,7 +71,7 @@ The user message should include:
 ```ts
 // app/api/comments-workflow/route.ts
 import { openai } from '@ai-sdk/openai'
-import { createCommentsWorkflow } from '@tiptap-pro/ai-toolkit-tool-definitions'
+import { createThreadsWorkflow } from '@tiptap-pro/ai-toolkit-tool-definitions'
 import { Output, streamText } from 'ai'
 
 export async function POST(req: Request) {
@@ -79,7 +79,7 @@ export async function POST(req: Request) {
 
   // Create and configure the Comments workflow (with the default settings).
   // It includes the ready-to-use system prompt and the output schema.
-  const workflow = createCommentsWorkflow()
+  const workflow = createThreadsWorkflow()
 
   const result = streamText({
     model: openai('gpt-5-mini'),
@@ -120,7 +120,7 @@ Then, call the API endpoint to start the workflow. Use the `editThreadsWorkflow`
 import { experimental_useObject as useObject } from '@ai-sdk/react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import { AiToolkit, getAiToolkit, commentsWorkflowOutputSchema } from '@tiptap-pro/ai-toolkit'
+import { AiToolkit, getAiToolkit, threadsWorkflowOutputSchema } from '@tiptap-pro/ai-toolkit'
 import { Comments } from '@tiptap-pro/extension-comments'
 import { useEffect, useState } from 'react'
 
@@ -160,7 +160,7 @@ export default function Page() {
 
   const { submit, isLoading, object } = useObject({
     api: '/api/comments-workflow',
-    schema: commentsWorkflowOutputSchema,
+    schema: threadsWorkflowOutputSchema,
   })
 
   const operations = object?.operations ?? []

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/comments.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/comments.mdx
@@ -1,0 +1,233 @@
+---
+title: Comments workflow
+meta:
+  title: Comments workflow | Tiptap Content AI
+  description: Use the Tiptap AI Toolkit to build a workflow that manages comments and threads in your documents.
+  category: Content AI
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+import { Callout } from '@/components/ui/Callout'
+
+Build a workflow that allows the AI to manage comments and threads in your Tiptap documents.
+
+<CodeDemo isLarge path="" isScrollable src="https://ai-toolkit-demos.vercel.app/comments-workflow" />
+
+See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
+
+## Tech stack
+
+- [React](https://react.dev/) + [Next.js](https://nextjs.org/)
+- [AI SDK by Vercel](https://ai-sdk.dev/) + [OpenAI](https://openai.com/) models
+- Tiptap AI Toolkit
+- Tiptap Comments extension
+
+## Project overview
+
+This demo uses the AI Toolkit's Comments workflow to manage threads and comments in the document. The AI can create new threads, add comments, update comments, remove comments, and manage thread status.
+
+## Installation
+
+Create a [Next.js](https://nextjs.org/) project:
+
+```bash
+npx create-next-app@latest comments-workflow
+```
+
+Install the core Tiptap packages and the [Vercel AI SDK](https://ai-sdk.dev/) for OpenAI:
+
+```bash
+npm install @tiptap/react @tiptap/starter-kit ai @ai-sdk/react @ai-sdk/openai zod uuid
+```
+
+Install the Tiptap AI Toolkit and Comments extension:
+
+<Callout title="Pro package" variant="hint">
+  The AI Toolkit is a pro package. Before installation, set up access to the private NPM registry by
+  following the [private registry guide](/guides/pro-extensions).
+</Callout>
+
+```bash
+npm install @tiptap-pro/ai-toolkit @tiptap-pro/ai-toolkit-tool-definitions @tiptap-pro/extension-comments
+```
+
+## Server setup
+
+Create an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to call the OpenAI model.
+
+Inside the API endpoint, create and configure the Comments workflow using the `createCommentsWorkflow` function. The workflow includes a ready-to-use system prompt that instructs the AI model on how to manage comments.
+
+The user message should include:
+
+- `nodes`: The nodes of the document (obtained from `tiptapRead`)
+- `threads`: The existing threads in the document (obtained from `getThreads`)
+- `task`: The task to be performed by the AI. For example, `Add a comment suggesting improvements to the introduction`.
+
+```ts
+// app/api/comments-workflow/route.ts
+import { openai } from '@ai-sdk/openai'
+import { createCommentsWorkflow } from '@tiptap-pro/ai-toolkit-tool-definitions'
+import { Output, streamText } from 'ai'
+
+export async function POST(req: Request) {
+  const { nodes, threads, task } = await req.json()
+
+  // Create and configure the Comments workflow (with the default settings).
+  // It includes the ready-to-use system prompt and the output schema.
+  const workflow = createCommentsWorkflow()
+
+  const result = streamText({
+    model: openai('gpt-5-mini'),
+    // System prompt
+    system: workflow.systemPrompt,
+    // User message
+    prompt: JSON.stringify({
+      nodes,
+      threads,
+      task,
+    }),
+    output: Output.object({ schema: workflow.zodOutputSchema }),
+    // If you use gpt-5-mini, set the reasoning effort to minimal to improve the
+    // response time.
+    providerOptions: {
+      openai: {
+        reasoningEffort: 'minimal',
+      },
+    },
+  })
+
+  return result.toTextStreamResponse()
+}
+```
+
+## Client setup
+
+Create a React component that renders the editor with the Comments extension and applies comment operations.
+
+First, when the workflow starts, call the `tiptapRead` method to get the document content and `getThreads` method to get existing threads.
+
+Then, call the API endpoint to start the workflow. Use the `editThreadsWorkflow` method to apply the comment operations.
+
+```tsx
+// app/comments-workflow/page.tsx
+'use client'
+
+import { experimental_useObject as useObject } from '@ai-sdk/react'
+import { EditorContent, useEditor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import { AiToolkit, getAiToolkit, commentsWorkflowOutputSchema } from '@tiptap-pro/ai-toolkit'
+import { Comments } from '@tiptap-pro/extension-comments'
+import { useEffect, useState } from 'react'
+
+// Create a simple comments provider
+const commentsProvider = {
+  threads: [],
+  getThreads: () => commentsProvider.threads,
+  createThread: (thread) => {
+    commentsProvider.threads.push(thread)
+    return thread
+  },
+  updateThread: (id, data) => {
+    const index = commentsProvider.threads.findIndex((t) => t.id === id)
+    if (index !== -1) {
+      commentsProvider.threads[index] = { ...commentsProvider.threads[index], ...data }
+    }
+  },
+  deleteThread: (id) => {
+    commentsProvider.threads = commentsProvider.threads.filter((t) => t.id !== id)
+  },
+}
+
+export default function Page() {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [
+      StarterKit,
+      AiToolkit,
+      Comments.configure({
+        provider: commentsProvider,
+      }),
+    ],
+    content: `<h1>Document with Comments</h1><p>This is a sample document where AI can add and manage comments.</p>`,
+  })
+
+  const [task, setTask] = useState('Add a comment suggesting improvements to this document')
+
+  const { submit, isLoading, object } = useObject({
+    api: '/api/comments-workflow',
+    schema: commentsWorkflowOutputSchema,
+  })
+
+  const operations = object?.operations ?? []
+
+  // Apply operations as they arrive
+  useEffect(() => {
+    if (!editor || operations.length === 0) return
+
+    const toolkit = getAiToolkit(editor)
+    toolkit.editThreadsWorkflow({
+      operations,
+    })
+  }, [operations, editor])
+
+  if (!editor) return null
+
+  const manageComments = () => {
+    const toolkit = getAiToolkit(editor)
+
+    // Get the document content and existing threads
+    const { nodes } = toolkit.tiptapRead()
+    const { threads } = toolkit.getThreads()
+
+    // Call the API endpoint to start the workflow
+    submit({ nodes, threads, task })
+  }
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+
+      <input
+        type="text"
+        value={task}
+        onChange={(e) => setTask(e.target.value)}
+        placeholder="Enter task for comments..."
+      />
+
+      <button onClick={manageComments} disabled={isLoading}>
+        {isLoading ? 'Processing...' : 'Manage Comments with AI'}
+      </button>
+    </div>
+  )
+}
+```
+
+## Available operations
+
+The Comments workflow supports the following operations:
+
+| Operation | Format | Description |
+|-----------|--------|-------------|
+| Create thread | `['createThread', nodeHash, htmlContent]` | Creates a new thread at a specific location |
+| Create comment | `['createComment', threadId, content]` | Adds a comment to an existing thread |
+| Update comment | `['updateComment', threadId, commentId, content]` | Updates an existing comment |
+| Remove comment | `['removeComment', threadId, commentId]` | Removes a comment from a thread |
+| Remove thread | `['removeThread', threadId]` | Removes an entire thread |
+| Resolve thread | `['resolveThread', threadId]` | Marks a thread as resolved |
+| Unresolve thread | `['unresolveThread', threadId]` | Marks a thread as unresolved |
+
+## End result
+
+With additional CSS styles, the result is a polished comments management application:
+
+<CodeDemo isLarge path="" isScrollable src="https://ai-toolkit-demos.vercel.app/comments-workflow" />
+
+See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
+
+## Related guides
+
+- [API reference](/content-ai/capabilities/ai-toolkit/primitives/read-the-document#tiptapread) of the `tiptapRead` method
+- [API reference](/content-ai/capabilities/ai-toolkit/primitives/workflows#getthreads) of the `getThreads` method
+- [API reference](/content-ai/capabilities/ai-toolkit/primitives/workflows#editthreadsworkflow) of the `editThreadsWorkflow` method
+- [Comments extension](/collaboration/comments/overview): Learn more about the Comments extension.
+

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/comments.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/comments.mdx
@@ -60,7 +60,7 @@ npm install @tiptap-pro/ai-toolkit @tiptap-pro/ai-toolkit-tool-definitions @tipt
 
 Create an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to call the OpenAI model.
 
-Inside the API endpoint, create and configure the Comments workflow using the `createThreadsWorkflow` function. The workflow includes a ready-to-use system prompt that instructs the AI model on how to manage comments.
+Inside the API endpoint, create and configure the Comments workflow using the `createEditThreadsWorkflow` function. The workflow includes a ready-to-use system prompt that instructs the AI model on how to manage comments.
 
 The user message should include:
 
@@ -71,7 +71,7 @@ The user message should include:
 ```ts
 // app/api/comments-workflow/route.ts
 import { openai } from '@ai-sdk/openai'
-import { createThreadsWorkflow } from '@tiptap-pro/ai-toolkit-tool-definitions'
+import { createEditThreadsWorkflow } from '@tiptap-pro/ai-toolkit-tool-definitions'
 import { Output, streamText } from 'ai'
 
 export async function POST(req: Request) {
@@ -79,7 +79,7 @@ export async function POST(req: Request) {
 
   // Create and configure the Comments workflow (with the default settings).
   // It includes the ready-to-use system prompt and the output schema.
-  const workflow = createThreadsWorkflow()
+  const workflow = createEditThreadsWorkflow()
 
   const result = streamText({
     model: openai('gpt-5-mini'),
@@ -120,7 +120,7 @@ Then, call the API endpoint to start the workflow. Use the `editThreadsWorkflow`
 import { experimental_useObject as useObject } from '@ai-sdk/react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import { AiToolkit, getAiToolkit, threadsWorkflowOutputSchema } from '@tiptap-pro/ai-toolkit'
+import { AiToolkit, getAiToolkit, editThreadsWorkflowOutputSchema } from '@tiptap-pro/ai-toolkit'
 import { Comments } from '@tiptap-pro/extension-comments'
 import { useEffect, useState } from 'react'
 
@@ -160,7 +160,7 @@ export default function Page() {
 
   const { submit, isLoading, object } = useObject({
     api: '/api/comments-workflow',
-    schema: threadsWorkflowOutputSchema,
+    schema: editThreadsWorkflowOutputSchema,
   })
 
   const operations = object?.operations ?? []

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/comments.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/comments.mdx
@@ -11,7 +11,12 @@ import { Callout } from '@/components/ui/Callout'
 
 Build a workflow that allows the AI to manage comments and threads in your Tiptap documents.
 
-<CodeDemo isLarge path="" isScrollable src="https://ai-toolkit-demos.vercel.app/comments-workflow" />
+<CodeDemo
+  isLarge
+  path=""
+  isScrollable
+  src="https://ai-toolkit-demos.vercel.app/comments-workflow"
+/>
 
 See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
 
@@ -206,21 +211,26 @@ export default function Page() {
 
 The Comments workflow supports the following operations:
 
-| Operation | Format | Description |
-|-----------|--------|-------------|
-| Create thread | `['createThread', nodeHash, htmlContent]` | Creates a new thread at a specific location |
-| Create comment | `['createComment', threadId, content]` | Adds a comment to an existing thread |
-| Update comment | `['updateComment', threadId, commentId, content]` | Updates an existing comment |
-| Remove comment | `['removeComment', threadId, commentId]` | Removes a comment from a thread |
-| Remove thread | `['removeThread', threadId]` | Removes an entire thread |
-| Resolve thread | `['resolveThread', threadId]` | Marks a thread as resolved |
-| Unresolve thread | `['unresolveThread', threadId]` | Marks a thread as unresolved |
+| Operation        | Format                                            | Description                                 |
+| ---------------- | ------------------------------------------------- | ------------------------------------------- |
+| Create thread    | `['createThread', nodeHash, htmlContent]`         | Creates a new thread at a specific location |
+| Create comment   | `['createComment', threadId, content]`            | Adds a comment to an existing thread        |
+| Update comment   | `['updateComment', threadId, commentId, content]` | Updates an existing comment                 |
+| Remove comment   | `['removeComment', threadId, commentId]`          | Removes a comment from a thread             |
+| Remove thread    | `['removeThread', threadId]`                      | Removes an entire thread                    |
+| Resolve thread   | `['resolveThread', threadId]`                     | Marks a thread as resolved                  |
+| Unresolve thread | `['unresolveThread', threadId]`                   | Marks a thread as unresolved                |
 
 ## End result
 
 With additional CSS styles, the result is a polished comments management application:
 
-<CodeDemo isLarge path="" isScrollable src="https://ai-toolkit-demos.vercel.app/comments-workflow" />
+<CodeDemo
+  isLarge
+  path=""
+  isScrollable
+- [Comments extension](/comments/getting-started/overview): Learn more about the Comments extension.
+/>
 
 See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
 
@@ -229,5 +239,4 @@ See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
 - [API reference](/content-ai/capabilities/ai-toolkit/primitives/read-the-document#tiptapread) of the `tiptapRead` method
 - [API reference](/content-ai/capabilities/ai-toolkit/primitives/workflows#getthreads) of the `getThreads` method
 - [API reference](/content-ai/capabilities/ai-toolkit/primitives/workflows#editthreadsworkflow) of the `editThreadsWorkflow` method
-- [Comments extension](/collaboration/comments/overview): Learn more about the Comments extension.
-
+- [Comments extension](/comments/getting-started/overview): Learn more about the Comments extension.

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/index.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/index.mdx
@@ -8,8 +8,8 @@ meta:
 
 Workflows are scenarios where the AI model has a single, well-defined task. The AI Toolkit includes these built-in workflows:
 
-- [Proofreader](/content-ai/capabilities/ai-toolkit/workflows/proofreader).
 - [Insert content](/content-ai/capabilities/ai-toolkit/workflows/insert-content).
+- [Proofreader](/content-ai/capabilities/ai-toolkit/workflows/proofreader).
 - [Tiptap Edit](/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit).
 - [Comments](/content-ai/capabilities/ai-toolkit/workflows/comments).
 

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/index.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/index.mdx
@@ -10,8 +10,8 @@ Workflows are scenarios where the AI model has a single, well-defined task. The 
 
 - [Proofreader](/content-ai/capabilities/ai-toolkit/workflows/proofreader).
 - [Insert content](/content-ai/capabilities/ai-toolkit/workflows/insert-content).
-- Replace editor content (coming soon).
-- Add comments (coming soon).
+- [Tiptap Edit](/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit).
+- [Comments](/content-ai/capabilities/ai-toolkit/workflows/comments).
 
 Each built-in workflow includes
 

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit.mdx
@@ -11,7 +11,12 @@ import { Callout } from '@/components/ui/Callout'
 
 Build a workflow that allows the AI to edit your Tiptap documents with precise, efficient operations.
 
-<CodeDemo isLarge path="" isScrollable src="https://ai-toolkit-demos.vercel.app/tiptap-edit-workflow" />
+<CodeDemo
+  isLarge
+  path=""
+  isScrollable
+  src="https://ai-toolkit-demos.vercel.app/tiptap-edit-workflow"
+/>
 
 See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
 
@@ -145,7 +150,7 @@ export default function Page() {
 
   // Stream partial results as they arrive
   useEffect(() => {
-    if (!editor || !operations) return
+    if (!editor || operations.length === 0) return
 
     const toolkit = getAiToolkit(editor)
     toolkit.tiptapEditWorkflow({
@@ -221,7 +226,12 @@ export default function Page() {
 
 With additional CSS styles, the result is a polished document editing application with real-time AI editing:
 
-<CodeDemo isLarge path="" isScrollable src="https://ai-toolkit-demos.vercel.app/tiptap-edit-workflow" />
+<CodeDemo
+  isLarge
+  path=""
+  isScrollable
+  src="https://ai-toolkit-demos.vercel.app/tiptap-edit-workflow"
+/>
 
 See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
 
@@ -230,4 +240,3 @@ See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
 - [API reference](/content-ai/capabilities/ai-toolkit/primitives/read-the-document#tiptapread) of the `tiptapRead` method
 - [API reference](/content-ai/capabilities/ai-toolkit/primitives/workflows#tiptapeditworkflow) of the `tiptapEditWorkflow` method
 - [Display suggestions](/content-ai/capabilities/ai-toolkit/primitives/display-suggestions): Learn about reviewing the document and displaying suggestions in the editor.
-

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit.mdx
@@ -112,9 +112,7 @@ First, when the editing process starts, call the `tiptapRead` method of the AI T
 
 Then, call the API endpoint to start the workflow. The component uses Vercel AI SDK's `useObject` hook to handle streaming, so that the response is received bit by bit and the edits are applied in real-time.
 
-Every time the response changes, call the `tiptapEditWorkflow` method of the AI Toolkit to apply the edits to the document in real-time.
-
-The option `mode: 'preview'` allows you to preview the edits before they are applied to the document. Otherwise, all the edits are applied immediately, without showing a preview.
+Every time the response changes, call the `tiptapEditWorkflow` method of the AI Toolkit to apply the edits to the document in real-time. The edits are applied immediately as they are received.
 
 ```tsx
 // app/tiptap-edit-workflow/page.tsx
@@ -134,16 +132,12 @@ export default function Page() {
     content: `<h1>Document Editor</h1><p>This is a sample document that can be edited by AI.</p>`,
   })
 
-  const [isReviewing, setIsReviewing] = useState(false)
   const [workflowId, setWorkflowId] = useState('')
   const [task, setTask] = useState('Make the text more formal and professional')
 
   const { submit, isLoading, object } = useObject({
     api: '/api/tiptap-edit-workflow',
     schema: tiptapEditWorkflowOutputSchema,
-    onFinish: () => {
-      setIsReviewing(true)
-    },
   })
 
   const operations = object?.operations ?? []
@@ -156,9 +150,6 @@ export default function Page() {
     toolkit.tiptapEditWorkflow({
       operations,
       workflowId,
-      reviewOptions: {
-        mode: 'preview',
-      },
     })
   }, [operations, workflowId, editor])
 
@@ -188,35 +179,9 @@ export default function Page() {
         placeholder="Enter editing task..."
       />
 
-      {!isReviewing && (
-        <button onClick={editDocument} disabled={isLoading}>
-          {isLoading ? 'Editing...' : 'Edit Document'}
-        </button>
-      )}
-
-      {isReviewing && (
-        <div>
-          <p>Changes are highlighted in the document above.</p>
-          <button
-            onClick={() => {
-              const toolkit = getAiToolkit(editor)
-              toolkit.acceptAllSuggestions()
-              setIsReviewing(false)
-            }}
-          >
-            Accept all
-          </button>
-          <button
-            onClick={() => {
-              const toolkit = getAiToolkit(editor)
-              toolkit.rejectAllSuggestions()
-              setIsReviewing(false)
-            }}
-          >
-            Reject all
-          </button>
-        </div>
-      )}
+      <button onClick={editDocument} disabled={isLoading}>
+        {isLoading ? 'Editing...' : 'Edit Document'}
+      </button>
     </div>
   )
 }
@@ -239,4 +204,3 @@ See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
 
 - [API reference](/content-ai/capabilities/ai-toolkit/primitives/read-the-document#tiptapread) of the `tiptapRead` method
 - [API reference](/content-ai/capabilities/ai-toolkit/primitives/workflows#tiptapeditworkflow) of the `tiptapEditWorkflow` method
-- [Display suggestions](/content-ai/capabilities/ai-toolkit/primitives/display-suggestions): Learn about reviewing the document and displaying suggestions in the editor.

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit.mdx
@@ -1,0 +1,233 @@
+---
+title: Tiptap Edit workflow
+meta:
+  title: Tiptap Edit workflow | Tiptap Content AI
+  description: Use the Tiptap AI Toolkit to build a workflow that edits documents with AI-generated content.
+  category: Content AI
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+import { Callout } from '@/components/ui/Callout'
+
+Build a workflow that allows the AI to edit your Tiptap documents with precise, efficient operations.
+
+<CodeDemo isLarge path="" isScrollable src="https://ai-toolkit-demos.vercel.app/tiptap-edit-workflow" />
+
+See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
+
+## Tech stack
+
+- [React](https://react.dev/) + [Next.js](https://nextjs.org/)
+- [AI SDK by Vercel](https://ai-sdk.dev/) + [OpenAI](https://openai.com/) models
+- Tiptap AI Toolkit
+
+## Project overview
+
+This demo uses the AI Toolkit's Tiptap Edit workflow to apply edit operations to the document in real-time. The workflow supports replacing, inserting before, and inserting after nodes.
+
+## Installation
+
+Create a [Next.js](https://nextjs.org/) project:
+
+```bash
+npx create-next-app@latest tiptap-edit-workflow
+```
+
+Install the core Tiptap packages and the [Vercel AI SDK](https://ai-sdk.dev/) for OpenAI:
+
+```bash
+npm install @tiptap/react @tiptap/starter-kit ai @ai-sdk/react @ai-sdk/openai zod uuid
+```
+
+Install the Tiptap AI Toolkit:
+
+<Callout title="Pro package" variant="hint">
+  The AI Toolkit is a pro package. Before installation, set up access to the private NPM registry by
+  following the [private registry guide](/guides/pro-extensions).
+</Callout>
+
+```bash
+npm install @tiptap-pro/ai-toolkit @tiptap-pro/ai-toolkit-tool-definitions
+```
+
+## Server setup
+
+Create an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to call the OpenAI model.
+
+Inside the API endpoint, create and configure the Tiptap Edit workflow using the `createTiptapEditWorkflow` function. The workflow includes a ready-to-use system prompt that instructs the AI model on how to generate edit operations.
+
+Additionally, you need to include these two properties in the user message:
+
+- `nodes`: The nodes of the document to be edited (obtained from `tiptapRead`)
+- `task`: The task to be performed by the AI. For example, `Make the text more formal`.
+
+As the AI model generates its response, the API endpoint streams the operations to the client.
+
+```ts
+// app/api/tiptap-edit-workflow/route.ts
+import { openai } from '@ai-sdk/openai'
+import { createTiptapEditWorkflow } from '@tiptap-pro/ai-toolkit-tool-definitions'
+import { Output, streamText } from 'ai'
+
+export async function POST(req: Request) {
+  const { nodes, task } = await req.json()
+
+  // Create and configure the Tiptap Edit workflow (with the default settings).
+  // It includes the ready-to-use system prompt and the output schema.
+  const workflow = createTiptapEditWorkflow()
+
+  const result = streamText({
+    model: openai('gpt-5-mini'),
+    // System prompt
+    system: workflow.systemPrompt,
+    // User message
+    prompt: JSON.stringify({
+      nodes,
+      task,
+    }),
+    output: Output.object({ schema: workflow.zodOutputSchema }),
+    // If you use gpt-5-mini, set the reasoning effort to minimal to improve the
+    // response time.
+    providerOptions: {
+      openai: {
+        reasoningEffort: 'minimal',
+      },
+    },
+  })
+
+  return result.toTextStreamResponse()
+}
+```
+
+## Client setup
+
+Create a React component that renders the editor and applies the edits in real-time.
+
+First, when the editing process starts, call the `tiptapRead` method of the AI Toolkit to read the document. The method returns the content in a format that is optimized for fast, precise edits.
+
+Then, call the API endpoint to start the workflow. The component uses Vercel AI SDK's `useObject` hook to handle streaming, so that the response is received bit by bit and the edits are applied in real-time.
+
+Every time the response changes, call the `tiptapEditWorkflow` method of the AI Toolkit to apply the edits to the document in real-time.
+
+The option `mode: 'preview'` allows you to preview the edits before they are applied to the document. Otherwise, all the edits are applied immediately, without showing a preview.
+
+```tsx
+// app/tiptap-edit-workflow/page.tsx
+'use client'
+
+import { experimental_useObject as useObject } from '@ai-sdk/react'
+import { EditorContent, useEditor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import { AiToolkit, getAiToolkit, tiptapEditWorkflowOutputSchema } from '@tiptap-pro/ai-toolkit'
+import { useEffect, useState } from 'react'
+import { v4 as uuid } from 'uuid'
+
+export default function Page() {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [StarterKit, AiToolkit],
+    content: `<h1>Document Editor</h1><p>This is a sample document that can be edited by AI.</p>`,
+  })
+
+  const [isReviewing, setIsReviewing] = useState(false)
+  const [workflowId, setWorkflowId] = useState('')
+  const [task, setTask] = useState('Make the text more formal and professional')
+
+  const { submit, isLoading, object } = useObject({
+    api: '/api/tiptap-edit-workflow',
+    schema: tiptapEditWorkflowOutputSchema,
+    onFinish: () => {
+      setIsReviewing(true)
+    },
+  })
+
+  const operations = object?.operations ?? []
+
+  // Stream partial results as they arrive
+  useEffect(() => {
+    if (!editor || !operations) return
+
+    const toolkit = getAiToolkit(editor)
+    toolkit.tiptapEditWorkflow({
+      operations,
+      workflowId,
+      reviewOptions: {
+        mode: 'preview',
+      },
+    })
+  }, [operations, workflowId, editor])
+
+  if (!editor) return null
+
+  const editDocument = () => {
+    const toolkit = getAiToolkit(editor)
+
+    // Obtain the nodes of the document to be edited
+    const { nodes } = toolkit.tiptapRead()
+
+    // Each workflow must have a unique ID
+    setWorkflowId(uuid())
+
+    // Call the API endpoint to start the workflow
+    submit({ nodes, task })
+  }
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+
+      <input
+        type="text"
+        value={task}
+        onChange={(e) => setTask(e.target.value)}
+        placeholder="Enter editing task..."
+      />
+
+      {!isReviewing && (
+        <button onClick={editDocument} disabled={isLoading}>
+          {isLoading ? 'Editing...' : 'Edit Document'}
+        </button>
+      )}
+
+      {isReviewing && (
+        <div>
+          <p>Changes are highlighted in the document above.</p>
+          <button
+            onClick={() => {
+              const toolkit = getAiToolkit(editor)
+              toolkit.acceptAllSuggestions()
+              setIsReviewing(false)
+            }}
+          >
+            Accept all
+          </button>
+          <button
+            onClick={() => {
+              const toolkit = getAiToolkit(editor)
+              toolkit.rejectAllSuggestions()
+              setIsReviewing(false)
+            }}
+          >
+            Reject all
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+## End result
+
+With additional CSS styles, the result is a polished document editing application with real-time AI editing:
+
+<CodeDemo isLarge path="" isScrollable src="https://ai-toolkit-demos.vercel.app/tiptap-edit-workflow" />
+
+See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
+
+## Related guides
+
+- [API reference](/content-ai/capabilities/ai-toolkit/primitives/read-the-document#tiptapread) of the `tiptapRead` method
+- [API reference](/content-ai/capabilities/ai-toolkit/primitives/workflows#tiptapeditworkflow) of the `tiptapEditWorkflow` method
+- [Display suggestions](/content-ai/capabilities/ai-toolkit/primitives/display-suggestions): Learn about reviewing the document and displaying suggestions in the editor.
+

--- a/src/content/content-ai/capabilities/generation/overview.mdx
+++ b/src/content/content-ai/capabilities/generation/overview.mdx
@@ -13,9 +13,10 @@ import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 
 <Requirements>
-    <RequirementItem label="1. Activate trial or subscribe">
-        Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start plan](https://cloud.tiptap.dev/v2/billing) in your account.
-    </RequirementItem>
+  <RequirementItem label="1. Activate trial or subscribe">
+    Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start
+    plan](https://cloud.tiptap.dev/v2/billing) in your account.
+  </RequirementItem>
   <RequirementItem label="2. Integrate an AI provider">
     Configure OpenAI in your [AI settings](https://cloud.tiptap.dev/v2/cloud/ai) or review the
     [Custom LLM guide](/content-ai/capabilities/generation/custom-llms).

--- a/src/content/content-ai/sidebar.ts
+++ b/src/content/content-ai/sidebar.ts
@@ -145,6 +145,14 @@ export const sidebarConfig: SidebarConfig = {
                   title: 'Proofreader',
                   href: '/content-ai/capabilities/ai-toolkit/workflows/proofreader',
                 },
+                {
+                  title: 'Tiptap Edit',
+                  href: '/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit',
+                },
+                {
+                  title: 'Comments',
+                  href: '/content-ai/capabilities/ai-toolkit/workflows/comments',
+                },
               ],
             },
             {


### PR DESCRIPTION
## Description

This PR adds documentation for the new AI Toolkit workflows introduced in ai-toolkit@3.0.0-alpha.52.

## Changes

### Workflow Guides
- Add `workflows/tiptap-edit.mdx` - Guide for using the Tiptap Edit workflow
- Add `workflows/comments.mdx` - Guide for using the Comments workflow

### API Reference Updates
- Add documentation for `createTiptapEditWorkflow` server-side utility
- Add documentation for `tiptapEditWorkflow` method
- Add documentation for `createCommentsWorkflow` server-side utility
- Add documentation for `editThreadsWorkflow` method
- Add documentation for `getThreads` method
- Update workflows list to remove "coming soon" labels

### Navigation Updates
- Update `sidebar.ts` with new workflow pages
- Update `workflows/index.mdx` with new workflow links

### Changelog Updates
- Update `changelog/ai-toolkit.mdx` with 3.0.0-alpha.52 changes
- Update `changelog/ai-toolkit-tool-definitions.mdx` with 3.0.0-alpha.23 changes

## Related PRs
- tiptap-pro: https://github.com/ueberdosis/tiptap-pro/pull/504
- ai-toolkit-demos: (pending)