### PR TITLE
fix(ai-toolkit): remove useRef workaround for useChat stale callbacks

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/comments.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/comments.mdx
@@ -73,22 +73,17 @@ Here's an example of how to implement this:
 import { useChat } from '@ai-sdk/react'
 import { getAiToolkit } from '@tiptap-pro/ai-toolkit'
 import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from 'ai'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 
 export function CommentsAiChatbot({ editor }) {
   const [input, setInput] = useState(
     "Add a comment to the first sentence of the last paragraph, that says 'well done'",
   )
 
-  // Fixes issue: https://github.com/vercel/ai/issues/8148
-  const editorRef = useRef(editor)
-  editorRef.current = editor
-
   const { messages, sendMessage, addtoolOutput } = useChat({
     transport: new DefaultChatTransport({ api: '/api/comments' }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     async onToolCall({ toolCall }) {
-      const editor = editorRef.current
       if (!editor) return
 
       const { toolName, input, toolCallId } = toolCall

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/multi-document.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/multi-document.mdx
@@ -323,18 +323,11 @@ export default function Page() {
     return result.output
   }
 
-  /**
-   * Reference to the handleToolCall function to avoid stale closure issues
-   * Fixes issue: https://github.com/vercel/ai/issues/8148
-   */
-  const handleToolCallRef = useRef(handleToolCall)
-  handleToolCallRef.current = handleToolCall
-
   const { messages, sendMessage, addtoolOutput } = useChat({
     transport: new DefaultChatTransport({ api: '/api/multi-document' }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     async onToolCall({ toolCall }) {
-      const output = handleToolCallRef.current(toolCall)
+      const output = handleToolCall(toolCall)
       if (output) {
         addtoolOutput({
           tool: toolCall.toolName,

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot.mdx
@@ -136,7 +136,7 @@ import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } fro
 import { useChat } from '@ai-sdk/react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import { AiToolkit, getAiToolkit } from '@tiptap-pro/ai-toolkit'
 
 export default function Page() {
@@ -146,15 +146,10 @@ export default function Page() {
     content: `<h1>AI agent demo</h1><p>Ask the AI to improve this.</p>`,
   })
 
-  // Fixes issue: https://github.com/vercel/ai/issues/8148
-  const editorRef = useRef(editor)
-  editorRef.current = editor
-
   const { messages, sendMessage, addtoolOutput } = useChat({
     transport: new DefaultChatTransport({ api: '/api/chat' }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     async onToolCall({ toolCall }) {
-      const editor = editorRef.current
       if (!editor) return
 
       const { toolName, input, toolCallId } = toolCall

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/review-changes-as-summary.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/review-changes-as-summary.mdx
@@ -155,7 +155,7 @@ import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import { AiToolkit, getAiToolkit, type SuggestionFeedbackEvent } from '@tiptap-pro/ai-toolkit'
 import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from 'ai'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import './suggestions.css'
 
 export default function Page() {
@@ -165,15 +165,10 @@ export default function Page() {
     content: `<h1>AI agent demo</h1><p>Ask the AI to improve this.</p>`,
   })
 
-  // Fixes issue: https://github.com/vercel/ai/issues/8148
-  const editorRef = useRef(editor)
-  editorRef.current = editor
-
   const { messages, sendMessage, addToolOutput, status } = useChat({
     transport: new DefaultChatTransport({ api: '/api/chat' }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     async onToolCall({ toolCall }) {
-      const editor = editorRef.current
       if (!editor) return
 
       const { toolName, input, toolCallId } = toolCall

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/review-changes.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/review-changes.mdx
@@ -53,7 +53,6 @@ const { messages, sendMessage, addtoolOutput } = useChat({
   transport: new DefaultChatTransport({ api: '/api/chat' }),
   sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
   async onToolCall({ toolCall }) {
-    const editor = editorRef.current
     if (!editor) return
 
     const { toolName, input, toolCallId } = toolCall
@@ -271,10 +270,6 @@ export default function Page() {
     content: `<h1>AI agent demo</h1><p>Ask the AI to improve this.</p>`,
   })
 
-  // Fixes issue: https://github.com/vercel/ai/issues/8148
-  const editorRef = useRef(editor)
-  editorRef.current = editor
-
   const [reviewState, setReviewState] = useState({
     // Whether to display the review UI
     isReviewing: false,
@@ -293,7 +288,6 @@ export default function Page() {
     transport: new DefaultChatTransport({ api: '/api/chat' }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     async onToolCall({ toolCall }) {
-      const editor = editorRef.current
       if (!editor) return
 
       const { toolName, input, toolCallId } = toolCall

--- a/src/content/content-ai/capabilities/ai-toolkit/guides/tool-streaming.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/guides/tool-streaming.mdx
@@ -107,7 +107,6 @@ const { messages, sendMessage, addtoolOutput } = useChat({
   transport: new DefaultChatTransport({ api: '/api/chat' }),
   sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
   async onToolCall({ toolCall }) {
-    const editor = editorRef.current
     if (!editor) return
 
     const { toolName, input, toolCallId } = toolCall
@@ -142,7 +141,7 @@ import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } fro
 import { useChat } from '@ai-sdk/react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { AiToolkit, getAiToolkit } from '@tiptap-pro/ai-toolkit'
 
 export default function Page() {
@@ -152,15 +151,10 @@ export default function Page() {
     content: `<h1>AI Agent Demo</h1><p>Ask the AI to improve this.</p>`,
   })
 
-  // Fixes issue: https://github.com/vercel/ai/issues/8148
-  const editorRef = useRef(editor)
-  editorRef.current = editor
-
   const { messages, sendMessage, addtoolOutput } = useChat({
     transport: new DefaultChatTransport({ api: '/api/chat' }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     async onToolCall({ toolCall }) {
-      const editor = editorRef.current
       if (!editor) return
 
       const { toolName, input, toolCallId } = toolCall


### PR DESCRIPTION
## Summary

- Remove the `editorRef` workaround pattern from AI Toolkit code examples
- The Vercel AI SDK issue [#8148](https://github.com/vercel/ai/issues/8148) has been fixed
- Code examples now use `editor` directly in `useChat` callbacks instead of `editorRef.current`

## Changes

Updated 6 documentation files:
- `guides/ai-agent-chatbot.mdx`
- `guides/tool-streaming.mdx`
- `guides/review-changes.mdx`
- `guides/review-changes-as-summary.mdx`
- `advanced-guides/multi-document.mdx`
- `advanced-guides/comments.mdx`

## Test plan

- [ ] Verify code examples render correctly in the docs
- [ ] Verify the simplified code pattern works with latest AI SDK version

🤖 Generated with [Claude Code](https://claude.com/claude-code)