### PR TITLE
docs(ui): update changelog for multi-block toggle fix

### DIFF
--- a/src/content/ui-components/getting-started/changelog.mdx
+++ b/src/content/ui-components/getting-started/changelog.mdx
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2026-01-15]
+
+### Fixed
+
+- Prevent block “turn into” actions from running when multiple blocks are selected, ensuring node toggles only apply to a single selected block.
+
 ## [2026-01-09]
 
 ### Added


### PR DESCRIPTION
This PR updates the changelog to document the recent fix that prevents block “turn into” actions from running when multiple blocks are selected.