### PR TITLE
Update AI Toolkit documentation: rename nodes to content in workflows

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/agents/comments.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/comments.mdx
@@ -30,7 +30,7 @@ Optionally, you can disable the `tiptapEdit` tool to prevent the AI from making 
 
 ```ts
 // app/api/chat/route.ts
-import { anthropic } from '@ai-sdk/anthropic'
+import { openai } from '@ai-sdk/openai'
 import { toolDefinitions } from '@tiptap-pro/ai-toolkit-ai-sdk'
 import { createAgentUIStreamResponse, ToolLoopAgent, UIMessage } from 'ai'
 
@@ -38,7 +38,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
   const agent = new ToolLoopAgent({
-    model: anthropic('claude-haiku-4-5-20251001'),
+    model: openai('gpt-5-mini'),
     instructions: 'You are an assistant that can add comments to a rich text document.',
     tools: toolDefinitions({
       tools: {
@@ -49,6 +49,13 @@ export async function POST(req: Request) {
         tiptapEdit: false,
       },
     }),
+    // If you use gpt-5-mini, set the reasoning effort
+    // to 'minimal' for faster response times
+    providerOptions: {
+      openai: {
+        reasoningEffort: 'minimal',
+      },
+    },
   })
 
   return createAgentUIStreamResponse({

--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/read-the-document.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/read-the-document.mdx
@@ -299,6 +299,6 @@ Used in the [Proofreader workflow](/content-ai/capabilities/ai-toolkit/workflows
   - `from` (`number`): Start position
   - `to` (`number`): End position
 
-### Returns
+### Returns (`TiptapReadResult`)
 
-`nodes`: The nodes of the document in a format that allows the AI to make fast, efficient edits.
+- `content` (`string`): The content of the document in a format that allows the AI to make fast, efficient edits.

--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/workflows.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/workflows.mdx
@@ -226,7 +226,7 @@ Applies a list of edit operations to the document.
 ### Returns (`TiptapEditWorkflowResult`)
 
 - `doc` (`Node`): The modified document after applying operations
-- `successful` (`string[]`): Array of successfully processed target hashes
+- `successful` (`string[]`): Array of successfully processed operations
 - `failed` (`{ target: string; error?: string }[]`): Array of failed operations with error messages
 
 ### Example
@@ -309,7 +309,7 @@ const result = toolkit.getThreads()
 
 console.log(`Found ${result.threadCount} threads`)
 
-result.threads.forEach(thread => {
+result.threads.forEach((thread) => {
   console.log(`Thread ${thread.id}: ${thread.comments.length} comments`)
 })
 ```
@@ -321,14 +321,7 @@ Applies comment and thread operations to the document.
 ### Parameters
 
 - `options` (`EditThreadsWorkflowOptions`): Configuration options
-  - `operations` (`string[][]`): Array of comment operations as tuples. Supported operations:
-    - `['createThread', nodeHash, htmlContent]`: Create a new thread
-    - `['createComment', threadId, content]`: Add a comment to a thread
-    - `['updateComment', threadId, commentId, content]`: Update a comment
-    - `['removeComment', threadId, commentId]`: Remove a comment
-    - `['removeThread', threadId]`: Remove a thread
-    - `['resolveThread', threadId]`: Resolve a thread
-    - `['unresolveThread', threadId]`: Unresolve a thread
+  - `operations` (`string[][]`): Array of comment operations as tuples.
   - `commentsOptions?` (`CommentsOptions`): Options for comment operations
     - `threadData?` (`Record<string, any>`): Extra metadata for created threads
     - `commentData?` (`Record<string, any>`): Extra metadata for created comments

--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/workflows.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/workflows.mdx
@@ -21,7 +21,7 @@ Creates a ready-made workflow configuration for proofreading. Returns a system p
 
 The workflow expects a user prompt as a JSON object with:
 
-- `nodes`: The nodes of the document to be proofread (see the client-side setup section on how to obtain them)
+- `content`: The content of the document to be proofread (see the client-side setup section on how to obtain it)
 - `task`: A string describing the task to complete
 
 ### Returns
@@ -39,8 +39,8 @@ import { createProofreaderWorkflow } from '@tiptap-pro/ai-toolkit-tool-definitio
 import { Output, streamText } from 'ai'
 import { openai } from '@ai-sdk/openai'
 
-// Get the nodes from the API endpoint request
-const { nodes } = apiEndpointRequest
+// Get the content from the API endpoint request
+const { content } = apiEndpointRequest
 
 // Create and configure the workflow
 const workflow = createProofreaderWorkflow()
@@ -49,9 +49,9 @@ const result = streamText({
   model: openai('gpt-5-mini'),
   // System prompt
   system: workflow.systemPrompt,
-  // User message with the nodes and the task
+  // User message with the content and the task
   prompt: JSON.stringify({
-    nodes,
+    content,
     task: 'Correct all grammar and spelling mistakes',
   }),
   output: Output.object({ schema: workflow.zodOutputSchema }),
@@ -159,9 +159,9 @@ Applies a list of proofreading operations to the document.
 const toolkit = getAiToolkit(editor)
 
 // Get the document in a format that allows the AI to make fast, efficient edits
-const { nodes } = toolkit.tiptapRead()
+const { content } = toolkit.tiptapRead()
 
-const operations = await callApiEndpoint({ nodes })
+const operations = await callApiEndpoint({ content })
 
 // Apply proofreading corrections
 const result = toolkit.proofreaderWorkflow({
@@ -179,7 +179,7 @@ Creates a ready-made workflow configuration for editing documents. Returns a sys
 
 The workflow expects a user prompt as a JSON object with:
 
-- `nodes`: The nodes of the document to be edited (obtained from `tiptapRead`)
+- `content`: The content of the document to be edited (obtained from `tiptapRead`)
 - `task`: A string describing the editing task to complete
 
 ### Returns
@@ -195,8 +195,8 @@ import { createTiptapEditWorkflow } from '@tiptap-pro/ai-toolkit-tool-definition
 import { Output, streamText } from 'ai'
 import { openai } from '@ai-sdk/openai'
 
-// Get the nodes and task from the API endpoint request
-const { nodes, task } = apiEndpointRequest
+// Get the content and task from the API endpoint request
+const { content, task } = apiEndpointRequest
 
 // Create and configure the workflow
 const workflow = createTiptapEditWorkflow()
@@ -204,7 +204,7 @@ const workflow = createTiptapEditWorkflow()
 const result = streamText({
   model: openai('gpt-5-mini'),
   system: workflow.systemPrompt,
-  prompt: JSON.stringify({ nodes, task }),
+  prompt: JSON.stringify({ content, task }),
   output: Output.object({ schema: workflow.zodOutputSchema }),
 })
 ```
@@ -234,10 +234,10 @@ Applies a list of edit operations to the document.
 ```ts
 const toolkit = getAiToolkit(editor)
 
-// Get the document with hashes
-const { nodes } = toolkit.tiptapRead()
+// Get the document content
+const { content } = toolkit.tiptapRead()
 
-const operations = await callApiEndpoint({ nodes, task: 'Make the text more formal' })
+const operations = await callApiEndpoint({ content, task: 'Make the text more formal' })
 
 // Apply edit operations
 const result = toolkit.tiptapEditWorkflow({
@@ -255,7 +255,7 @@ Creates a ready-made workflow configuration for managing comments and threads. R
 
 The workflow expects a user prompt as a JSON object with:
 
-- `nodes`: The nodes of the document (obtained from `tiptapRead`)
+- `content`: The content of the document (obtained from `tiptapRead`)
 - `threads`: The existing threads in the document (obtained from `getThreads`)
 - `task`: A string describing the comment management task to complete
 
@@ -272,8 +272,8 @@ import { createEditThreadsWorkflow } from '@tiptap-pro/ai-toolkit-tool-definitio
 import { Output, streamText } from 'ai'
 import { openai } from '@ai-sdk/openai'
 
-// Get the nodes, threads, and task from the API endpoint request
-const { nodes, threads, task } = apiEndpointRequest
+// Get the content, threads, and task from the API endpoint request
+const { content, threads, task } = apiEndpointRequest
 
 // Create and configure the workflow
 const workflow = createEditThreadsWorkflow()
@@ -281,7 +281,7 @@ const workflow = createEditThreadsWorkflow()
 const result = streamText({
   model: openai('gpt-5-mini'),
   system: workflow.systemPrompt,
-  prompt: JSON.stringify({ nodes, threads, task }),
+  prompt: JSON.stringify({ content, threads, task }),
   output: Output.object({ schema: workflow.zodOutputSchema }),
 })
 ```
@@ -345,10 +345,10 @@ Applies comment and thread operations to the document.
 const toolkit = getAiToolkit(editor)
 
 // Get document and threads
-const { nodes } = toolkit.tiptapRead()
+const { content } = toolkit.tiptapRead()
 const { threads } = toolkit.getThreads()
 
-const operations = await callApiEndpoint({ nodes, threads, task: 'Add review comments' })
+const operations = await callApiEndpoint({ content, threads, task: 'Add review comments' })
 
 // Apply comment operations
 const result = toolkit.editThreadsWorkflow({

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 3.0.0-alpha.28
+
+### Patch Changes
+
+- Bump version to align with refactored Tiptap edit implementation in the core AI Toolkit.
+
 ## 3.0.0-alpha.27
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 3.0.0-alpha.17
+
+### Patch Changes
+
+- Bump version to align with refactored Tiptap edit implementation in the core AI Toolkit.
+
 ## 3.0.0-alpha.16
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 3.0.0-alpha.22
+
+### Patch Changes
+
+- Bump version to align with refactored Tiptap edit implementation in the core AI Toolkit.
+
 ## 3.0.0-alpha.21
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 3.0.0-alpha.21
+
+### Patch Changes
+
+- Bump version to align with refactored Tiptap edit implementation in the core AI Toolkit.
+
 ## 3.0.0-alpha.20
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,17 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 3.0.0-alpha.27
+
+### Major Changes
+
+- **Breaking**: Rename `nodes` input property to `content` in workflow user prompts. This affects `createTiptapEditWorkflow` and `createEditThreadsWorkflow`. Update your workflow calls to use `content` instead of `nodes`.
+
+### Patch Changes
+
+- Update `editThreadsWorkflow` to clarify that `htmlContent` must include the entire node HTML, including the HTML tag of that node.
+- Update `editThreads` tool description to clarify HTML content requirements.
+
 ## 3.0.0-alpha.26
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,25 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.57
+
+### Major Changes
+
+- **Breaking**: Refactor Tiptap edit implementation for improved efficiency and accuracy. The new implementation removes the `HashAttributeExtension` and enhances schema handling with better hash generation.
+- **Breaking**: Rename `nodeRange` to `contentRange` in `tiptapRead` method return type for better clarity and consistency.
+- **Breaking**: Rename `nodes` input property to `content` in workflow user prompts. This affects `tiptapEditWorkflow` and `editThreadsWorkflow`. Update your workflow calls to use `content` instead of `nodes`.
+
+### Minor Changes
+
+- Unify `selectableNodeTypes` handling across all Tiptap methods for consistency.
+- Relocate `addHashesToDocument` utility to `tiptap-read` directory for improved organization.
+
+### Patch Changes
+
+- Fix bug in comments tools where comments would be inserted in the wrong places.
+- Simplify hash generation in `addHashesToDocument` and `shortHash` utilities.
+- Streamline selectable node handling in Tiptap edit functions.
+
 ## 3.0.0-alpha.56
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/comments.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/comments.mdx
@@ -64,7 +64,7 @@ Inside the API endpoint, create and configure the Comments workflow using the `c
 
 The user message should include:
 
-- `nodes`: The nodes of the document (obtained from `tiptapRead`)
+- `content`: The content of the document (obtained from `tiptapRead`)
 - `threads`: The existing threads in the document (obtained from `getThreads`)
 - `task`: The task to be performed by the AI. For example, `Add a comment suggesting improvements to the introduction`.
 
@@ -75,7 +75,7 @@ import { createEditThreadsWorkflow } from '@tiptap-pro/ai-toolkit-tool-definitio
 import { Output, streamText } from 'ai'
 
 export async function POST(req: Request) {
-  const { nodes, threads, task } = await req.json()
+  const { content, threads, task } = await req.json()
 
   // Create and configure the Comments workflow (with the default settings).
   // It includes the ready-to-use system prompt and the output schema.
@@ -87,7 +87,7 @@ export async function POST(req: Request) {
     system: workflow.systemPrompt,
     // User message
     prompt: JSON.stringify({
-      nodes,
+      content,
       threads,
       task,
     }),
@@ -181,11 +181,11 @@ export default function Page() {
     const toolkit = getAiToolkit(editor)
 
     // Get the document content and existing threads
-    const { nodes } = toolkit.tiptapRead()
+    const { content } = toolkit.tiptapRead()
     const { threads } = toolkit.getThreads()
 
     // Call the API endpoint to start the workflow
-    submit({ nodes, threads, task })
+    submit({ content, threads, task })
   }
 
   return (

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/proofreader.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/proofreader.mdx
@@ -58,7 +58,7 @@ Inside the API endpoint, create and configure the proofreader workflow, using th
 
 Additionally, you need include these two properties in the user message:
 
-- `nodes`: The nodes of the document to be proofread (see the client-side setup section on how to obtain them)
+- `content`: The content of the document to be proofread (see the client-side setup section on how to obtain it)
 - `task`: The task to be performed by the AI. For example, `Correct all grammar and spelling mistakes`.
 
 As the AI model generates its response, the API endpoint streams the suggestions to the client.
@@ -70,7 +70,7 @@ import { createProofreaderWorkflow } from '@tiptap-pro/ai-toolkit-tool-definitio
 import { Output, streamText } from 'ai'
 
 export async function POST(req: Request) {
-  const { nodes } = await req.json()
+  const { content } = await req.json()
 
   // Create and configure the proofreader workflow (with the default settings).
   // It includes the ready-to-use system prompt and the output schema.
@@ -82,7 +82,7 @@ export async function POST(req: Request) {
     system: workflow.systemPrompt,
     // User message
     prompt: JSON.stringify({
-      nodes,
+      content,
       task: 'Correct all grammar and spelling mistakes',
     }),
     output: Output.object({ schema: workflow.zodOutputSchema }),
@@ -161,14 +161,14 @@ export default function Page() {
   const checkGrammar = () => {
     const toolkit = getAiToolkit(editor)
 
-    // Obtain the nodes of the document to be proofread
-    const { nodes } = toolkit.tiptapRead()
+    // Obtain the content of the document to be proofread
+    const { content } = toolkit.tiptapRead()
 
     // Each workflow must have a unique ID
     setWorkflowId(uuid())
 
     // Call the API endpoint to start the workflow
-    submit({ nodes })
+    submit({ content })
   }
 
   return (

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit.mdx
@@ -63,7 +63,7 @@ Inside the API endpoint, create and configure the Tiptap Edit workflow using the
 
 Additionally, you need to include these two properties in the user message:
 
-- `nodes`: The nodes of the document to be edited (obtained from `tiptapRead`)
+- `content`: The content of the document to be edited (obtained from `tiptapRead`)
 - `task`: The task to be performed by the AI. For example, `Make the text more formal`.
 
 As the AI model generates its response, the API endpoint streams the operations to the client.
@@ -87,7 +87,7 @@ export async function POST(req: Request) {
     system: workflow.systemPrompt,
     // User message
     prompt: JSON.stringify({
-      nodes,
+      content,
       task,
     }),
     output: Output.object({ schema: workflow.zodOutputSchema }),
@@ -158,14 +158,14 @@ export default function Page() {
   const editDocument = () => {
     const toolkit = getAiToolkit(editor)
 
-    // Obtain the nodes of the document to be edited
-    const { nodes } = toolkit.tiptapRead()
+    // Obtain the content of the document to be edited
+    const { content } = toolkit.tiptapRead()
 
     // Each workflow must have a unique ID
     setWorkflowId(uuid())
 
     // Call the API endpoint to start the workflow
-    submit({ nodes, task })
+    submit({ content, task })
   }
 
   return (


### PR DESCRIPTION
## Summary

This PR updates the AI Toolkit documentation to reflect the breaking change where the `nodes` input property has been renamed to `content` in workflow user prompts.

## Changes

### API Reference
- Updated `tiptapRead` method return type documentation
- Updated workflow API reference (`createProofreaderWorkflow`, `createTiptapEditWorkflow`, `createEditThreadsWorkflow`) to use `content` instead of `nodes`
- Updated all code examples in workflow documentation

### Workflow Guides
- Updated Tiptap Edit workflow guide to use `content` instead of `nodes`
- Updated Comments workflow guide to use `content` instead of `nodes`

### Changelogs
- Updated all AI Toolkit package changelogs with the breaking change
- Added changelog entries for version bumps

## Breaking Change

The `nodes` input property in workflow user prompts has been renamed to `content`. This affects:
- `createTiptapEditWorkflow`
- `createEditThreadsWorkflow`
- `createProofreaderWorkflow`

Users need to update their workflow calls to use `content` instead of `nodes`:

```typescript
// Before
submit({ nodes, task })

// After
submit({ content, task })
```

## Related

Related to PR #513 in tiptap-pro repository.