### PR TITLE
Add smartInline diff mode documentation

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/diff-utility.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/diff-utility.mdx
@@ -29,7 +29,10 @@ To compare parts of the document, you can provide them as a Tiptap JSON fragment
 - `ignoreAttributes?` (`string[]`): The attributes to ignore. Default: `['id', 'data-thread-id']`
 - `ignoreMarks?` (`string[]`): The marks to ignore. Default: `['inlineThread']`
 - `changeMergeDistance?` (`number | null`): Maximum distance (in document positions) between changes to merge them. If two adjacent changes have a distance less than or equal to this value in either rangeA or rangeB, they will be merged into a single change. Set to `null` or `undefined` to disable merging. Only applies when mode is 'detailed'. Default: `null`
-- `mode?` (`'detailed' | 'block'`): The diff mode to use for comparison. `'detailed'` performs character-level diff that identifies precise changes within text (default). `'block'` performs block-level diff that treats each top-level node as a single unit. Block mode is useful when you only need to know which paragraphs, headings, or other block-level elements have changed, without character-level detail. In block mode, `simplifyChanges` and `changeMergeDistance` options are ignored. Default: `'detailed'`
+- `mode?` (`'detailed' | 'block' | 'smartInline'`): The diff mode to use for comparison.
+  - `'detailed'` performs character-level diff that identifies precise changes within text (default).
+  - `'block'` performs block-level diff that treats each top-level node as a single unit. Block mode is useful when you only need to know which paragraphs, headings, or other block-level elements have changed, without character-level detail. In block mode, `simplifyChanges` and `changeMergeDistance` options are ignored.
+  - `'smartInline'` combines both approaches: first identifies changed blocks, then performs inline diff within those blocks. This is more efficient for documents where only portions have changed, while still providing character-level precision. Default: `'detailed'`
 
 <Callout title="Schema issue" variant="warning">
   Both documents must have the same schema. If the documents come from different editors, convert
@@ -61,5 +64,13 @@ const blockChanges = diffUtility({
   docA,
   docB,
   mode: 'block',
+})
+
+// Use smart inline diffing for efficient character-level changes
+const smartChanges = diffUtility({
+  schema: editor.schema,
+  docA,
+  docB,
+  mode: 'smartInline',
 })
 ```

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.58
+
+### Minor Changes
+
+- Add `smartInline` diff mode that combines block-level and inline-level comparison for more efficient change detection. This mode first identifies changed blocks, then performs detailed inline diff within those blocks only.
+
 ## 3.0.0-alpha.57
 
 ### Major Changes


### PR DESCRIPTION
## Summary

- Add `smartInline` mode to the diff-utility API reference documentation
- Add changelog entry for version 3.0.0-alpha.58

## Details

This PR documents the new `smartInline` diff mode added to the AI Toolkit in PR https://github.com/ueberdosis/tiptap-pro/pull/515.

The `smartInline` mode combines block-level and inline-level comparison:
- First identifies changed blocks
- Then performs detailed inline diff within those blocks only
- More efficient for documents where only portions have changed
- Still provides character-level precision

## Test plan

- [x] Verify lint passes: `pnpm lint`
- [x] Verify build succeeds: `pnpm build`
- [x] Verify documentation follows existing format
- [x] Verify all three diff modes are documented