### PR TITLE
Docs/pages headers and footers new version

### DIFF
--- a/src/content/pages/core-concepts/page-header-footer.mdx
+++ b/src/content/pages/core-concepts/page-header-footer.mdx
@@ -564,13 +564,64 @@ Pages.configure({
 })
 ```
 
+## Accent colors
+
+Customize the visual appearance of the header and footer editor overlays using accent colors. The accent color affects three elements:
+
+- **Caret color** - The text cursor in the editor
+- **Toolbar border** - The top border (header) or bottom border (footer) of the editing toolbar
+- **Label background** - The "Header" or "Footer" label background
+
+### Configuration
+
+Set accent colors when configuring the extension:
+
+```js
+Pages.configure({
+  header: 'My Header',
+  footer: 'Page {page}',
+  // Set the same color for both header and footer overlays
+  accentColor: '#3b82f6',
+})
+```
+
+You can also set different colors for header and footer overlays:
+
+```js
+Pages.configure({
+  header: 'My Header',
+  footer: 'Page {page}',
+  headerAccentColor: '#3b82f6',  // Blue for headers
+  footerAccentColor: '#10b981',  // Green for footers
+})
+```
+
+### Runtime updates
+
+Change accent colors dynamically using commands:
+
+```js
+// Update both header and footer overlay colors
+editor.commands.setAccentColor('#8b5cf6')
+
+// Update header overlay color only
+editor.commands.setHeaderAccentColor('#3b82f6')
+
+// Update footer overlay color only
+editor.commands.setFooterAccentColor('#ef4444')
+```
+
+<Callout title="CSS color values" variant="info">
+  Accent color options accept any valid CSS color value including hex (`#3b82f6`), rgb (`rgb(59, 130, 246)`), hsl (`hsl(217, 91%, 60%)`), oklch, or CSS variables (`var(--primary-color)`).
+</Callout>
+
 ## Limitations
 
 ### Editing cannot be disabled
 The double-click editing behavior is built into the extension and cannot be disabled. All users with access to the editor can edit headers and footers.
 
 ### Header & Footer editor styling
-The header/footer editor uses built-in styles that cannot be customized.
+The header/footer editor uses built-in styles. However, you can customize the accent color using the `accentColor`, `headerAccentColor`, and `footerAccentColor` options.
 
 ### Collaboration
 Collaborative editing is not supported for headers and footers. The header and footer editors are separate Tiptap instances that are independent from the main document's collaboration session.
@@ -595,6 +646,9 @@ Collaborative editing is not supported for headers and footers. The header and f
 | `onDblClickHeaderFooterPreventClose` | `(event: MouseEvent) => boolean` | `undefined` | Callback to prevent closing header/footer editors on double-click outside |
 | `onDblClickHeaderPreventClose` | `(event: MouseEvent) => boolean` | `undefined` | Callback to prevent closing header editor on double-click outside |
 | `onDblClickFooterPreventClose` | `(event: MouseEvent) => boolean` | `undefined` | Callback to prevent closing footer editor on double-click outside |
+| `accentColor` | `string` | `'#6366f1'` | Accent color for header/footer editor overlays |
+| `headerAccentColor` | `string` | `accentColor` value | Accent color for header editor overlay |
+| `footerAccentColor` | `string` | `accentColor` value | Accent color for footer editor overlay |
 
 ## Commands reference
 
@@ -617,3 +671,6 @@ Collaborative editing is not supported for headers and footers. The header and f
 | `closeHeaderFooterEditors` | none | Close whichever header/footer editor is open |
 | `closeHeaderEditor` | none | Close the header editor if open |
 | `closeFooterEditor` | none | Close the footer editor if open |
+| `setAccentColor` | `color: string` | Set accent color for both editor overlays |
+| `setHeaderAccentColor` | `color: string` | Set accent color for header editor overlay |
+| `setFooterAccentColor` | `color: string` | Set accent color for footer editor overlay |

--- a/src/content/pages/core-concepts/page-header-footer.mdx
+++ b/src/content/pages/core-concepts/page-header-footer.mdx
@@ -458,6 +458,19 @@ const headerFooterData = getHeaderFooterContent(editor)
 await saveDocument({ content: editor.getJSON(), headerFooter: headerFooterData })
 ```
 
+## Programmatically closing editors
+
+You can close header and footer editor overlays programmatically. This is useful when integrating with custom UI elements or when you need to dismiss the overlay in response to user actions outside the editor.
+
+```js
+// Close whichever overlay is currently open
+editor.commands.closeHeaderFooterEditors()
+
+// Close specific overlays
+editor.commands.closeHeaderEditor()
+editor.commands.closeFooterEditor()
+```
+
 ## Limitations
 
 ### Editing cannot be disabled
@@ -503,3 +516,6 @@ Collaborative editing is not supported for headers and footers. The header and f
 | `setHeaderEven` | `header: PagesHeaderFooter` | Set even pages header content |
 | `setFooterOdd` | `footer: PagesHeaderFooter` | Set odd pages footer content |
 | `setFooterEven` | `footer: PagesHeaderFooter` | Set even pages footer content |
+| `closeHeaderFooterEditors` | none | Close whichever header/footer editor is open |
+| `closeHeaderEditor` | none | Close the header editor if open |
+| `closeFooterEditor` | none | Close the footer editor if open |

--- a/src/content/pages/core-concepts/page-header-footer.mdx
+++ b/src/content/pages/core-concepts/page-header-footer.mdx
@@ -2,7 +2,7 @@
 title: Page header and footer
 meta:
   title: Page header and footer | Tiptap Pages Docs
-  description: Learn how to adjust page header height and footer height in Tiptap Pages extension.
+  description: Learn how to configure headers and footers in Tiptap Pages, including different first page, odd/even pages, and editable overlays.
   category: Pages
 sidebars:
   hideSecondary: true
@@ -11,157 +11,382 @@ sidebars:
 import { Callout } from '@/components/ui/Callout'
 import { CodeDemo } from '@/components/CodeDemo'
 
-You can adjust some aspects of the page layout to better fit your needs. The main options are `header`, `footer`, `headerHeight` and `footerHeight`.
+Headers and footers allow you to display consistent content at the top and bottom of each page. The Pages extension supports static text, HTML markup, dynamic page numbering with placeholders, rich formatting via JSONContent, different headers/footers for first page or odd/even pages, and interactive editing through double-click overlays.
 
 <CodeDemo isPro src="https://feature-pages-extension--tiptap-pro.netlify.app/preview/extensions/pagesheaderfooter" />
 
-## Header content
+## Content types
 
-- What is going to be rendered within the page header
-- Default: `''` –empty `string`
+The `PagesHeaderFooter` type accepts either an HTML string or Tiptap `JSONContent` for rich formatting:
 
-### Initial configuration (string)
+```typescript
+type PagesHeaderFooter = string | JSONContent
+```
+
+### HTML strings
+
+You can use plain text or HTML markup for headers and footers:
 
 ```js
 Pages.configure({
-  header: 'Awesome Tiptap header', // String!
+  header: 'My Document Title',
+  footer: '<strong>Confidential</strong> - Internal Use Only',
 })
 ```
 
-### Initial configuration (HTML)
+### Template placeholders
+
+Use `{page}` and `{total}` placeholders for dynamic page numbering. These work in both HTML strings and JSONContent, and are substituted at render time:
 
 ```js
 Pages.configure({
-  header: () => '<bold>Awesome Tiptap header</bold>', // A function that returns HTML or a string!
+  header: 'Company Report',
+  footer: 'Page {page} of {total}',
 })
 ```
 
-### Header content editor command
+### JSONContent
 
-```js
-editor.commands.setHeader('My awesome header') // String!
-// or
-editor.commands.Header((page, total) => `${page} of ${total}`) // A function that returns HTML or a string!
-```
-
-### Header replacement templates
-
-The `header` property, when usign a string comes with two handy template replacements:
-
-- `{page}`: gets replaced with the current page.
-- `{total}`: gets replaced with the total amout of pages of the document.
-
-The `header` property, also accepts a function that gives you them same information, but this time it's passed on to you via function arguments:
+For rich formatting, use Tiptap's JSONContent structure:
 
 ```js
 Pages.configure({
-  header: (page, total) => `${page} of ${total}` // Eg, shows: "1 of 10"
+  header: {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [
+          { type: 'text', text: 'Document Title', marks: [{ type: 'bold' }] }
+        ]
+      }
+    ]
+  }
 })
 ```
 
-## Header height
+## Header configuration
 
-- Controls how tall the header area is at the top of each page.
-- Default: `50` (pixels)
+### Default header
 
-### Initial configuration
+The `header` option sets the content displayed in the header area of each page.
+
+**Initial configuration:**
 
 ```js
 Pages.configure({
-  headerHeight: 80, // Makes the header area taller
+  header: '<strong>Tiptap</strong> – Document Header',
 })
 ```
 
-### Header height editor command
+**Editor command:**
 
 ```js
-editor.commands.setHeaderHeight(30) // A smaller header!
+editor.commands.setHeader('My New Header')
+// or with HTML
+editor.commands.setHeader('<em>Updated</em> Header')
 ```
 
-## Footer content
+### Header margin
 
-- What is going to be rendered within the page header
-- Default: `{page}` –`string` with template replacement for the page number
+The `headerTopMargin` option controls the distance from the page's top edge to where the header content starts (in pixels). If not specified, it defaults to 50% of the top margin.
 
-### Initial configuration (string)
+**Initial configuration:**
 
 ```js
 Pages.configure({
-  footer: 'Awesome Tiptap footer', // String!
+  headerTopMargin: 30,
 })
 ```
 
-### Initial configuration (HTML)
+**Editor command:**
+
+```js
+editor.commands.setHeaderTopMargin(40)
+```
+
+## Footer configuration
+
+### Default footer
+
+The `footer` option sets the content displayed in the footer area of each page.
+
+**Initial configuration:**
 
 ```js
 Pages.configure({
-  footer: () => '<bold>Awesome Tiptap footer</bold>', // A function that returns HTML or a string!
+  footer: 'Page {page} of {total}',
 })
 ```
 
-### Footer content editor command
+**Editor command:**
 
 ```js
-editor.commands.setFooter('My awesome footer') // String!
-// or
-editor.commands.setFooter((page, total) => `${page} of ${total}`) // A function that returns HTML or a string!
+editor.commands.setFooter('Powered by Tiptap')
+// or with placeholders
+editor.commands.setFooter('{page}/{total}')
 ```
 
-### Footer replacement templates
+### Footer margin
 
-The `footer` property, when usign a string comes with two handy template replacements:
+The `footerBottomMargin` option controls the distance from the footer content bottom to the page's bottom edge (in pixels). If not specified, it defaults to 50% of the bottom margin.
 
-- `{page}`: gets replaced with the current page.
-- `{total}`: gets replaced with the total amout of pages of the document.
-
-The `footer` property, also accepts a function that gives you them same information, but this time it's passed on to you via function arguments:
+**Initial configuration:**
 
 ```js
 Pages.configure({
-  footer: (page, total) => `${page} of ${total}` // Eg, shows: "1 of 10"
+  footerBottomMargin: 30,
 })
 ```
 
-## Footer height
+**Editor command:**
 
-- Controls how tall the footer area is at the bottom of each page.
-- Default: `50` (pixels)
+```js
+editor.commands.setFooterBottomMargin(40)
+```
 
-### Initial configuration
+## Different first page
+
+Enable a different header and/or footer for the first page, similar to Microsoft Word's "Different First Page" option.
+
+<Callout title="Note" variant="info">
+  The `setDifferentFirstPage()` command enables both different first page header and footer together, matching Microsoft Word's behavior.
+</Callout>
+
+### Configuration
 
 ```js
 Pages.configure({
-  footerHeight: 80, // Makes the footer area taller
+  header: 'Default Header',
+  footer: 'Page {page}',
+  differentFirstPage: true,
+  headerFirstPage: 'Title Page',
+  footerFirstPage: '', // No footer on first page
 })
 ```
 
-### Editor footer height command
+### Commands
 
 ```js
-editor.commands.setFooterHeight(30) // A smaller footer!
+// Enable different first page (affects both header and footer)
+editor.commands.setDifferentFirstPage(true)
+
+// Set first page header and footer content
+editor.commands.setHeaderFirstPage('Welcome to My Document')
+editor.commands.setFooterFirstPage('')
 ```
 
-## Page margins
+## Different odd and even pages
 
-Page margins can be customized by using a custom page format. Built-in formats come with fixed margins, but you can create your own format with custom margins:
+Enable different headers and/or footers for odd-numbered pages (1, 3, 5...) and even-numbered pages (2, 4, 6...), similar to Microsoft Word's "Different Odd & Even Pages" option.
+
+<Callout title="Note" variant="info">
+  The `setDifferentOddEven()` command enables both different odd/even headers and footers together, matching Microsoft Word's behavior.
+</Callout>
+
+### Configuration
 
 ```js
 Pages.configure({
-  pageFormat: {
-    id: 'custom-layout',
-    width: 794,   // px
-    height: 1123, // px
-    margins: {
-      top: 60,    // px
-      right: 40,  // px
-      bottom: 60, // px
-      left: 40,   // px
-    },
-  },
+  differentOddEven: true,
+  headerOdd: 'Chapter Title – Odd Page',
+  headerEven: 'Book Title – Even Page',
+  footerOdd: 'Page {page}',
+  footerEven: 'Page {page}',
 })
 ```
 
-<Callout title="Flexibility" variant="info">
-  With custom page formats, you have full control over both page dimensions and margins to create the exact layout you need. 
-  For a detailed guide and more examples, see the [Custom page formats section](/pages/core-concepts/page-format#custom-page-formats) of the [Page format](/pages/core-concepts/page-format) documentation.
-</Callout> 
+### Commands
+
+```js
+// Enable different odd/even (affects both header and footer)
+editor.commands.setDifferentOddEven(true)
+
+// Set odd and even page headers
+editor.commands.setHeaderOdd('Odd Page Header')
+editor.commands.setHeaderEven('Even Page Header')
+
+// Set odd and even page footers
+editor.commands.setFooterOdd('Page {page}')
+editor.commands.setFooterEven('Page {page}')
+```
+
+## Editable headers and footers
+
+Users can edit headers and footers directly by double-clicking on them. This opens a fully featured Tiptap editor that allows rich text editing.
+
+### Custom extensions
+
+By default, the header/footer editor uses StarterKit. You can provide custom extensions:
+
+```js
+import { Extension } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import TextAlign from '@tiptap/extension-text-align'
+
+Pages.configure({
+  header: 'My Header',
+  headerFooterExtensions: [
+    StarterKit,
+    TextAlign.configure({
+      types: ['heading', 'paragraph'],
+    }),
+  ],
+})
+```
+
+### Active editor state
+
+When a user double-clicks a header or footer to edit it, the extension exposes the active editor through storage. This allows you to build custom toolbars that work with the header/footer editor.
+
+**Storage properties:**
+
+- `activeEditor` – The Tiptap Editor instance for the currently open overlay (or `null`)
+- `activeEditorType` – `'header'`, `'footer'`, or `null`
+- `activePageNumber` – The page number being edited (or `null`)
+
+### Building a custom toolbar
+
+Here's an example of a React component that provides a unified toolbar for both the main editor and header/footer editors:
+
+```tsx
+import { useEditor, useEditorState, EditorContent } from '@tiptap/react'
+import { useEffect, useState } from 'react'
+
+function DocumentEditor() {
+  const [headerFooterEditor, setHeaderFooterEditor] = useState(null)
+  const [activeEditorType, setActiveEditorType] = useState(null)
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit,
+      Pages.configure({
+        header: 'Document Header',
+        footer: 'Page {page}',
+      }),
+    ],
+  })
+
+  // Listen for changes to active header/footer editor
+  useEffect(() => {
+    if (!editor) return
+
+    const handleUpdate = () => {
+      const { activeEditor, activeEditorType } = editor.storage.pages
+      setHeaderFooterEditor(activeEditor)
+      setActiveEditorType(activeEditorType)
+    }
+
+    editor.on('update', handleUpdate)
+    return () => editor.off('update', handleUpdate)
+  }, [editor])
+
+  // Use the active editor (header/footer or main)
+  const activeEditor = activeEditorType ? headerFooterEditor : editor
+
+  const { isBoldActive } = useEditorState({
+    editor: activeEditor,
+    selector: ({ editor: e }) => ({
+      isBoldActive: e?.isActive('bold') ?? false,
+    }),
+  })
+
+  return (
+    <div>
+      <div className="toolbar">
+        <span>Editing: {activeEditorType || 'Document'}</span>
+        <button
+          className={isBoldActive ? 'is-active' : ''}
+          onClick={() => activeEditor?.chain().focus().toggleBold().run()}
+        >
+          Bold
+        </button>
+      </div>
+      <EditorContent editor={editor} />
+    </div>
+  )
+}
+```
+
+## Accessing header and footer content
+
+After users edit headers or footers through the headers or footers Tiptap editors, the content is stored in the extension's storage. This is useful for saving the document or exporting to formats like DOCX.
+
+### HTML content
+
+Access the edited HTML content:
+
+```js
+// Default header/footer
+const headerHTML = editor.storage.pages.headerHTML
+const footerHTML = editor.storage.pages.footerHTML
+
+// First page
+const headerFirstPageHTML = editor.storage.pages.headerFirstPageHTML
+const footerFirstPageHTML = editor.storage.pages.footerFirstPageHTML
+
+// Odd/even pages
+const headerOddHTML = editor.storage.pages.headerOddHTML
+const headerEvenHTML = editor.storage.pages.headerEvenHTML
+const footerOddHTML = editor.storage.pages.footerOddHTML
+const footerEvenHTML = editor.storage.pages.footerEvenHTML
+```
+
+### JSON content for DOCX export
+
+For DOCX export, use the JSON versions which provide structured Tiptap document format:
+
+```js
+// Default header/footer
+const headerJSON = editor.storage.pages.headerJSON
+const footerJSON = editor.storage.pages.footerJSON
+
+// First page
+const headerFirstPageJSON = editor.storage.pages.headerFirstPageJSON
+const footerFirstPageJSON = editor.storage.pages.footerFirstPageJSON
+
+// Odd/even pages
+const headerOddJSON = editor.storage.pages.headerOddJSON
+const headerEvenJSON = editor.storage.pages.headerEvenJSON
+const footerOddJSON = editor.storage.pages.footerOddJSON
+const footerEvenJSON = editor.storage.pages.footerEvenJSON
+```
+
+<Callout title="Note" variant="info">
+  These storage values are `null` until the user has edited the header/footer through the overlay editor. Before editing, the original template from configuration is used.
+</Callout>
+
+## Complete options reference
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `header` | `string \| JSONContent` | `''` | Default header content |
+| `footer` | `string \| JSONContent` | `''` | Default footer content |
+| `headerTopMargin` | `number` | 50% of top margin | Distance from page top to header content |
+| `footerBottomMargin` | `number` | 50% of bottom margin | Distance from footer content to page bottom |
+| `differentFirstPage` | `boolean` | `false` | Enable different first page header and footer |
+| `headerFirstPage` | `PagesHeaderFooter` | `''` | First page header content |
+| `footerFirstPage` | `PagesHeaderFooter` | `''` | First page footer content |
+| `differentOddEven` | `boolean` | `false` | Enable different odd/even headers and footers |
+| `headerOdd` | `PagesHeaderFooter` | `''` | Odd pages header content |
+| `headerEven` | `PagesHeaderFooter` | `''` | Even pages header content |
+| `footerOdd` | `PagesHeaderFooter` | `''` | Odd pages footer content |
+| `footerEven` | `PagesHeaderFooter` | `''` | Even pages footer content |
+| `headerFooterExtensions` | `Extension[]` | `StarterKit` | Extensions for header/footer editor |
+
+## Commands reference
+
+| Command | Parameters | Description |
+|---------|------------|-------------|
+| `setHeader` | `header: PagesHeaderFooter` | Set default header content |
+| `setFooter` | `footer: PagesHeaderFooter` | Set default footer content |
+| `setHeaderTopMargin` | `margin: number` | Set header top margin (pixels) |
+| `setFooterBottomMargin` | `margin: number` | Set footer bottom margin (pixels) |
+| `setDifferentFirstPage` | `enabled: boolean` | Toggle different first page (header + footer) |
+| `setHeaderFirstPage` | `header: PagesHeaderFooter` | Set first page header content |
+| `setFooterFirstPage` | `footer: PagesHeaderFooter` | Set first page footer content |
+| `setDifferentOddEven` | `enabled: boolean` | Toggle different odd/even pages (header + footer) |
+| `setHeaderOdd` | `header: PagesHeaderFooter` | Set odd pages header content |
+| `setHeaderEven` | `header: PagesHeaderFooter` | Set even pages header content |
+| `setFooterOdd` | `footer: PagesHeaderFooter` | Set odd pages footer content |
+| `setFooterEven` | `footer: PagesHeaderFooter` | Set even pages footer content |

--- a/src/content/pages/core-concepts/page-header-footer.mdx
+++ b/src/content/pages/core-concepts/page-header-footer.mdx
@@ -2,7 +2,7 @@
 title: Page header and footer
 meta:
   title: Page header and footer | Tiptap Pages Docs
-  description: Learn how to configure headers and footers in Tiptap Pages, including different first page, odd/even pages, and editable overlays.
+  description: Learn how to configure headers and footers in Tiptap Pages, including different first page, odd/even pages, and live Tiptap-powered editing.
   category: Pages
 sidebars:
   hideSecondary: true

--- a/src/content/pages/core-concepts/page-header-footer.mdx
+++ b/src/content/pages/core-concepts/page-header-footer.mdx
@@ -523,6 +523,47 @@ editor.commands.closeHeaderEditor()
 editor.commands.closeFooterEditor()
 ```
 
+## Preventing editor close on double-click
+
+By default, double-clicking outside an open header or footer editor closes it. You can prevent this behavior using callback options, which is useful when you have toolbar buttons or other UI elements that users might double-click while editing.
+
+### Configuration
+
+Three callback options are available:
+
+- `onDblClickHeaderFooterPreventClose` - Applies to both headers and footers (fallback)
+- `onDblClickHeaderPreventClose` - Applies only to headers (takes priority over the fallback)
+- `onDblClickFooterPreventClose` - Applies only to footers (takes priority over the fallback)
+
+Each callback receives the `MouseEvent` and returns `true` to prevent closing or `false` to allow closing.
+
+**Example: Prevent closing when clicking a toolbar**
+
+```js
+Pages.configure({
+  header: 'My Header',
+  footer: 'Page {page}',
+  onDblClickHeaderFooterPreventClose: (event) => {
+    // Keep editor open if clicking inside the toolbar
+    const toolbar = document.querySelector('.my-toolbar')
+    return toolbar?.contains(event.target)
+  },
+})
+```
+
+**Example: Different behavior for headers and footers**
+
+```js
+Pages.configure({
+  header: 'My Header',
+  footer: 'Page {page}',
+  // Never close header editor on double-click outside
+  onDblClickHeaderPreventClose: () => true,
+  // Use default behavior for footer (close on double-click outside)
+  onDblClickFooterPreventClose: () => false,
+})
+```
+
 ## Limitations
 
 ### Editing cannot be disabled
@@ -551,6 +592,9 @@ Collaborative editing is not supported for headers and footers. The header and f
 | `footerOdd` | `PagesHeaderFooter` | `''` | Odd pages footer content |
 | `footerEven` | `PagesHeaderFooter` | `''` | Even pages footer content |
 | `headerFooterExtensions` | `Extension[]` | `StarterKit` | Extensions for header/footer editor |
+| `onDblClickHeaderFooterPreventClose` | `(event: MouseEvent) => boolean` | `undefined` | Callback to prevent closing header/footer editors on double-click outside |
+| `onDblClickHeaderPreventClose` | `(event: MouseEvent) => boolean` | `undefined` | Callback to prevent closing header editor on double-click outside |
+| `onDblClickFooterPreventClose` | `(event: MouseEvent) => boolean` | `undefined` | Callback to prevent closing footer editor on double-click outside |
 
 ## Commands reference
 

--- a/src/content/pages/core-concepts/page-header-footer.mdx
+++ b/src/content/pages/core-concepts/page-header-footer.mdx
@@ -11,7 +11,11 @@ sidebars:
 import { Callout } from '@/components/ui/Callout'
 import { CodeDemo } from '@/components/CodeDemo'
 
-Headers and footers allow you to display consistent content at the top and bottom of each page. The Pages extension supports static text, HTML markup, dynamic page numbering with placeholders, rich formatting via JSONContent, different headers/footers for first page or odd/even pages, and interactive editing through double-click overlays.
+Headers and footers allow you to display consistent content at the top and bottom of each page. The Pages extension supports static text, HTML markup, dynamic page numbering with placeholders, rich formatting via JSONContent, different headers/footers for first page or odd/even pages, and interactive editing through double-click in the header or footer area.
+
+<Callout title="Note" variant="info">
+  Headers and footers are always editable via double-click. This behavior cannot be disabled.
+</Callout>
 
 <CodeDemo isPro src="https://feature-pages-extension--tiptap-pro.netlify.app/preview/extensions/pagesheaderfooter" />
 
@@ -63,6 +67,26 @@ Pages.configure({
     ]
   }
 })
+```
+
+## Configuration vs commands
+
+Use `Pages.configure()` when setting up the editor with initial default content. Use editor commands like `setHeader()` to update content dynamically at runtime.
+
+Both approaches are valid for setting content:
+
+**Initial setup with configure:**
+```js
+Pages.configure({
+  header: 'My Document Title',
+  footer: 'Page {page} of {total}',
+})
+```
+
+**Runtime updates with commands:**
+```js
+// Update header after editor is initialized
+editor.commands.setHeader('Updated Header')
 ```
 
 ## Header configuration
@@ -211,29 +235,63 @@ editor.commands.setFooterOdd('Page {page}')
 editor.commands.setFooterEven('Page {page}')
 ```
 
+## Combining first page and odd/even pages
+
+When both `differentFirstPage` and `differentOddEven` are enabled, the first page header/footer takes precedence over odd/even settings for page 1.
+
+**Precedence order:**
+1. First page (if `differentFirstPage` is enabled) - applies to page 1
+2. Odd/even (if `differentOddEven` is enabled) - applies to pages 2+
+3. Default header/footer - fallback
+
+```js
+Pages.configure({
+  header: 'Default Header',                    // Fallback
+  differentFirstPage: true,
+  headerFirstPage: 'Title Page',               // Page 1
+  differentOddEven: true,
+  headerOdd: 'Odd Page Header',                // Pages 3, 5, 7...
+  headerEven: 'Even Page Header',              // Pages 2, 4, 6...
+})
+```
+
 ## Editable headers and footers
 
 Users can edit headers and footers directly by double-clicking on them. This opens a fully featured Tiptap editor that allows rich text editing.
 
 ### Custom extensions
 
-By default, the header/footer editor uses StarterKit. You can provide custom extensions:
+By default, the header/footer editor uses `StarterKit`. You can provide custom extensions to enable additional features like images, tables, or text alignment:
 
 ```js
 import { Extension } from '@tiptap/core'
 import StarterKit from '@tiptap/starter-kit'
+import Image from '@tiptap/extension-image'
+import Table from '@tiptap/extension-table'
+import TableRow from '@tiptap/extension-table-row'
+import TableCell from '@tiptap/extension-table-cell'
+import TableHeader from '@tiptap/extension-table-header'
 import TextAlign from '@tiptap/extension-text-align'
 
 Pages.configure({
   header: 'My Header',
   headerFooterExtensions: [
     StarterKit,
+    Image,
+    Table.configure({
+      resizable: true,
+    }),
+    TableRow,
+    TableCell,
+    TableHeader,
     TextAlign.configure({
       types: ['heading', 'paragraph'],
     }),
   ],
 })
 ```
+
+Any Tiptap extension can be added to the header/footer editors through the `headerFooterExtensions` option.
 
 ### Active editor state
 
@@ -332,6 +390,10 @@ const footerOddHTML = editor.storage.pages.footerOddHTML
 const footerEvenHTML = editor.storage.pages.footerEvenHTML
 ```
 
+<Callout title="Note" variant="info">
+  These storage values are `null` until the user has edited the header/footer through the corresponding header/footer editor. Before editing, the original template from configuration is used.
+</Callout>
+
 ### JSON content for DOCX export
 
 For DOCX export, use the JSON versions which provide structured Tiptap document format:
@@ -353,8 +415,59 @@ const footerEvenJSON = editor.storage.pages.footerEvenJSON
 ```
 
 <Callout title="Note" variant="info">
-  These storage values are `null` until the user has edited the header/footer through the overlay editor. Before editing, the original template from configuration is used.
+  These storage values are `null` until the user has edited the header/footer through the corresponding header/footer editor. Before editing, the original template from configuration is used.
 </Callout>
+
+### Saving header and footer content
+
+Persisting header and footer content is your responsibility. Retrieve the content from storage when saving your document and restore it when loading.
+
+**Saving all header and footer content:**
+
+```js
+function getHeaderFooterContent(editor) {
+  const { pages } = editor.storage
+
+  return {
+    // Default header/footer
+    headerHTML: pages.headerHTML,
+    headerJSON: pages.headerJSON,
+    footerHTML: pages.footerHTML,
+    footerJSON: pages.footerJSON,
+
+    // First page
+    headerFirstPageHTML: pages.headerFirstPageHTML,
+    headerFirstPageJSON: pages.headerFirstPageJSON,
+    footerFirstPageHTML: pages.footerFirstPageHTML,
+    footerFirstPageJSON: pages.footerFirstPageJSON,
+
+    // Odd/even pages
+    headerOddHTML: pages.headerOddHTML,
+    headerOddJSON: pages.headerOddJSON,
+    headerEvenHTML: pages.headerEvenHTML,
+    headerEvenJSON: pages.headerEvenJSON,
+    footerOddHTML: pages.footerOddHTML,
+    footerOddJSON: pages.footerOddJSON,
+    footerEvenHTML: pages.footerEvenHTML,
+    footerEvenJSON: pages.footerEvenJSON,
+  }
+}
+
+// Save to your backend
+const headerFooterData = getHeaderFooterContent(editor)
+await saveDocument({ content: editor.getJSON(), headerFooter: headerFooterData })
+```
+
+## Limitations
+
+### Editing cannot be disabled
+The double-click editing behavior is built into the extension and cannot be disabled. All users with access to the editor can edit headers and footers.
+
+### Header & Footer editor styling
+The header/footer editor uses built-in styles that cannot be customized.
+
+### Collaboration
+Collaborative editing is not supported for headers and footers. The header and footer editors are separate Tiptap instances that are independent from the main document's collaboration session.
 
 ## Complete options reference
 

--- a/src/content/pages/core-concepts/page-header-footer.mdx
+++ b/src/content/pages/core-concepts/page-header-footer.mdx
@@ -299,7 +299,7 @@ When a user double-clicks a header or footer to edit it, the extension exposes t
 
 **Storage properties:**
 
-- `activeEditor` – The Tiptap Editor instance for the currently open overlay (or `null`)
+- `activeEditor` – The Tiptap Editor instance for the currently open header or footer editor (or `null`)
 - `activeEditorType` – `'header'`, `'footer'`, or `null`
 - `activePageNumber` – The page number being edited (or `null`)
 
@@ -458,15 +458,67 @@ const headerFooterData = getHeaderFooterContent(editor)
 await saveDocument({ content: editor.getJSON(), headerFooter: headerFooterData })
 ```
 
-## Programmatically closing editors
+## Programmatically opening and closing editors
 
-You can close header and footer editor overlays programmatically. This is useful when integrating with custom UI elements or when you need to dismiss the overlay in response to user actions outside the editor.
+You can open and close header and footer editors programmatically. This is useful when integrating with custom UI elements, building navigation interfaces, or responding to user actions.
+
+### Opening editors
+
+Use the `openHeaderEditor` and `openFooterEditor` commands to programmatically open the editor for a specific page:
 
 ```js
-// Close whichever overlay is currently open
+// Open header editor for page 1
+editor.commands.openHeaderEditor({ pageNumber: 1 })
+
+// Open footer editor for page 3
+editor.commands.openFooterEditor({ pageNumber: 3 })
+```
+
+These commands return `true` if the editor was opened successfully, or `false` if the specified page doesn't exist.
+
+<Callout title="Note" variant="info">
+  Opening an editor automatically closes any previously open header or footer editor. The main document editor becomes non-editable while the header or footer editor is open.
+</Callout>
+
+**Use cases:**
+- Building a page navigation UI that lets users jump directly to editing a specific page's header or footer
+- Creating a "Go to header/footer" button in your toolbar
+- Implementing keyboard shortcuts to open headers or footers
+- Programmatically opening editors in response to external events
+
+**Example: Page navigation component**
+
+```tsx
+function PageNavigation({ editor }) {
+  const pageCount = editor.storage.pages.getPageCount?.() ?? 1
+
+  return (
+    <div>
+      {Array.from({ length: pageCount }, (_, i) => (
+        <div key={i + 1}>
+          <span>Page {i + 1}</span>
+          <button onClick={() => editor.commands.openHeaderEditor({ pageNumber: i + 1 })}>
+            Edit Header
+          </button>
+          <button onClick={() => editor.commands.openFooterEditor({ pageNumber: i + 1 })}>
+            Edit Footer
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}
+```
+
+### Closing editors
+
+Use the close commands to dismiss the header or footer editor:
+
+```js
+// Close whichever editor is currently open
 editor.commands.closeHeaderFooterEditors()
 
-// Close specific overlays
+// Close specific editors
 editor.commands.closeHeaderEditor()
 editor.commands.closeFooterEditor()
 ```
@@ -516,6 +568,8 @@ Collaborative editing is not supported for headers and footers. The header and f
 | `setHeaderEven` | `header: PagesHeaderFooter` | Set even pages header content |
 | `setFooterOdd` | `footer: PagesHeaderFooter` | Set odd pages footer content |
 | `setFooterEven` | `footer: PagesHeaderFooter` | Set even pages footer content |
+| `openHeaderEditor` | `{ pageNumber: number }` | Open header editor for a specific page (1-indexed) |
+| `openFooterEditor` | `{ pageNumber: number }` | Open footer editor for a specific page (1-indexed) |
 | `closeHeaderFooterEditors` | none | Close whichever header/footer editor is open |
 | `closeHeaderEditor` | none | Close the header editor if open |
 | `closeFooterEditor` | none | Close the footer editor if open |

--- a/src/content/pages/sidebar.ts
+++ b/src/content/pages/sidebar.ts
@@ -36,6 +36,7 @@ export const sidebarConfig: SidebarConfig = {
         {
           title: 'Headers & Footers',
           href: '/pages/core-concepts/page-header-footer',
+          tags: ['New'],
         },
         {
           title: 'Page break',


### PR DESCRIPTION
This pull request significantly expands and refactors the documentation for configuring headers and footers in Tiptap Pages. It introduces new features, clarifies existing options, and provides detailed examples for advanced scenarios like different first/odd/even pages and live editing via overlays. The documentation is now much more comprehensive and user-friendly, covering both configuration and editor commands.

**Major documentation improvements:**

* **Expanded header and footer configuration:** Now details support for static text, HTML markup, dynamic placeholders (`{page}`, `{total}`), rich formatting via `JSONContent`, and interactive editing overlays.
* **Advanced page layouts:** Added sections on configuring different headers/footers for the first page, as well as odd/even pages, including configuration options and editor commands to enable these features.
* **Editable overlays and custom toolbars:** Describes how users can double-click headers/footers to open rich Tiptap editors, customize extensions, and build toolbars that work with both the main and overlay editors.
* **Accessing edited content:** Explains how to retrieve both HTML and JSON versions of header/footer content from extension storage, useful for saving or exporting documents.
* **Comprehensive options and commands reference:** Added tables summarizing all configuration options and available editor commands for headers and footers.

**Other improvements:**

* Updated the page meta description to reflect the expanded scope, including support for first/odd/even page headers/footers and live editing.