### PR TITLE
Update Nuxt installation guide for Nuxt 4

### DIFF
--- a/.changeset/sweet-ties-repeat.md
+++ b/.changeset/sweet-ties-repeat.md
@@ -2,4 +2,4 @@
 'tiptap-docs': patch
 ---
 
-change install documentation for nuxt
+Update Nuxt installation guide for Nuxt 4

--- a/.changeset/sweet-ties-repeat.md
+++ b/.changeset/sweet-ties-repeat.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+change install documentation for nuxt

--- a/src/content/editor/getting-started/install/nuxt.mdx
+++ b/src/content/editor/getting-started/install/nuxt.mdx
@@ -6,24 +6,24 @@ meta:
   category: Editor
 ---
 
-This guide covers how to integrate Tiptap with your Nuxt.js (Nuxt 3) project, complete with code examples.
+This guide covers how to integrate Tiptap with your Nuxt project (Nuxt 4), complete with code examples.
 
 import { CodeDemo } from '@/components/CodeDemo'
 
 ### Requirements
 
-- [Node](https://nodejs.org/en/download/) installed on your machine
-- Experience with [Vue](https://vuejs.org/v2/guide/#Getting-Started)
+- [Node](https://nodejs.org/en/download/) installed on your machine (18.20+ recommended)
+- Experience with [Vue](https://vuejs.org/guide/introduction.html)
 
 ## Create a project (optional)
 
-If you already have a Nuxt.js project, that's fine too. Just skip this step.
+If you already have a Nuxt project, that's fine too. Just skip this step.
 
-For the purpose of this project, start with a fresh Nuxt.js project called `my-tiptap-project`. The following command sets up everything we need. It asks a lot of questions, but just use what floats your boat or use the defaults.
+For the purpose of this guide, start with a fresh Nuxt project called `my-tiptap-project`. The following command sets up everything you need:
 
 ```bash
 # create a project
-npm init nuxt-app my-tiptap-project
+npx nuxi@latest init my-tiptap-project
 
 # change directory
 cd my-tiptap-project
@@ -31,17 +31,17 @@ cd my-tiptap-project
 
 ### Install the dependencies
 
-Enough of the boring boilerplate work. Let's install Tiptap! For the following example, you'll need the `@tiptap/vue-3` package with a few components, the `@tiptap/pm` package, and `@tiptap/starter-kit`, which has the most common extensions to get started quickly.
+Now let's install Tiptap! For the following example, you'll need the `@tiptap/vue-3` package with a few components, the `@tiptap/pm` package, and `@tiptap/starter-kit`, which has the most common extensions to get started quickly.
 
 ```bash
 npm install @tiptap/vue-3 @tiptap/pm @tiptap/starter-kit
 ```
 
-If you followed steps 1 and 2, you can now start your project with `npm run dev` and open [http://localhost:8080/](http://localhost:8080/) in your favorite browser. This might be different if you're working with an existing project.
+If you followed steps 1 and 2, you can now start your project with `npm run dev` and open [http://localhost:3000/](http://localhost:3000/) in your favorite browser. This might be different if you're working with an existing project.
 
 ## Integrate Tiptap
 
-To actually start using Tiptap, you'll need to add a new component to your app. Let's call it `TiptapEditor` and put the following example code in `components/TiptapEditor.vue`.
+To actually start using Tiptap, you'll need to add a new component to your app. Let's call it `TiptapEditor` and put the following example code in `app/components/TiptapEditor.vue`.
 
 This is the fastest way to get Tiptap up and running with Vue. It will give you a very basic version of Tiptap, without any buttons. No worries, you will be able to add more functionality soon.
 
@@ -50,37 +50,36 @@ This is the fastest way to get Tiptap up and running with Vue. It will give you 
   <EditorContent :editor="editor" />
 </template>
 
-<script>
-  import { Editor, EditorContent } from '@tiptap/vue-3'
-  import StarterKit from '@tiptap/starter-kit'
+<script setup>
+import { Editor, EditorContent } from '@tiptap/vue-3'
+import StarterKit from '@tiptap/starter-kit'
 
-  const editor = ref(null)
+const editor = ref(null)
 
-  onMounted(() => {
-    editor.value = new Editor({
-      content: `<p>I'm running Tiptap with Vue.js. 🎉</p>`,
-      extensions: [StarterKit],
-    })
+onMounted(() => {
+  editor.value = new Editor({
+    content: `<p>I'm running Tiptap with Vue.js. 🎉</p>`,
+    extensions: [StarterKit],
   })
-  
-  onBeforeUnmount(() => {
-    editor.value.destroy()
-  })
+})
+
+onBeforeUnmount(() => {
+  editor.value.destroy()
+})
 </script>
 ```
 
 ### Add it to your app
 
-Now, let's replace the content of `pages/index.vue` with the following example code to use our new `TiptapEditor` component in our app.
+Now, let's replace the content of `app/pages/index.vue` with the following example code to use our new `TiptapEditor` component in our app.
 
 ```html
 <template>
   <TiptapEditor />
 </template>
-<script>
-  import TiptapEditor from '~/components/TiptapEditor.vue'
-</script>
 ```
+
+In Nuxt 4, components are auto-imported, so you don't need to manually import or register them.
 
 You should now see Tiptap in your browser. Time to give yourself a pat on the back! :)
 
@@ -144,3 +143,11 @@ You're probably used to binding your data with `v-model` in forms. This also pos
   })
 </script>
 ```
+
+## Next steps
+
+- [Configure your editor](/editor/getting-started/configure)
+- [Add styles to your editor](/editor/getting-started/style-editor)
+- [Learn more about Tiptaps concepts](/editor/core-concepts/introduction)
+- [Learn how to persist the editor state](/editor/core-concepts/persistence)
+- [Start building your own extensions](/editor/extensions/custom-extensions)

--- a/src/content/editor/getting-started/install/nuxt.mdx
+++ b/src/content/editor/getting-started/install/nuxt.mdx
@@ -51,20 +51,12 @@ This is the fastest way to get Tiptap up and running with Vue. It will give you 
 </template>
 
 <script setup>
-  import { Editor, EditorContent } from '@tiptap/vue-3'
+  import { useEditor, EditorContent } from '@tiptap/vue-3'
   import StarterKit from '@tiptap/starter-kit'
 
-  const editor = ref(null)
-
-  onMounted(() => {
-    editor.value = new Editor({
-      content: `<p>I'm running Tiptap with Vue.js. 🎉</p>`,
-      extensions: [StarterKit],
-    })
-  })
-
-  onBeforeUnmount(() => {
-    editor.value?.destroy()
+  const editor = useEditor({
+    content: `<p>I'm running Tiptap with Vue.js. 🎉</p>`,
+    extensions: [StarterKit],
   })
 </script>
 ```
@@ -81,7 +73,7 @@ Now, let's replace the content of `app/pages/index.vue` with the following examp
 </template>
 ```
 
-In Nuxt 4, both components and Vue composables (like `ref`, `watch`, `onMounted`, and `onBeforeUnmount`) are auto-imported, so you don't need to manually import or register them.
+In Nuxt 4, both components and Vue composables (like `ref` and `watch`) are auto-imported, so you don't need to manually import or register them.
 
 You should now see Tiptap in your browser. Time to give yourself a pat on the back! :)
 
@@ -97,15 +89,26 @@ You're probably used to binding your data with `v-model` in forms. This also pos
 </template>
 
 <script setup>
-  import { Editor, EditorContent } from '@tiptap/vue-3'
+  import { useEditor, EditorContent } from '@tiptap/vue-3'
   import StarterKit from '@tiptap/starter-kit'
 
-  const editor = ref(null)
   const emit = defineEmits(['update:modelValue'])
   const props = defineProps({
     modelValue: {
       type: String,
       default: '',
+    },
+  })
+
+  const editor = useEditor({
+    content: props.modelValue,
+    extensions: [StarterKit],
+    onUpdate: ({ editor }) => {
+      // HTML
+      emit('update:modelValue', editor.getHTML())
+
+      // JSON
+      // emit('update:modelValue', editor.getJSON())
     },
   })
 
@@ -125,24 +128,6 @@ You're probably used to binding your data with `v-model` in forms. This also pos
       editor.value?.commands.setContent(value, false)
     }
   )
-
-  onMounted(() => {
-    editor.value = new Editor({
-      content: props.modelValue,
-      extensions: [StarterKit],
-      onUpdate: ({ editor }) => {
-        // HTML
-        emit('update:modelValue', editor.getHTML())
-
-        // JSON
-        // emit('update:modelValue', editor.getJSON())
-      },
-    })
-  })
-
-  onBeforeUnmount(() => {
-    editor.value?.destroy()
-  })
 </script>
 ```
 

--- a/src/content/editor/getting-started/install/nuxt.mdx
+++ b/src/content/editor/getting-started/install/nuxt.mdx
@@ -64,15 +64,7 @@ This is the fastest way to get Tiptap up and running with Vue. It will give you 
 
 ### Add it to your app
 
-First, update `app/app.vue` to use the Nuxt page router:
-
-```html
-<template>
-  <NuxtPage />
-</template>
-```
-
-Then, create `app/pages/index.vue` with the following code to use our new `TiptapEditor` component:
+Now, replace the content of `app/app.vue` with the following code to use our new `TiptapEditor` component:
 
 ```html
 <template>

--- a/src/content/editor/getting-started/install/nuxt.mdx
+++ b/src/content/editor/getting-started/install/nuxt.mdx
@@ -64,7 +64,15 @@ This is the fastest way to get Tiptap up and running with Vue. It will give you 
 
 ### Add it to your app
 
-Now, let's replace the content of `app/pages/index.vue` with the following example code to use our new `TiptapEditor` component in our app.
+First, update `app/app.vue` to use the Nuxt page router:
+
+```html
+<template>
+  <NuxtPage />
+</template>
+```
+
+Then, create `app/pages/index.vue` with the following code to use our new `TiptapEditor` component:
 
 ```html
 <template>

--- a/src/content/editor/getting-started/install/nuxt.mdx
+++ b/src/content/editor/getting-started/install/nuxt.mdx
@@ -51,21 +51,21 @@ This is the fastest way to get Tiptap up and running with Vue. It will give you 
 </template>
 
 <script setup>
-import { Editor, EditorContent } from '@tiptap/vue-3'
-import StarterKit from '@tiptap/starter-kit'
+  import { Editor, EditorContent } from '@tiptap/vue-3'
+  import StarterKit from '@tiptap/starter-kit'
 
-const editor = ref(null)
+  const editor = ref(null)
 
-onMounted(() => {
-  editor.value = new Editor({
-    content: `<p>I'm running Tiptap with Vue.js. 🎉</p>`,
-    extensions: [StarterKit],
+  onMounted(() => {
+    editor.value = new Editor({
+      content: `<p>I'm running Tiptap with Vue.js. 🎉</p>`,
+      extensions: [StarterKit],
+    })
   })
-})
 
-onBeforeUnmount(() => {
-  editor.value.destroy()
-})
+  onBeforeUnmount(() => {
+    editor.value?.destroy()
+  })
 </script>
 ```
 
@@ -75,11 +75,13 @@ Now, let's replace the content of `app/pages/index.vue` with the following examp
 
 ```html
 <template>
-  <TiptapEditor />
+  <ClientOnly>
+    <TiptapEditor />
+  </ClientOnly>
 </template>
 ```
 
-In Nuxt 4, components are auto-imported, so you don't need to manually import or register them.
+In Nuxt 4, both components and Vue composables (like `ref`, `watch`, `onMounted`, and `onBeforeUnmount`) are auto-imported, so you don't need to manually import or register them.
 
 You should now see Tiptap in your browser. Time to give yourself a pat on the back! :)
 
@@ -119,7 +121,7 @@ You're probably used to binding your data with `v-model` in forms. This also pos
       if (isSame) {
         return
       }
-      
+
       editor.value?.commands.setContent(value, false)
     }
   )
@@ -137,9 +139,9 @@ You're probably used to binding your data with `v-model` in forms. This also pos
       },
     })
   })
-  
+
   onBeforeUnmount(() => {
-    editor.value.destroy()
+    editor.value?.destroy()
   })
 </script>
 ```

--- a/src/content/editor/getting-started/install/nuxt.mdx
+++ b/src/content/editor/getting-started/install/nuxt.mdx
@@ -6,7 +6,7 @@ meta:
   category: Editor
 ---
 
-This guide covers how to integrate Tiptap with your Nuxt.js project, complete with code examples.
+This guide covers how to integrate Tiptap with your Nuxt.js (Nuxt 3) project, complete with code examples.
 
 import { CodeDemo } from '@/components/CodeDemo'
 
@@ -47,35 +47,25 @@ This is the fastest way to get Tiptap up and running with Vue. It will give you 
 
 ```html
 <template>
-  <editor-content :editor="editor" />
+  <EditorContent :editor="editor" />
 </template>
 
 <script>
   import { Editor, EditorContent } from '@tiptap/vue-3'
   import StarterKit from '@tiptap/starter-kit'
 
-  export default {
-    components: {
-      EditorContent,
-    },
+  const editor = ref(null)
 
-    data() {
-      return {
-        editor: null,
-      }
-    },
-
-    mounted() {
-      this.editor = new Editor({
-        content: "<p>I'm running Tiptap with Vue.js. 🎉</p>",
-        extensions: [StarterKit],
-      })
-    },
-
-    beforeUnmount() {
-      this.editor.destroy()
-    },
-  }
+  onMounted(() => {
+    editor.value = new Editor({
+      content: `<p>I'm running Tiptap with Vue.js. 🎉</p>`,
+      extensions: [StarterKit],
+    })
+  })
+  
+  onBeforeUnmount(() => {
+    editor.value.destroy()
+  })
 </script>
 ```
 
@@ -85,23 +75,12 @@ Now, let's replace the content of `pages/index.vue` with the following example c
 
 ```html
 <template>
-  <div>
-    <client-only>
-      <tiptap-editor />
-    </client-only>
-  </div>
+  <TiptapEditor />
 </template>
 <script>
   import TiptapEditor from '~/components/TiptapEditor.vue'
-  export default {
-    components: {
-      TiptapEditor,
-    },
-  }
 </script>
 ```
-
-Note that Tiptap needs to run in the client, not on the server. It's required to wrap the editor in a `<client-only>` tag. [Read more about client-only components.](https://nuxtjs.org/api/components-client-only)
 
 You should now see Tiptap in your browser. Time to give yourself a pat on the back! :)
 
@@ -113,72 +92,55 @@ You're probably used to binding your data with `v-model` in forms. This also pos
 
 ```html
 <template>
-  <editor-content :editor="editor" />
+  <EditorContent :editor="editor" />
 </template>
 
-<script>
+<script setup>
   import { Editor, EditorContent } from '@tiptap/vue-3'
   import StarterKit from '@tiptap/starter-kit'
 
-  export default {
-    components: {
-      EditorContent,
+  const editor = ref(null)
+  const emit = defineEmits(['update:modelValue'])
+  const props = defineProps({
+    modelValue: {
+      type: String,
+      default: '',
     },
+  })
 
-    props: {
-      value: {
-        type: String,
-        default: '',
-      },
-    },
+  watch(
+    () => props.modelValue,
+    (value) => {
+      // HTML
+      const isSame = editor.value?.getHTML() === value
 
-    data() {
-      return {
-        editor: null,
+      // JSON
+      // const isSame = JSON.stringify(editor.value?.getJSON()) === JSON.stringify(value)
+
+      if (isSame) {
+        return
       }
-    },
+      
+      editor.value?.commands.setContent(value, false)
+    }
+  )
 
-    watch: {
-      value(value) {
+  onMounted(() => {
+    editor.value = new Editor({
+      content: props.modelValue,
+      extensions: [StarterKit],
+      onUpdate: ({ editor }) => {
         // HTML
-        const isSame = this.editor.getHTML() === value
+        emit('update:modelValue', editor.getHTML())
 
         // JSON
-        // const isSame = JSON.stringify(this.editor.getJSON()) === JSON.stringify(value)
-
-        if (isSame) {
-          return
-        }
-
-        this.editor.commands.setContent(value, false)
+        // emit('update:modelValue', editor.getJSON())
       },
-    },
-
-    mounted() {
-      this.editor = new Editor({
-        content: this.value,
-        extensions: [StarterKit],
-        onUpdate: () => {
-          // HTML
-          this.$emit('input', this.editor.getHTML())
-
-          // JSON
-          // this.$emit('input', this.editor.getJSON())
-        },
-      })
-    },
-
-    beforeUnmount() {
-      this.editor.destroy()
-    },
-  }
+    })
+  })
+  
+  onBeforeUnmount(() => {
+    editor.value.destroy()
+  })
 </script>
 ```
-
-## Next steps
-
-- [Configure your editor](/editor/getting-started/configure)
-- [Add styles to your editor](/editor/getting-started/style-editor)
-- [Learn more about Tiptaps concepts](/editor/core-concepts/introduction)
-- [Learn how to persist the editor state](/editor/core-concepts/persistence)
-- [Start building your own extensions](/editor/extensions/custom-extensions)

--- a/src/content/editor/getting-started/install/nuxt.mdx
+++ b/src/content/editor/getting-started/install/nuxt.mdx
@@ -6,13 +6,13 @@ meta:
   category: Editor
 ---
 
-This guide covers how to integrate Tiptap with your Nuxt project (Nuxt 4), complete with code examples.
+This guide covers how to integrate Tiptap with your Nuxt 4 project, complete with code examples.
 
 import { CodeDemo } from '@/components/CodeDemo'
 
 ### Requirements
 
-- [Node](https://nodejs.org/en/download/) installed on your machine (18.20+ recommended)
+- [Node](https://nodejs.org/en/download/) installed on your machine
 - Experience with [Vue](https://vuejs.org/guide/introduction.html)
 
 ## Create a project (optional)

--- a/src/content/editor/getting-started/install/nuxt.mdx
+++ b/src/content/editor/getting-started/install/nuxt.mdx
@@ -41,7 +41,7 @@ If you followed steps 1 and 2, you can now start your project with `npm run dev`
 
 ## Integrate Tiptap
 
-To actually start using Tiptap, you'll need to add a new component to your app. Let's call it `TiptapEditor` and put the following example code in `app/components/TiptapEditor.vue`.
+To actually start using Tiptap, you'll need to add a new component to your app. Let's call it `TiptapEditor` and put the following example code in `components/TiptapEditor.vue`.
 
 This is the fastest way to get Tiptap up and running with Vue. It will give you a very basic version of Tiptap, without any buttons. No worries, you will be able to add more functionality soon.
 

--- a/src/content/editor/getting-started/install/nuxt.mdx
+++ b/src/content/editor/getting-started/install/nuxt.mdx
@@ -45,6 +45,8 @@ To actually start using Tiptap, you'll need to add a new component to your app. 
 
 This is the fastest way to get Tiptap up and running with Vue. It will give you a very basic version of Tiptap, without any buttons. No worries, you will be able to add more functionality soon.
 
+Since Nuxt uses server-side rendering (SSR), we set `immediatelyRender: false` to prevent the editor from rendering on the server. The editor requires browser APIs that aren't available during SSR, so this option ensures it only renders on the client after hydration.
+
 ```html
 <template>
   <EditorContent :editor="editor" />
@@ -57,6 +59,7 @@ This is the fastest way to get Tiptap up and running with Vue. It will give you 
   const editor = useEditor({
     content: `<p>I'm running Tiptap with Vue.js. 🎉</p>`,
     extensions: [StarterKit],
+    // Don't render on the server, only on the client after hydration
     immediatelyRender: false,
   })
 </script>
@@ -102,6 +105,7 @@ You're probably used to binding your data with `v-model` in forms. This also pos
   const editor = useEditor({
     content: props.modelValue,
     extensions: [StarterKit],
+    // Don't render on the server, only on the client after hydration
     immediatelyRender: false,
     onUpdate: ({ editor }) => {
       // HTML

--- a/src/content/editor/getting-started/install/nuxt.mdx
+++ b/src/content/editor/getting-started/install/nuxt.mdx
@@ -57,6 +57,7 @@ This is the fastest way to get Tiptap up and running with Vue. It will give you 
   const editor = useEditor({
     content: `<p>I'm running Tiptap with Vue.js. 🎉</p>`,
     extensions: [StarterKit],
+    immediatelyRender: false,
   })
 </script>
 ```
@@ -67,9 +68,7 @@ Now, let's replace the content of `app/pages/index.vue` with the following examp
 
 ```html
 <template>
-  <ClientOnly>
-    <TiptapEditor />
-  </ClientOnly>
+  <TiptapEditor />
 </template>
 ```
 
@@ -103,6 +102,7 @@ You're probably used to binding your data with `v-model` in forms. This also pos
   const editor = useEditor({
     content: props.modelValue,
     extensions: [StarterKit],
+    immediatelyRender: false,
     onUpdate: ({ editor }) => {
       // HTML
       emit('update:modelValue', editor.getHTML())


### PR DESCRIPTION
## Summary

- Update documentation for Nuxt 4 (building on the Nuxt 3 contribution from #127 by @illiyyin)
- Use Composition API with `<script setup>` syntax
- Replace Options API with modern ref/lifecycle composables
- Update project creation command to use `npx nuxi@latest`
- Update file paths to use `app/` directory (Nuxt 4 structure)
- Remove manual imports (no longer needed with auto-imports)

## Context

This builds on the work from #127 by @illiyyin, who correctly identified that the Nuxt docs were outdated (using Nuxt 2 Options API). Since Nuxt 2 reached EOL on June 30, 2024, and Nuxt 4 is now the current version, this PR updates the docs to reflect the latest Nuxt 4 conventions.

The original author's commits are preserved in the git history.

## Test plan

- [ ] Verify code examples render correctly in the docs site
- [ ] Test the documented steps in a fresh Nuxt 4 project