### PR TITLE
Add docs for Floating & Bubble Menu Show/Hide Events

### DIFF
--- a/.changeset/spotty-guests-work.md
+++ b/.changeset/spotty-guests-work.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': minor
+---
+
+Add documentation for bubble & floating menu's show & hide events

--- a/src/content/editor/extensions/functionality/bubble-menu.mdx
+++ b/src/content/editor/extensions/functionality/bubble-menu.mdx
@@ -207,3 +207,17 @@ If the bubble menu changes size after the initial render, its position will not 
 ```ts
 editor.commands.setMeta('bubbleMenu', 'updatePosition')
 ```
+
+### Force show or hide the bubble menu
+
+To programatically show the bubble menu, you can emit a 'show' event via transaction metadata:
+
+```ts
+editor.commands.setMeta('bubbleMenu', 'show')
+```
+
+Similarly to hide the bubble menu, you can emit a 'hide' event:
+
+```ts
+editor.commands.setMeta('bubbleMenu', 'hide')
+```

--- a/src/content/editor/extensions/functionality/floatingmenu.mdx
+++ b/src/content/editor/extensions/functionality/floatingmenu.mdx
@@ -201,3 +201,17 @@ Alternatively, you can emit an `'updatePosition'` event via transaction metadata
 ```ts
 editor.commands.setMeta('floatingMenu', 'updatePosition')
 ```
+
+### Force show or hide the floating menu
+
+To programatically show the floating menu, you can emit a 'show' event via transaction metadata:
+
+```ts
+editor.commands.setMeta('floatingMenu', 'show')
+```
+
+To hide the floating menu, you can emit a 'hide' event:
+
+```ts
+editor.commands.setMeta('floatingMenu', 'hide')
+```


### PR DESCRIPTION
**Tiptap PR:** https://github.com/ueberdosis/tiptap/pull/7171

Document the addition of the show & hide events for both the bubble & floating menu plugins.