### PR TITLE
docs: document new Tiptap component API for React

### DIFF
--- a/src/content/editor/getting-started/install/react.mdx
+++ b/src/content/editor/getting-started/install/react.mdx
@@ -7,12 +7,13 @@ meta:
 ---
 
 import { CodeDemo } from '@/components/CodeDemo'
+import { Callout } from '@/components/ui/Callout'
 
 This guide describes how to integrate Tiptap with your React project. We're using Vite, but the workflow should be similar with other setups.
 
 <CodeDemo path="/Examples/Default" />
 
-### Create a React project (optional)
+## Create a React project (optional)
 
 Start with a fresh React project called `my-tiptap-project`. [Vite](https://vitejs.dev/guide/) will set up everything we need.
 
@@ -30,7 +31,7 @@ yarn create vite my-tiptap-project --template react-ts
 cd my-tiptap-project
 ```
 
-### Install Tiptap dependencies
+## Install Tiptap dependencies
 
 Next, install the `@tiptap/react` package, `@tiptap/pm` (the ProseMirror library), and `@tiptap/starter-kit`, which includes the most common extensions to get started quickly.
 
@@ -46,18 +47,157 @@ If you followed steps 1 and 2, you can now start your project with `npm run dev`
 
 ## Integrate Tiptap into your React app
 
-To actually start using Tiptap we need to create a new component. Let's call it `Tiptap` and add the following example code in `src/Tiptap.tsx`.
+Tiptap provides a declarative `<Tiptap>` component that simplifies editor setup and provides context to all child components. This is the recommended approach for integrating Tiptap with React.
 
-```jsx
-// src/Tiptap.tsx
+### Using the Tiptap component
+
+Create a new component called `Editor` and add the following code in `src/Editor.tsx`:
+
+```tsx
+// src/Editor.tsx
+import { Tiptap, useEditor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+
+function Editor() {
+  const editor = useEditor({
+    extensions: [StarterKit],
+    content: '<p>Hello World!</p>',
+  })
+
+  return (
+    <Tiptap instance={editor}>
+      <Tiptap.Loading>Loading editor...</Tiptap.Loading>
+      <MenuBar />
+      <Tiptap.Content />
+      <Tiptap.BubbleMenu>
+        <button>Bold</button>
+        <button>Italic</button>
+      </Tiptap.BubbleMenu>
+      <Tiptap.FloatingMenu>
+        <button>Add heading</button>
+      </Tiptap.FloatingMenu>
+    </Tiptap>
+  )
+}
+
+export default Editor
+```
+
+The `<Tiptap>` component provides several subcomponents:
+
+| Component | Description |
+| --- | --- |
+| `Tiptap.Content` | Renders the editor content area. Replaces `<EditorContent editor={editor} />`. |
+| `Tiptap.Loading` | Renders its children only while the editor is initializing. |
+| `Tiptap.BubbleMenu` | A context-aware bubble menu that appears on text selection. |
+| `Tiptap.FloatingMenu` | A context-aware floating menu that appears on empty lines. |
+
+### Add it to your app
+
+Replace the content of `src/App.tsx` with your new `Editor` component:
+
+```tsx
+import Editor from './Editor'
+
+function App() {
+  return (
+    <div className="card">
+      <Editor />
+    </div>
+  )
+}
+
+export default App
+```
+
+## Accessing the editor in child components
+
+The `<Tiptap>` component provides context that allows any child component to access the editor instance using the `useTiptap` hook.
+
+### Using useTiptap
+
+The `useTiptap` hook returns the editor instance and an `isReady` flag that indicates whether the editor has finished initializing.
+
+```tsx
+import { useTiptap } from '@tiptap/react'
+
+function MenuBar() {
+  const { editor, isReady } = useTiptap()
+
+  if (!isReady || !editor) {
+    return null
+  }
+
+  return (
+    <div className="menu-bar">
+      <button
+        onClick={() => editor.chain().focus().toggleBold().run()}
+        className={editor.isActive('bold') ? 'is-active' : ''}
+      >
+        Bold
+      </button>
+      <button
+        onClick={() => editor.chain().focus().toggleItalic().run()}
+        className={editor.isActive('italic') ? 'is-active' : ''}
+      >
+        Italic
+      </button>
+    </div>
+  )
+}
+```
+
+Then include the menu bar in your editor:
+
+```tsx
+<Tiptap instance={editor}>
+  <MenuBar />
+  <Tiptap.Content />
+</Tiptap>
+```
+
+### Using useTiptapState for reactive state
+
+For performance-sensitive components, use `useTiptapState` to subscribe to specific parts of the editor state. This prevents unnecessary re-renders when unrelated state changes.
+
+```tsx
+import { useTiptap, useTiptapState } from '@tiptap/react'
+
+function WordCount() {
+  const { isReady } = useTiptap()
+
+  const wordCount = useTiptapState((state) => {
+    const text = state.editor.state.doc.textContent
+    return text.split(/\s+/).filter(Boolean).length
+  })
+
+  if (!isReady) {
+    return null
+  }
+
+  return <span>{wordCount} words</span>
+}
+```
+
+The selector function receives an `EditorStateSnapshot` and should return only the data your component needs. The component will only re-render when the selected value changes.
+
+<Callout title="Important" variant="warning">
+  Only use `useTiptapState` when the editor is ready. Check `isReady` from `useTiptap()` before rendering components that use this hook.
+</Callout>
+
+## Alternative: Manual setup with EditorContent
+
+For cases where you need more control over the editor setup, you can use `EditorContent` directly:
+
+```tsx
 import { useEditor, EditorContent } from '@tiptap/react'
 import { FloatingMenu, BubbleMenu } from '@tiptap/react/menus'
 import StarterKit from '@tiptap/starter-kit'
 
-const Tiptap = () => {
+function Editor() {
   const editor = useEditor({
-    extensions: [StarterKit], // define your extension array
-    content: '<p>Hello World!</p>', // initial content
+    extensions: [StarterKit],
+    content: '<p>Hello World!</p>',
   })
 
   return (
@@ -69,143 +209,135 @@ const Tiptap = () => {
   )
 }
 
-export default Tiptap
+export default Editor
 ```
 
-### Add it to your app
-
-Finally, replace the content of `src/App.tsx` with our new `Tiptap` component.
-
-```jsx
-import Tiptap from './Tiptap'
-
-const App = () => {
-  return (
-    <div className="card">
-      <Tiptap />
-    </div>
-  )
-}
-
-export default App
-```
+This approach requires manually passing the `editor` prop to each component. The `<Tiptap>` component is preferred for most use cases as it reduces boilerplate and provides context automatically.
 
 ## Using the EditorContext
 
-Tiptap provides a React context called `EditorContext`, that allows you to access the editor instance and its state from anywhere in your component tree. This is particularly useful for building custom toolbars, menus, or other components that need to interact with the editor.
-
-```jsx
-// src/Tiptap.tsx
-import { useEditor, EditorContent, EditorContext } from '@tiptap/react'
-import { FloatingMenu, BubbleMenu } from '@tiptap/react/menus'
-import StarterKit from '@tiptap/starter-kit'
-
-const Tiptap = () => {
-  const editor = useEditor({
-    extensions: [StarterKit], // define your extension array
-    content: '<p>Hello World!</p>', // initial content
-  })
-
-  // Memoize the provider value to avoid unnecessary re-renders
-  const providerValue = useMemo(() => ({ editor }), [editor])
-
-  return (
-    <EditorContext.Provider value={providerValue}>
-      <EditorContent editor={editor} />
-      <FloatingMenu editor={editor}>This is the floating menu</FloatingMenu>
-      <BubbleMenu editor={editor}>This is the bubble menu</BubbleMenu>
-    </EditorContext.Provider>
-  )
-}
-
-export default Tiptap
-```
-
-### Consume the Editor context in child components
-
-If you use the `EditorProvider` to set up your Tiptap editor, you can now access your editor instance from any child component using the `useCurrentEditor` hook.
+The `<Tiptap>` component automatically provides the `EditorContext`, which means you can also use the `useCurrentEditor` hook inside it for backwards compatibility with existing code.
 
 ```tsx
 import { useCurrentEditor } from '@tiptap/react'
 
-const EditorJSONPreview = () => {
+function EditorJSONPreview() {
   const { editor } = useCurrentEditor()
+
+  if (!editor) {
+    return null
+  }
 
   return <pre>{JSON.stringify(editor.getJSON(), null, 2)}</pre>
 }
 ```
 
-**Important**: This won't work if you use the `useEditor` hook to setup your editor.
+For new code, prefer using `useTiptap()` which provides additional context like the `isReady` flag.
 
-You should now see a pretty barebones example of Tiptap in your browser.
+## Reacting to editor state changes
 
-## Reacting to Editor state changes
+To react to editor state changes without causing unnecessary re-renders, use the `useEditorState` hook:
 
-To react to editor state changes, you can use the `useEditorState` hook from `@tiptap/react`. This hook can be used to fetch information from the editor state without causing re-renders on the editor component or it's children.
-
-```jsx
+```tsx
 import { useEditorState } from '@tiptap/react'
 
-function MyEditorComponent() {
-  // ... your editor setup code
-
+function EditorStateDisplay({ editor }) {
   const editorState = useEditorState({
     editor,
-
-    // the selector function is used to select the state you want to react to
     selector: ({ editor }) => {
-      if (!editor) return null;
+      if (!editor) return null
 
       return {
         isEditable: editor.isEditable,
-        currentSelection: editor.state.selection,
-        currentContent: editor.getJSON(),
-        // you can add more state properties here e.g.:
-        // isBold: editor.isActive('bold'),
-        // isItalic: editor.isActive('italic'),
-      };
+        isBold: editor.isActive('bold'),
+        isItalic: editor.isActive('italic'),
+      }
     },
-  });
+  })
+
+  return <div>Bold active: {editorState?.isBold ? 'Yes' : 'No'}</div>
 }
 ```
 
+<Callout title="Tip" variant="hint">
+  When using the `<Tiptap>` component, prefer `useTiptapState` which automatically uses the editor from context.
+</Callout>
+
 ## Use SSR with React and Tiptap
 
-Tiptap can be used with server-side rendering (SSR) in React applications. However, to ensure that the editor is only initialized on the client side, you need to use the `immediatelyRender` option
-when creating the editor instance to prevent it from rendering on the server.
+Tiptap can be used with server-side rendering (SSR) in React applications. To ensure that the editor is only initialized on the client side, use the `immediatelyRender` option:
 
-Here is an example of how to set up Tiptap with SSR in a React component:
-
-```jsx
+```tsx
 'use client'
 
-import { useEditor, EditorContent } from '@tiptap/react'
+import { Tiptap, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 
 export function MyEditor() {
   const editor = useEditor({
     extensions: [StarterKit],
     content: '<p>Hello World!</p>',
-    // Disable immediate rendering to prevent SSR issues
     immediatelyRender: false,
   })
 
-  if (!editor) {
-    return null // Prevent rendering until the editor is initialized
-  }
-
-  return <EditorContent editor={editor} />
+  return (
+    <Tiptap instance={editor}>
+      <Tiptap.Loading>
+        <div className="skeleton">Loading editor...</div>
+      </Tiptap.Loading>
+      <Tiptap.Content />
+    </Tiptap>
+  )
 }
 ```
+
+The `Tiptap.Loading` component is particularly useful with SSR as it displays a placeholder until the editor initializes on the client.
 
 ## Optimize your performance
 
 We recommend visiting the [React Performance Guide](/guides/performance) to integrate the Tiptap Editor efficiently. This will help you avoid potential issues as your app scales.
 
+## API Reference
+
+### Tiptap component
+
+The root provider component that makes the editor instance available via React context.
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `instance` | `Editor \| null` | The editor instance from `useEditor()` |
+| `children` | `ReactNode` | Child components |
+
+### useTiptap hook
+
+Returns the Tiptap context value.
+
+```tsx
+const { editor, isReady } = useTiptap()
+```
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `editor` | `Editor \| null` | The editor instance |
+| `isReady` | `boolean` | `true` when the editor has finished initializing |
+
+### useTiptapState hook
+
+Subscribes to a slice of the editor state using a selector function.
+
+```tsx
+const value = useTiptapState(selector, equalityFn?)
+```
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `selector` | `(state: EditorStateSnapshot) => T` | Function to select state |
+| `equalityFn` | `(a: T, b: T) => boolean` | Optional equality function to control re-renders |
+
 ## Next steps
 
 - [Configure your editor](/editor/getting-started/configure)
 - [Add styles to your editor](/editor/getting-started/style-editor)
-- [Learn more about Tiptaps concepts](/editor/core-concepts/introduction)
+- [Learn more about Tiptap concepts](/editor/core-concepts/introduction)
 - [Learn how to persist the editor state](/editor/core-concepts/persistence)
 - [Start building your own extensions](/editor/extensions/custom-extensions)


### PR DESCRIPTION
- Add documentation for the declarative <Tiptap> component
- Document Tiptap.Content, Tiptap.Loading, Tiptap.BubbleMenu, Tiptap.FloatingMenu
- Add examples for useTiptap and useTiptapState hooks
- Include API reference section
- Update SSR example to use the new component
- Keep backwards compatibility section for EditorContext/useCurrentEditor

For https://github.com/ueberdosis/tiptap/pull/6917