### PR TITLE
Add tiptapEditHooks documentation

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks.mdx
@@ -82,7 +82,7 @@ const result = toolkit.executeTool({
   tiptapEditHooks: {
     beforeOperation: (context) => {
       // Log every operation
-      log(`Operation ${context.operationIndex}: ${context.operation.type}`)
+      log(`Operation type: ${context.operation.type}`)
 
       // Example: reject operations that delete too much content
       if (context.deleteContent && context.deleteContent.size > 1000) {

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks.mdx
@@ -29,13 +29,14 @@ The `beforeOperation` hook is called before each Tiptap Edit operation is applie
 
 The hook receives a `BeforeOperationContext` object with these properties:
 
-| Property        | Type                           | Description                                                                                                       |
-| --------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
-| `operation`     | `TiptapEditOperation`          | The operation being executed, containing `type`, `target`, and `content`                                          |
-| `doc`           | `Node`                         | The document at the current point in the transaction                                                              |
-| `deleteContent` | `Fragment \| null`             | The content that will be deleted (`null` if the content is just being inserted)                                   |
-| `insertContent` | `Fragment`                     | The content that will be inserted (as a [ProseMirror Fragment](https://prosemirror.net/docs/ref/#model.Fragment)) |
-| `range`         | `{ from: number; to: number }` | The position range where the operation will be applied                                                            |
+| Property         | Type                           | Description                                                                                                       |
+| ---------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `operation`      | `TiptapEditOperation`          | The operation being executed, containing `type`, `target`, and `content`                                          |
+| `operationIndex` | `number`                       | Index of this operation in the batch (0-based)                                                                    |
+| `doc`            | `Node`                         | The document at the current point in the transaction                                                              |
+| `deleteContent`  | `Fragment \| null`             | The content that will be deleted (`null` for `insertBefore`/`insertAfter`)                                        |
+| `insertContent`  | `Fragment`                     | The content that will be inserted (as a [ProseMirror Fragment](https://prosemirror.net/docs/ref/#model.Fragment)) |
+| `range`          | `{ from: number; to: number }` | The position range where the operation will be applied                                                            |
 
 To access the editor instance inside your hook, capture it in a closure when defining the hook.
 

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks.mdx
@@ -10,7 +10,7 @@ import { Callout } from '@/components/ui/Callout'
 
 Tiptap Edit hooks allow you to intercept operations before they are applied to the document. You can accept or reject each operation based on custom logic, and optionally modify the content or operation type when accepting.
 
-<Callout title="Experimental feature" type="info">
+<Callout title="Experimental feature" variant="info">
   Tiptap Edit hooks are currently an experimental feature and their API may change in the future.
 </Callout>
 

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks.mdx
@@ -1,0 +1,149 @@
+---
+title: Tiptap Edit hooks
+meta:
+  title: Tiptap Edit hooks | Tiptap Content AI
+  description: Intercept, modify, or reject Tiptap Edit operations before they are applied.
+  category: Content AI
+---
+
+import { Callout } from '@/components/ui/Callout'
+
+Tiptap Edit hooks allow you to intercept operations before they are applied to the document. You can accept or reject each operation based on custom logic, and optionally modify the content or operation type when accepting.
+
+<Callout title="Experimental feature" type="info">
+  Tiptap Edit hooks are currently an experimental feature and their API may change in the future.
+</Callout>
+
+## Use cases
+
+- **Content moderation**: Filter or sanitize AI-generated content before it reaches the document
+- **Custom validation**: Ensure operations meet business requirements
+- **Logging and analytics**: Track what changes the AI is making
+- **Access control**: Prevent modifications to certain parts of the document
+
+## The `beforeOperation` hook
+
+The `beforeOperation` hook is called before each Tiptap Edit operation is applied. It receives context about the operation and returns an action to take.
+
+### Hook context
+
+The hook receives a `BeforeOperationContext` object with these properties:
+
+| Property        | Type                           | Description                                                                                                       |
+| --------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `operation`     | `TiptapEditOperation`          | The operation being executed, containing `type`, `target`, and `content`                                          |
+| `doc`           | `Node`                         | The document at the current point in the transaction                                                              |
+| `deleteContent` | `Fragment \| null`             | The content that will be deleted (`null` if the content is just being inserted)                                   |
+| `insertContent` | `Fragment`                     | The content that will be inserted (as a [ProseMirror Fragment](https://prosemirror.net/docs/ref/#model.Fragment)) |
+| `range`         | `{ from: number; to: number }` | The position range where the operation will be applied                                                            |
+
+To access the editor instance inside your hook, capture it in a closure when defining the hook.
+
+### Hook return values
+
+The hook must return one of these actions:
+
+```ts
+// Accept the operation unchanged
+{ action: 'accept' }
+
+// Accept with a modified fragment (overrides the content to insert)
+{ action: 'accept', fragment: modifiedFragment }
+
+// Accept with a modified operation type
+{ action: 'accept', operationType: 'insertAfter' }
+
+// Accept with both modifications
+{ action: 'accept', fragment: modifiedFragment, operationType: 'replace' }
+
+// Skip this operation and record an error
+{ action: 'reject', error: 'Reason for rejection' }
+```
+
+The `fragment` property allows you to override the [ProseMirror Fragment](https://prosemirror.net/docs/ref/#model.Fragment) that will be inserted. The `operationType` property allows you to change the operation type (`'replace'`, `'insertBefore'`, or `'insertAfter'`).
+
+When an operation is rejected, the remaining operations in the batch continue to execute.
+
+## Usage
+
+### With `executeTool`
+
+```ts
+import { getAiToolkit } from '@tiptap-pro/ai-toolkit'
+import { log } from './lib/logger'
+
+const toolkit = getAiToolkit(editor)
+
+const result = toolkit.executeTool({
+  toolName: 'tiptapEdit',
+  input: {
+    operations: [['replace', 'abc123', '<p>New content</p>']],
+  },
+  tiptapEditHooks: {
+    beforeOperation: (context) => {
+      // Log every operation
+      log(`Operation ${context.operationIndex}: ${context.operation.type}`)
+
+      // Example: reject operations that delete too much content
+      if (context.deleteContent && context.deleteContent.size > 1000) {
+        return {
+          action: 'reject',
+          error: 'Content to delete is too large',
+        }
+      }
+
+      return { action: 'accept' }
+    },
+  },
+})
+```
+
+### With `streamTool`
+
+```ts
+const result = toolkit.streamTool({
+  toolCallId: 'call_123',
+  toolName: 'tiptapEdit',
+  hasFinished: true,
+  input,
+  tiptapEditHooks: {
+    beforeOperation: (context) => {
+      // Change all replacements to insertAfter operations
+      if (context.operation.type === 'replace') {
+        return {
+          action: 'accept',
+          operationType: 'insertAfter',
+        }
+      }
+
+      return { action: 'accept' }
+    },
+  },
+})
+```
+
+### With `tiptapEditWorkflow`
+
+```ts
+const { content } = toolkit.tiptapRead()
+
+const operations = await callApiEndpoint({ content, task: 'Improve the writing' })
+
+const result = toolkit.tiptapEditWorkflow({
+  operations,
+  workflowId: 'edit-123',
+  tiptapEditHooks: {
+    beforeOperation: (context) => {
+      // Only allow replacements, not insertions
+      if (context.operation.type !== 'replace') {
+        return {
+          action: 'reject',
+          error: 'Only replace operations are allowed',
+        }
+      }
+
+      return { action: 'accept' }
+    },
+  },
+})
+```

--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/execute-tool.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/execute-tool.mdx
@@ -38,6 +38,8 @@ Executes a supported tool by name and input.
 - `commentsOptions?` (`CommentsOptions`): Options for comment and thread operations. This allows passing custom data to comment and thread creation/update operations. The `data` property is used for thread data, while `commentData` is used for comment data.
   - `threadData?` (`Record<string, any>`): Extra metadata for the AI-generated threads that are created with the `editThreads` tool
   - `commentData?` (`Record<string, any>`): Extra metadata for the AI-generated comments that are created with the `editThreads` tool
+- `tiptapEditHooks?` (`TiptapEditHooks`): Hooks for intercepting and modifying Tiptap Edit operations. See the [Tiptap Edit hooks guide](/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks) for details.
+  - `beforeOperation?` (`(context: BeforeOperationContext) => BeforeOperationResult`): Called before each operation is applied. Return `{ action: 'accept' }` to apply unchanged, `{ action: 'modify', operation }` to apply a modified operation, or `{ action: 'reject', error }` to skip the operation.
 
 ### Returns (`ExecuteToolResult`)
 
@@ -92,6 +94,8 @@ This method has the same effect as calling the `executeTool` method, but it edit
 - `commentsOptions?` (`CommentsOptions`): Options for comment and thread operations. This allows passing custom data to comment and thread creation/update operations. The `data` property is used for thread data, while `commentData` is used for comment data.
   - `threadData?` (`Record<string, any>`): Extra metadata for the AI-generated threads that are created with the `editThreads` tool
   - `commentData?` (`Record<string, any>`): Extra metadata for the AI-generated comments that are created with the `editThreads` tool
+- `tiptapEditHooks?` (`TiptapEditHooks`): Hooks for intercepting and modifying Tiptap Edit operations. See the [Tiptap Edit hooks guide](/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks) for details.
+  - `beforeOperation?` (`(context: BeforeOperationContext) => BeforeOperationResult`): Called before each operation is applied. Return `{ action: 'accept' }` to apply unchanged, `{ action: 'modify', operation }` to apply a modified operation, or `{ action: 'reject', error }` to skip the operation.
 
 ### Returns (`StreamToolResult`)
 

--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/execute-tool.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/execute-tool.mdx
@@ -39,7 +39,7 @@ Executes a supported tool by name and input.
   - `threadData?` (`Record<string, any>`): Extra metadata for the AI-generated threads that are created with the `editThreads` tool
   - `commentData?` (`Record<string, any>`): Extra metadata for the AI-generated comments that are created with the `editThreads` tool
 - `tiptapEditHooks?` (`TiptapEditHooks`): Hooks for intercepting and modifying Tiptap Edit operations. See the [Tiptap Edit hooks guide](/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks) for details.
-  - `beforeOperation?` (`(context: BeforeOperationContext) => BeforeOperationResult`): Called before each operation is applied. Return `{ action: 'accept' }` to apply unchanged, `{ action: 'modify', operation }` to apply a modified operation, or `{ action: 'reject', error }` to skip the operation.
+  - `beforeOperation?` (`(context: BeforeOperationContext) => BeforeOperationResult`): Called before each operation is applied. Return `{ action: 'accept' }` to apply the operation (optionally with `fragment` or `operationType` overrides), or `{ action: 'reject', error }` to skip it.
 
 ### Returns (`ExecuteToolResult`)
 
@@ -95,7 +95,7 @@ This method has the same effect as calling the `executeTool` method, but it edit
   - `threadData?` (`Record<string, any>`): Extra metadata for the AI-generated threads that are created with the `editThreads` tool
   - `commentData?` (`Record<string, any>`): Extra metadata for the AI-generated comments that are created with the `editThreads` tool
 - `tiptapEditHooks?` (`TiptapEditHooks`): Hooks for intercepting and modifying Tiptap Edit operations. See the [Tiptap Edit hooks guide](/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks) for details.
-  - `beforeOperation?` (`(context: BeforeOperationContext) => BeforeOperationResult`): Called before each operation is applied. Return `{ action: 'accept' }` to apply unchanged, `{ action: 'modify', operation }` to apply a modified operation, or `{ action: 'reject', error }` to skip the operation.
+  - `beforeOperation?` (`(context: BeforeOperationContext) => BeforeOperationResult`): Called before each operation is applied. Return `{ action: 'accept' }` to apply the operation (optionally with `fragment` or `operationType` overrides), or `{ action: 'reject', error }` to skip it.
 
 ### Returns (`StreamToolResult`)
 

--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/workflows.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/workflows.mdx
@@ -224,6 +224,8 @@ Applies a list of edit operations to the document.
   - `workflowId` (`unknown`): Unique ID for this workflow run
   - `selectableNodeTypes?` (`string[]`): Array of node type names that should always have hashes, even if they are not top-level nodes. By default, all block node types can have hashes. If set to `[]`, only top-level nodes will have hashes.
   - `reviewOptions?` (`ReviewOptions`): Control preview/review behavior (same options as `proofreaderWorkflow`)
+  - `tiptapEditHooks?` (`TiptapEditHooks`): Hooks for intercepting and modifying operations. See the [Tiptap Edit hooks guide](/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks) for details.
+    - `beforeOperation?` (`(context: BeforeOperationContext) => BeforeOperationResult`): Called before each operation is applied. Return `{ action: 'accept' }` to apply unchanged, `{ action: 'modify', operation }` to apply a modified operation, or `{ action: 'reject', error }` to skip the operation.
 
 ### Returns (`TiptapEditWorkflowResult`)
 

--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/workflows.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/workflows.mdx
@@ -225,7 +225,7 @@ Applies a list of edit operations to the document.
   - `selectableNodeTypes?` (`string[]`): Array of node type names that should always have hashes, even if they are not top-level nodes. By default, all block node types can have hashes. If set to `[]`, only top-level nodes will have hashes.
   - `reviewOptions?` (`ReviewOptions`): Control preview/review behavior (same options as `proofreaderWorkflow`)
   - `tiptapEditHooks?` (`TiptapEditHooks`): Hooks for intercepting and modifying operations. See the [Tiptap Edit hooks guide](/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks) for details.
-    - `beforeOperation?` (`(context: BeforeOperationContext) => BeforeOperationResult`): Called before each operation is applied. Return `{ action: 'accept' }` to apply unchanged, `{ action: 'modify', operation }` to apply a modified operation, or `{ action: 'reject', error }` to skip the operation.
+    - `beforeOperation?` (`(context: BeforeOperationContext) => BeforeOperationResult`): Called before each operation is applied. Return `{ action: 'accept' }` to apply the operation (optionally with `fragment` or `operationType` overrides), or `{ action: 'reject', error }` to skip it.
 
 ### Returns (`TiptapEditWorkflowResult`)
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.63
+
+### Minor Changes
+
+- Add `tiptapEditHooks` option to `executeTool`, `streamTool`, and `tiptapEditWorkflow` methods. This allows intercepting, modifying, or rejecting Tiptap Edit operations before they are applied. The `beforeOperation` hook receives context about each operation (including the operation itself, editor instance, operation index, current document state, content being deleted/inserted, and position range) and can return `{ action: 'accept' }` to proceed unchanged, `{ action: 'modify', operation }` to apply a modified operation, or `{ action: 'reject', error }` to skip the operation. See the [Tiptap Edit hooks guide](/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks) for details.
+
 ## 3.0.0-alpha.62
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -12,7 +12,7 @@ meta:
 
 ### Minor Changes
 
-- Add `tiptapEditHooks` option to `executeTool`, `streamTool`, and `tiptapEditWorkflow` methods. This allows intercepting, modifying, or rejecting Tiptap Edit operations before they are applied. The `beforeOperation` hook receives context about each operation (including the operation itself, editor instance, operation index, current document state, content being deleted/inserted, and position range) and can return `{ action: 'accept' }` to proceed unchanged, `{ action: 'modify', operation }` to apply a modified operation, or `{ action: 'reject', error }` to skip the operation. See the [Tiptap Edit hooks guide](/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks) for details.
+- Add `tiptapEditHooks` option to `executeTool`, `streamTool`, and `tiptapEditWorkflow` methods. This allows intercepting, modifying, or rejecting Tiptap Edit operations before they are applied. The `beforeOperation` hook receives context about each operation (including the operation, operationIndex, current document, deleteContent, insertContent, and position range) and can return `{ action: 'accept' }` to apply the operation unchanged, `{ action: 'accept', fragment }` to apply with modified content, `{ action: 'accept', operationType }` to apply with a different operation type, or `{ action: 'reject', error }` to skip the operation and record an error. See the [Tiptap Edit hooks guide](/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks) for details.
 
 ## 3.0.0-alpha.62
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -12,7 +12,7 @@ meta:
 
 ### Minor Changes
 
-- Add `tiptapEditHooks` option to `executeTool`, `streamTool`, and `tiptapEditWorkflow` methods. This allows intercepting, modifying, or rejecting Tiptap Edit operations before they are applied. The `beforeOperation` hook receives context about each operation (including the operation, operationIndex, current document, deleteContent, insertContent, and position range) and can return `{ action: 'accept' }` to apply the operation unchanged, `{ action: 'accept', fragment }` to apply with modified content, `{ action: 'accept', operationType }` to apply with a different operation type, or `{ action: 'reject', error }` to skip the operation and record an error. See the [Tiptap Edit hooks guide](/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks) for details.
+- Add `tiptapEditHooks` option to `executeTool`, `streamTool`, and `tiptapEditWorkflow` methods. This allows intercepting, modifying, or rejecting Tiptap Edit operations before they are applied. The `beforeOperation` hook receives context about each operation and returns a `BeforeOperationResult` that controls whether and how the operation is applied. See the [Tiptap Edit hooks guide](/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks) for details on the context properties and return value shapes.
 
 ## 3.0.0-alpha.62
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -12,7 +12,7 @@ meta:
 
 ### Minor Changes
 
-- Add `tiptapEditHooks` option to `executeTool`, `streamTool`, and `tiptapEditWorkflow` methods. This allows intercepting, modifying, or rejecting Tiptap Edit operations before they are applied. The `beforeOperation` hook receives context about each operation and returns a `BeforeOperationResult` that controls whether and how the operation is applied. See the [Tiptap Edit hooks guide](/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks) for details on the context properties and return value shapes.
+- Add `tiptapEditHooks` option to `executeTool`, `streamTool`, and `tiptapEditWorkflow` methods. This allows intercepting, modifying, or rejecting Tiptap Edit operations before they are applied. The `beforeOperation` hook receives context about each operation and returns a `BeforeOperationResult` that controls whether and how the operation is applied.
 
 ## 3.0.0-alpha.62
 

--- a/src/content/content-ai/sidebar.ts
+++ b/src/content/content-ai/sidebar.ts
@@ -158,6 +158,10 @@ export const sidebarConfig: SidebarConfig = {
                   href: '/content-ai/capabilities/ai-toolkit/advanced-guides/compare-documents',
                 },
                 {
+                  title: 'Tiptap Edit hooks',
+                  href: '/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks',
+                },
+                {
                   title: 'Migration guides',
                   href: '/content-ai/capabilities/ai-toolkit/advanced-guides/migration-guides',
                   children: [


### PR DESCRIPTION
## Purpose

Documents the new tiptapEditHooks feature that allows developers to intercept, modify, or reject Tiptap Edit operations before they are applied.

## Changes

- Created new advanced guide: `tiptap-edit-hooks.mdx` covering:
  - Hook concept and use cases (validation, transformation, logging, access control)
  - BeforeOperationContext properties
  - BeforeOperationResult actions (accept/reject)
  - Code examples for common patterns
- Updated `execute-tool.mdx` API reference with tiptapEditHooks parameter
- Updated `workflows.mdx` API reference with tiptapEditHooks parameter
- Added changelog entry for the feature
- Updated sidebar navigation with new guide

## Related PRs

- Implementation: https://github.com/ueberdosis/tiptap-pro/pull/521

## Verification

- [x] Run `pnpm build` - builds successfully
- [x] Review new documentation page renders correctly
- [x] Verify sidebar navigation includes new guide