### PR TITLE
docs: create dedicated guide for React Composable API

### DIFF
--- a/src/content/editor/getting-started/install/react.mdx
+++ b/src/content/editor/getting-started/install/react.mdx
@@ -47,157 +47,22 @@ If you followed steps 1 and 2, you can now start your project with `npm run dev`
 
 ## Integrate Tiptap into your React app
 
-Tiptap provides a declarative `<Tiptap>` component that simplifies editor setup and provides context to all child components. This is the recommended approach for integrating Tiptap with React.
-
-### Using the Tiptap component
-
-Create a new component called `Editor` and add the following code in `src/Editor.tsx`:
-
-```tsx
-// src/Editor.tsx
-import { Tiptap, useEditor } from '@tiptap/react'
-import StarterKit from '@tiptap/starter-kit'
-
-function Editor() {
-  const editor = useEditor({
-    extensions: [StarterKit],
-    content: '<p>Hello World!</p>',
-  })
-
-  return (
-    <Tiptap instance={editor}>
-      <Tiptap.Loading>Loading editor...</Tiptap.Loading>
-      <MenuBar />
-      <Tiptap.Content />
-      <Tiptap.BubbleMenu>
-        <button>Bold</button>
-        <button>Italic</button>
-      </Tiptap.BubbleMenu>
-      <Tiptap.FloatingMenu>
-        <button>Add heading</button>
-      </Tiptap.FloatingMenu>
-    </Tiptap>
-  )
-}
-
-export default Editor
-```
-
-The `<Tiptap>` component provides several subcomponents:
-
-| Component | Description |
-| --- | --- |
-| `Tiptap.Content` | Renders the editor content area. Replaces `<EditorContent editor={editor} />`. |
-| `Tiptap.Loading` | Renders its children only while the editor is initializing. |
-| `Tiptap.BubbleMenu` | A context-aware bubble menu that appears on text selection. |
-| `Tiptap.FloatingMenu` | A context-aware floating menu that appears on empty lines. |
-
-### Add it to your app
-
-Replace the content of `src/App.tsx` with your new `Editor` component:
-
-```tsx
-import Editor from './Editor'
-
-function App() {
-  return (
-    <div className="card">
-      <Editor />
-    </div>
-  )
-}
-
-export default App
-```
-
-## Accessing the editor in child components
-
-The `<Tiptap>` component provides context that allows any child component to access the editor instance using the `useTiptap` hook.
-
-### Using useTiptap
-
-The `useTiptap` hook returns the editor instance and an `isReady` flag that indicates whether the editor has finished initializing.
-
-```tsx
-import { useTiptap } from '@tiptap/react'
-
-function MenuBar() {
-  const { editor, isReady } = useTiptap()
-
-  if (!isReady || !editor) {
-    return null
-  }
-
-  return (
-    <div className="menu-bar">
-      <button
-        onClick={() => editor.chain().focus().toggleBold().run()}
-        className={editor.isActive('bold') ? 'is-active' : ''}
-      >
-        Bold
-      </button>
-      <button
-        onClick={() => editor.chain().focus().toggleItalic().run()}
-        className={editor.isActive('italic') ? 'is-active' : ''}
-      >
-        Italic
-      </button>
-    </div>
-  )
-}
-```
-
-Then include the menu bar in your editor:
-
-```tsx
-<Tiptap instance={editor}>
-  <MenuBar />
-  <Tiptap.Content />
-</Tiptap>
-```
-
-### Using useTiptapState for reactive state
-
-For performance-sensitive components, use `useTiptapState` to subscribe to specific parts of the editor state. This prevents unnecessary re-renders when unrelated state changes.
-
-```tsx
-import { useTiptap, useTiptapState } from '@tiptap/react'
-
-function WordCount() {
-  const { isReady } = useTiptap()
-
-  const wordCount = useTiptapState((state) => {
-    const text = state.editor.state.doc.textContent
-    return text.split(/\s+/).filter(Boolean).length
-  })
-
-  if (!isReady) {
-    return null
-  }
-
-  return <span>{wordCount} words</span>
-}
-```
-
-The selector function receives an `EditorStateSnapshot` and should return only the data your component needs. The component will only re-render when the selected value changes.
-
-<Callout title="Important" variant="warning">
-  Only use `useTiptapState` when the editor is ready. Check `isReady` from `useTiptap()` before rendering components that use this hook.
+<Callout title="New: React Composable API" variant="hint">
+  Tiptap now offers a declarative `<Tiptap>` component with automatic context management and built-in subcomponents. Perfect for complex UIs with multiple child components. [Learn more →](/guides/react-composable-api)
 </Callout>
 
-## Alternative: Manual setup with EditorContent
+To start using Tiptap, create a new component. Let's call it `Tiptap` and add the following code in `src/Tiptap.tsx`:
 
-For cases where you need more control over the editor setup, you can use `EditorContent` directly:
-
-```tsx
+```jsx
+// src/Tiptap.tsx
 import { useEditor, EditorContent } from '@tiptap/react'
 import { FloatingMenu, BubbleMenu } from '@tiptap/react/menus'
 import StarterKit from '@tiptap/starter-kit'
 
-function Editor() {
+const Tiptap = () => {
   const editor = useEditor({
-    extensions: [StarterKit],
-    content: '<p>Hello World!</p>',
+    extensions: [StarterKit], // define your extension array
+    content: '<p>Hello World!</p>', // initial content
   })
 
   return (
@@ -209,130 +74,143 @@ function Editor() {
   )
 }
 
-export default Editor
+export default Tiptap
 ```
 
-This approach requires manually passing the `editor` prop to each component. The `<Tiptap>` component is preferred for most use cases as it reduces boilerplate and provides context automatically.
+### Add it to your app
+
+Finally, replace the content of `src/App.tsx` with our new `Tiptap` component.
+
+```jsx
+import Tiptap from './Tiptap'
+
+const App = () => {
+  return (
+    <div className="card">
+      <Tiptap />
+    </div>
+  )
+}
+
+export default App
+```
 
 ## Using the EditorContext
 
-The `<Tiptap>` component automatically provides the `EditorContext`, which means you can also use the `useCurrentEditor` hook inside it for backwards compatibility with existing code.
+Tiptap provides a React context called `EditorContext`, that allows you to access the editor instance and its state from anywhere in your component tree. This is particularly useful for building custom toolbars, menus, or other components that need to interact with the editor.
+
+```jsx
+// src/Tiptap.tsx
+import { useEditor, EditorContent, EditorContext } from '@tiptap/react'
+import { FloatingMenu, BubbleMenu } from '@tiptap/react/menus'
+import StarterKit from '@tiptap/starter-kit'
+import { useMemo } from 'react'
+
+const Tiptap = () => {
+  const editor = useEditor({
+    extensions: [StarterKit], // define your extension array
+    content: '<p>Hello World!</p>', // initial content
+  })
+
+  // Memoize the provider value to avoid unnecessary re-renders
+  const providerValue = useMemo(() => ({ editor }), [editor])
+
+  return (
+    <EditorContext.Provider value={providerValue}>
+      <EditorContent editor={editor} />
+      <FloatingMenu editor={editor}>This is the floating menu</FloatingMenu>
+      <BubbleMenu editor={editor}>This is the bubble menu</BubbleMenu>
+    </EditorContext.Provider>
+  )
+}
+
+export default Tiptap
+```
+
+### Consume the Editor context in child components
+
+If you use the `EditorProvider` to set up your Tiptap editor, you can now access your editor instance from any child component using the `useCurrentEditor` hook.
 
 ```tsx
 import { useCurrentEditor } from '@tiptap/react'
 
-function EditorJSONPreview() {
+const EditorJSONPreview = () => {
   const { editor } = useCurrentEditor()
-
-  if (!editor) {
-    return null
-  }
 
   return <pre>{JSON.stringify(editor.getJSON(), null, 2)}</pre>
 }
 ```
 
-For new code, prefer using `useTiptap()` which provides additional context like the `isReady` flag.
+**Important**: This won't work if you use the `useEditor` hook to setup your editor.
 
-## Reacting to editor state changes
+You should now see a pretty barebones example of Tiptap in your browser.
 
-To react to editor state changes without causing unnecessary re-renders, use the `useEditorState` hook:
+## Reacting to Editor state changes
 
-```tsx
+To react to editor state changes, you can use the `useEditorState` hook from `@tiptap/react`. This hook can be used to fetch information from the editor state without causing re-renders on the editor component or it's children.
+
+```jsx
 import { useEditorState } from '@tiptap/react'
 
-function EditorStateDisplay({ editor }) {
+function MyEditorComponent() {
+  // ... your editor setup code
+
   const editorState = useEditorState({
     editor,
+
+    // the selector function is used to select the state you want to react to
     selector: ({ editor }) => {
-      if (!editor) return null
+      if (!editor) return null;
 
       return {
         isEditable: editor.isEditable,
-        isBold: editor.isActive('bold'),
-        isItalic: editor.isActive('italic'),
-      }
+        currentSelection: editor.state.selection,
+        currentContent: editor.getJSON(),
+        // you can add more state properties here e.g.:
+        // isBold: editor.isActive('bold'),
+        // isItalic: editor.isActive('italic'),
+      };
     },
-  })
-
-  return <div>Bold active: {editorState?.isBold ? 'Yes' : 'No'}</div>
+  });
 }
 ```
 
-<Callout title="Tip" variant="hint">
-  When using the `<Tiptap>` component, prefer `useTiptapState` which automatically uses the editor from context.
-</Callout>
-
 ## Use SSR with React and Tiptap
 
-Tiptap can be used with server-side rendering (SSR) in React applications. To ensure that the editor is only initialized on the client side, use the `immediatelyRender` option:
+Tiptap can be used with server-side rendering (SSR) in React applications. However, to ensure that the editor is only initialized on the client side, you need to use the `immediatelyRender` option
+when creating the editor instance to prevent it from rendering on the server.
 
-```tsx
+Here is an example of how to set up Tiptap with SSR in a React component:
+
+```jsx
 'use client'
 
-import { Tiptap, useEditor } from '@tiptap/react'
+import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 
 export function MyEditor() {
   const editor = useEditor({
     extensions: [StarterKit],
     content: '<p>Hello World!</p>',
+    // Disable immediate rendering to prevent SSR issues
     immediatelyRender: false,
   })
 
-  return (
-    <Tiptap instance={editor}>
-      <Tiptap.Loading>
-        <div className="skeleton">Loading editor...</div>
-      </Tiptap.Loading>
-      <Tiptap.Content />
-    </Tiptap>
-  )
+  if (!editor) {
+    return null // Prevent rendering until the editor is initialized
+  }
+
+  return <EditorContent editor={editor} />
 }
 ```
-
-The `Tiptap.Loading` component is particularly useful with SSR as it displays a placeholder until the editor initializes on the client.
 
 ## Optimize your performance
 
 We recommend visiting the [React Performance Guide](/guides/performance) to integrate the Tiptap Editor efficiently. This will help you avoid potential issues as your app scales.
 
-## API Reference
+## Alternative: Composable React API
 
-### Tiptap component
-
-The root provider component that makes the editor instance available via React context.
-
-| Prop | Type | Description |
-| --- | --- | --- |
-| `instance` | `Editor \| null` | The editor instance from `useEditor()` |
-| `children` | `ReactNode` | Child components |
-
-### useTiptap hook
-
-Returns the Tiptap context value.
-
-```tsx
-const { editor, isReady } = useTiptap()
-```
-
-| Property | Type | Description |
-| --- | --- | --- |
-| `editor` | `Editor \| null` | The editor instance |
-| `isReady` | `boolean` | `true` when the editor has finished initializing |
-
-### useTiptapState hook
-
-Subscribes to a slice of the editor state using a selector function.
-
-```tsx
-const value = useTiptapState(selector, equalityFn?)
-```
-
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `selector` | `(state: EditorStateSnapshot) => T` | Function to select state |
-| `equalityFn` | `(a: T, b: T) => boolean` | Optional equality function to control re-renders |
+Tiptap also provides a declarative `<Tiptap>` component that simplifies editor setup with automatic context management and built-in subcomponents. This composable API is ideal for complex UIs with many child components. Learn more in the [React Composable API guide](/guides/react-composable-api).
 
 ## Next steps
 

--- a/src/content/guides/index.mdx
+++ b/src/content/guides/index.mdx
@@ -63,6 +63,21 @@ Tiptap Guides provide practical advice on configuring your editor, enhancing the
     </FilterGrid.Item>
     <FilterGrid.Item filter="Editor">
       <CardGrid.Item asChild>
+        <Link href="/guides/react-composable-api">
+          <CardGrid.Subtitle size="sm">React</CardGrid.Subtitle>
+          <div>
+            <CardGrid.ItemTitle>
+              Using Tiptap with the React Composable API
+            </CardGrid.ItemTitle>
+          </div>
+          <CardGrid.ItemFooter>
+            <Tag>Editor</Tag>
+          </CardGrid.ItemFooter>
+        </Link>
+      </CardGrid.Item>
+    </FilterGrid.Item>
+    <FilterGrid.Item filter="Editor">
+      <CardGrid.Item asChild>
         <Link href="/guides/invalid-schema">
           <CardGrid.Subtitle size="sm">Essential</CardGrid.Subtitle>
           <div>

--- a/src/content/guides/react-composable-api.mdx
+++ b/src/content/guides/react-composable-api.mdx
@@ -1,0 +1,296 @@
+---
+tags:
+  - type: editor
+title: Using Tiptap with the React Composable API
+meta:
+  title: React Composable API | Tiptap Editor Docs
+  description: Learn how to use Tiptap's composable React API with the declarative Tiptap component for a streamlined integration experience.
+  category: Editor
+---
+
+import { Callout } from '@/components/ui/Callout'
+
+Tiptap provides a declarative `<Tiptap>` component that simplifies editor setup and automatically provides context to all child components. This composable API is an alternative to the traditional `useEditor` + `<EditorContent />` approach, offering a more React-idiomatic way to work with Tiptap.
+
+## When to use the Composable API
+
+The composable API is ideal when you:
+
+- Want a more declarative, component-based approach
+- Need to access the editor from multiple child components
+- Prefer automatic context management over manual prop passing
+- Want built-in loading states and SSR-friendly patterns
+
+For simpler use cases or when you need more direct control, the traditional [useEditor approach](/editor/getting-started/install/react) may be more appropriate.
+
+## Installation
+
+Before using the composable API, make sure you have Tiptap installed in your React project. Follow the [React installation guide](/editor/getting-started/install/react) to set up the required dependencies.
+
+## Using the Tiptap component
+
+The `<Tiptap>` component is the root provider that makes the editor instance available to all child components via React context.
+
+### Basic setup
+
+Create a new component and import the `Tiptap` component along with `useEditor`:
+
+```tsx
+// src/Editor.tsx
+import { Tiptap, useEditor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+
+function Editor() {
+  const editor = useEditor({
+    extensions: [StarterKit],
+    content: '<p>Hello World!</p>',
+  })
+
+  return (
+    <Tiptap instance={editor}>
+      <Tiptap.Loading>Loading editor...</Tiptap.Loading>
+      <MenuBar />
+      <Tiptap.Content />
+      <Tiptap.BubbleMenu>
+        <button>Bold</button>
+        <button>Italic</button>
+      </Tiptap.BubbleMenu>
+      <Tiptap.FloatingMenu>
+        <button>Add heading</button>
+      </Tiptap.FloatingMenu>
+    </Tiptap>
+  )
+}
+
+export default Editor
+```
+
+### Available subcomponents
+
+The `<Tiptap>` component provides several subcomponents that handle common editor UI patterns:
+
+| Component | Description |
+| --- | --- |
+| `Tiptap.Content` | Renders the editor content area. Replaces `<EditorContent editor={editor} />`. |
+| `Tiptap.Loading` | Renders its children only while the editor is initializing. Useful for loading states. |
+| `Tiptap.BubbleMenu` | A context-aware bubble menu that appears on text selection. |
+| `Tiptap.FloatingMenu` | A context-aware floating menu that appears on empty lines. |
+
+## Accessing the editor in child components
+
+One of the main benefits of the composable API is that child components can access the editor without prop drilling.
+
+### Using the useTiptap hook
+
+The `useTiptap` hook returns the editor instance and an `isReady` flag that indicates whether the editor has finished initializing.
+
+```tsx
+import { useTiptap } from '@tiptap/react'
+
+function MenuBar() {
+  const { editor, isReady } = useTiptap()
+
+  if (!isReady || !editor) {
+    return null
+  }
+
+  return (
+    <div className="menu-bar">
+      <button
+        onClick={() => editor.chain().focus().toggleBold().run()}
+        className={editor.isActive('bold') ? 'is-active' : ''}
+      >
+        Bold
+      </button>
+      <button
+        onClick={() => editor.chain().focus().toggleItalic().run()}
+        className={editor.isActive('italic') ? 'is-active' : ''}
+      >
+        Italic
+      </button>
+    </div>
+  )
+}
+```
+
+Then include the menu bar anywhere inside your `<Tiptap>` component:
+
+```tsx
+<Tiptap instance={editor}>
+  <MenuBar />
+  <Tiptap.Content />
+</Tiptap>
+```
+
+### Using useTiptapState for reactive state
+
+For performance-sensitive components, use `useTiptapState` to subscribe to specific parts of the editor state. This prevents unnecessary re-renders when unrelated state changes.
+
+```tsx
+import { useTiptap, useTiptapState } from '@tiptap/react'
+
+function WordCount() {
+  const { isReady } = useTiptap()
+
+  const wordCount = useTiptapState((state) => {
+    const text = state.editor.state.doc.textContent
+    return text.split(/\s+/).filter(Boolean).length
+  })
+
+  if (!isReady) {
+    return null
+  }
+
+  return <span>{wordCount} words</span>
+}
+```
+
+The selector function receives an `EditorStateSnapshot` and should return only the data your component needs. The component will only re-render when the selected value changes.
+
+<Callout title="Important" variant="warning">
+  Only use `useTiptapState` when the editor is ready. Check `isReady` from `useTiptap()` before rendering components that use this hook.
+</Callout>
+
+## Server-side rendering (SSR)
+
+The composable API works seamlessly with server-side rendering. Use the `immediatelyRender` option to prevent the editor from rendering on the server, and leverage `Tiptap.Loading` to display a placeholder:
+
+```tsx
+'use client'
+
+import { Tiptap, useEditor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+
+export function MyEditor() {
+  const editor = useEditor({
+    extensions: [StarterKit],
+    content: '<p>Hello World!</p>',
+    immediatelyRender: false,
+  })
+
+  return (
+    <Tiptap instance={editor}>
+      <Tiptap.Loading>
+        <div className="skeleton">Loading editor...</div>
+      </Tiptap.Loading>
+      <Tiptap.Content />
+    </Tiptap>
+  )
+}
+```
+
+The `Tiptap.Loading` component is particularly useful with SSR as it displays a placeholder until the editor initializes on the client.
+
+## Performance considerations
+
+The composable API is designed with performance in mind:
+
+- **Automatic context optimization**: The editor context is memoized to prevent unnecessary re-renders
+- **Selective subscriptions**: Use `useTiptapState` to subscribe only to the state you need
+- **Built-in loading states**: Prevent rendering child components until the editor is ready
+
+For more performance tips, see the [React Performance Guide](/guides/performance).
+
+## Backwards compatibility
+
+The `<Tiptap>` component automatically provides the `EditorContext`, which means you can use the `useCurrentEditor` hook inside it for backwards compatibility with existing code:
+
+```tsx
+import { useCurrentEditor } from '@tiptap/react'
+
+function EditorJSONPreview() {
+  const { editor } = useCurrentEditor()
+
+  if (!editor) {
+    return null
+  }
+
+  return <pre>{JSON.stringify(editor.getJSON(), null, 2)}</pre>
+}
+```
+
+However, for new code, we recommend using `useTiptap()` which provides additional context like the `isReady` flag.
+
+## API Reference
+
+### Tiptap component
+
+The root provider component that makes the editor instance available via React context.
+
+**Props:**
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `instance` | `Editor \| null` | The editor instance from `useEditor()` |
+| `children` | `ReactNode` | Child components |
+
+**Example:**
+
+```tsx
+<Tiptap instance={editor}>
+  <Tiptap.Content />
+</Tiptap>
+```
+
+### useTiptap hook
+
+Returns the Tiptap context value.
+
+**Returns:**
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `editor` | `Editor \| null` | The editor instance |
+| `isReady` | `boolean` | `true` when the editor has finished initializing |
+
+**Example:**
+
+```tsx
+const { editor, isReady } = useTiptap()
+
+if (!isReady || !editor) {
+  return null
+}
+```
+
+### useTiptapState hook
+
+Subscribes to a slice of the editor state using a selector function.
+
+**Signature:**
+
+```tsx
+const value = useTiptapState(selector, equalityFn?)
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `selector` | `(state: EditorStateSnapshot) => T` | Function to select state |
+| `equalityFn` | `(a: T, b: T) => boolean` | Optional equality function to control re-renders |
+
+**Example:**
+
+```tsx
+const isBold = useTiptapState((state) => state.editor.isActive('bold'))
+```
+
+## Comparison: Composable API vs Traditional Approach
+
+| Feature | Composable API | Traditional Approach |
+| --- | --- | --- |
+| Setup complexity | Low - declarative components | Medium - manual prop passing |
+| Context management | Automatic | Manual via EditorContext.Provider |
+| Child component access | Easy via `useTiptap()` | Requires prop drilling or context |
+| Loading states | Built-in `Tiptap.Loading` | Manual implementation |
+| SSR support | Built-in with `Tiptap.Loading` | Requires manual null checks |
+| Performance | Optimized with `useTiptapState` | Optimized with `useEditorState` |
+| Best for | Complex UIs with many child components | Simple UIs or direct control needed |
+
+## Next steps
+
+- [Optimize your React integration](/guides/performance)
+- [Configure your editor](/editor/getting-started/configure)
+- [Add styles to your editor](/editor/getting-started/style-editor)
+- [Learn more about Tiptap concepts](/editor/core-concepts/introduction)

--- a/src/content/guides/react-composable-api.mdx
+++ b/src/content/guides/react-composable-api.mdx
@@ -10,7 +10,7 @@ meta:
 
 import { Callout } from '@/components/ui/Callout'
 
-Tiptap provides a declarative `<Tiptap>` component that simplifies editor setup and automatically provides context to all child components. This composable API is an alternative to the traditional `useEditor` + `<EditorContent />` approach, offering a more React-idiomatic way to work with Tiptap.
+Tiptap provides a declarative `<Tiptap>` component that simplifies editor setup and automatically provides context to all child components. This composable API is an alternative to the hook-based `useEditor` + `<EditorContent />` approach, offering a more React-idiomatic way to work with Tiptap.
 
 ## When to use the Composable API
 
@@ -21,7 +21,7 @@ The composable API is ideal when you:
 - Prefer automatic context management over manual prop passing
 - Want built-in loading states and SSR-friendly patterns
 
-For simpler use cases or when you need more direct control, the traditional [useEditor approach](/editor/getting-started/install/react) may be more appropriate.
+For simpler use cases or when you need more direct control, the [hook-based useEditor approach](/editor/getting-started/install/react) may be more appropriate.
 
 ## Installation
 
@@ -268,7 +268,7 @@ const value = useTiptapState(selector, equalityFn?)
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `selector` | `(state: EditorStateSnapshot) => T` | Function to select state |
-| `equalityFn` | `(a: T, b: T) => boolean` | Optional equality function to control re-renders |
+| `equalityFn` | `(a: T, b: T) => boolean` | Optional equality function to control re-renders. Defaults to `deepEqual` from `fast-equals` (deep value comparison). |
 
 **Example:**
 
@@ -276,9 +276,9 @@ const value = useTiptapState(selector, equalityFn?)
 const isBold = useTiptapState((state) => state.editor.isActive('bold'))
 ```
 
-## Comparison: Composable API vs Traditional Approach
+## Comparison: Composable API vs Hook-based Approach
 
-| Feature | Composable API | Traditional Approach |
+| Feature | Composable API | Hook-based Approach |
 | --- | --- | --- |
 | Setup complexity | Low - declarative components | Medium - manual prop passing |
 | Context management | Automatic | Manual via EditorContext.Provider |

--- a/src/content/guides/sidebar.ts
+++ b/src/content/guides/sidebar.ts
@@ -34,6 +34,10 @@ export const sidebarConfig: SidebarConfig = {
           title: 'Performance',
         },
         {
+          href: '/guides/react-composable-api',
+          title: 'React Composable API',
+        },
+        {
           href: '/guides/invalid-schema',
           title: 'Invalid schema handling',
         },


### PR DESCRIPTION
- Extract composable API documentation from React installation guide
- Create new standalone guide at /guides/react-composable-api
- Refocus React installation guide on traditional useEditor approach
- Add guide to guides index page and sidebar navigation
- Include callout in installation guide linking to new composable API guide

The React installation guide now emphasizes the useEditor + EditorContent approach as the primary method, while the new composable API guide provides comprehensive documentation for the declarative <Tiptap> component approach.