### PR TITLE
docs(ui-component): correct -p flag handling for custom paths

### DIFF
--- a/.changeset/yellow-pigs-swim.md
+++ b/.changeset/yellow-pigs-swim.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Fix `-p` flag handling for custom paths and bump CLI to v3.18.0

--- a/src/content/ui-components/getting-started/changelog.mdx
+++ b/src/content/ui-components/getting-started/changelog.mdx
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2026-02-03]
+
+- Update CLI version to 3.18.0. Fix `-p` flag for custom paths.
+
 ## [2026-01-15]
 
 ### Fixed


### PR DESCRIPTION
This PR is adding changelog to the UI Component section

- Bumps CLI version to `3.18.0`
- Fixes incorrect handling of the `-p` flag when using custom paths