### PR TITLE
chore: add fixed headers version to install docs

### DIFF
--- a/src/content/pages/getting-started/install.mdx
+++ b/src/content/pages/getting-started/install.mdx
@@ -31,7 +31,7 @@ Install and configure the Pages extension by following this guide.
 ## Install the Pages extension
 
 ```bash
-npm install @tiptap-pro/extension-pages@alpha
+npm install @tiptap-pro/extension-pages@1.0.0-alpha.16.2
 ```
 
 ## Integrating the Pages extensionis there


### PR DESCRIPTION
This pull request updates the installation instructions for the Pages extension to specify a particular version. This ensures users install the correct and stable version of the extension.

- Documentation update:
  * Changed the install command in `src/content/pages/getting-started/install.mdx` to use `@tiptap-pro/extension-pages@1.0.0-alpha.16.2` instead of the generic `@alpha` tag.