### PR TITLE
links are not styled #378

### DIFF
--- a/src/content/editor/extensions/custom-extensions/extend-existing.mdx
+++ b/src/content/editor/extensions/custom-extensions/extend-existing.mdx
@@ -318,7 +318,7 @@ This checks for `<strong>` and `<b>` tags, and any HTML tag with an inline style
 
 As you can see, you can optionally pass a `getAttrs` callback, to add more complex checks, for example for specific HTML attributes. The callback gets passed the HTML DOM node, except when checking for the `style` attribute, then it’s the value.
 
-You are wondering what’s that `&& null` doing? [ProseMirror expects `null` or `undefined` if the check is successful.](https://prosemirror.net/docs/ref/version/0.18.0.html#model.ParseRule.getAttrs)
+You are wondering what’s that `&& null` doing? [ProseMirror expects null or undefined if the check is successful.](https://prosemirror.net/docs/ref/version/0.18.0.html#model.ParseRule.getAttrs)
 
 [Pass `priority` to a rule](https://prosemirror.net/docs/ref/version/0.18.0.html#model.ParseRule.priority) to resolve conflicts with other extensions, for example if you build a custom extension which looks for paragraphs with a class attribute, but you already use the default paragraph extension.
 


### PR DESCRIPTION
FIX #378 

The text "ProseMirror expects null or undefined if the check is successful." is a link, but it has identical styles to the surrounding text so you can't tell: