### PR TITLE
Add .well-known/security.txt endpoint

### DIFF
--- a/src/app/.well-known/security.txt/route.ts
+++ b/src/app/.well-known/security.txt/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  // Calculate expiration date: one year from now
+  const expirationDate = new Date()
+  expirationDate.setFullYear(expirationDate.getFullYear() + 1)
+  
+  // Format as ISO 8601 string
+  const expires = expirationDate.toISOString()
+
+  const securityTxt = `Contact: mailto:security@tiptap.dev
+Expires: ${expires}
+Preferred-Languages: en
+Canonical: https://tiptap.dev/.well-known/security.txt
+Policy: https://github.com/ueberdosis/tiptap/blob/main/SECURITY.md
+`
+
+  return new NextResponse(securityTxt, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  })
+}


### PR DESCRIPTION
Adds a route for the security.txt file that automatically sets an expiration date one year in the future and provides security contact information. The goal is to provide the URL https://tiptap.dev/.well-known/security.txt as defined in the RFC (https://securitytxt.org/).