### PR TITLE
Add AI Toolkit alpha.66 changelog entry

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -7,6 +7,12 @@ meta:
 ---
 
 # @tiptap-pro/ai-toolkit
+## 3.0.0-alpha.66
+
+### Patch Changes
+
+- Make `smartInlineV2` diff mode handle elements that are neither inline nor block elements, like table cells.
+
 
 ## 3.0.0-alpha.65
 


### PR DESCRIPTION
## Summary
- add `3.0.0-alpha.66` entry to AI Toolkit docs changelog
- document the smartInlineV2 patch for elements that are neither inline nor block (for example table cells)
