### PR TITLE
AI Toolkit: add justified changes guide

### DIFF
--- a/.changeset/change-explanations.md
+++ b/.changeset/change-explanations.md
@@ -1,5 +1,0 @@
----
-'tiptap-docs': patch
----
-
-Add justified changes guide and update AI Toolkit changelogs.

--- a/.changeset/change-explanations.md
+++ b/.changeset/change-explanations.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Add justified changes guide and update AI Toolkit changelogs.

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/justified-changes.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/justified-changes.mdx
@@ -1,0 +1,109 @@
+---
+title: Justified changes
+meta:
+  title: Justified changes | Tiptap Content AI
+  description: Show AI-generated justifications for each change using floating tooltips.
+  category: Content AI
+---
+
+import { Callout } from '@/components/ui/Callout'
+import { CodeDemo } from '@/components/CodeDemo'
+
+<Callout title="Continuation from the review changes guide" variant="info">
+  This guide continues the [review changes
+  guide](/content-ai/capabilities/ai-toolkit/agents/review-changes). Read it first.
+</Callout>
+
+The AI Toolkit can instruct the AI to include justifications for each change it makes to the document. This allows you to show users *why* a change was made, not just *what* changed.
+
+<CodeDemo path="" isScrollable src="https://ai-toolkit-demos.vercel.app/justified-changes" />
+
+See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
+
+## Enable justified changes
+
+To enable justified changes, pass the `operationMeta` option to `toolDefinitions()` on the server. The string you provide becomes the description of the `meta` field in the tool schema, which the AI uses to understand what kind of justification to provide.
+
+```ts
+// api/route.ts
+const agent = new ToolLoopAgent({
+  model,
+  instructions: '...',
+  tools: toolDefinitions({
+    operationMeta: 'Brief explanation of why this change improves the text',
+  }),
+})
+```
+
+## Show justifications as tooltips
+
+When a suggestion is selected, you can display the justification as a tooltip using the [Floating UI](https://floating-ui.com/) library.
+
+### Install Floating UI
+
+```bash
+npm install @floating-ui/dom
+```
+
+### Access the justification in `renderDecorations`
+
+The justification is available in `suggestion.metadata?.operationMeta`. Use the `isSelected` option to only show the tooltip when the suggestion is focused.
+
+```tsx
+import { computePosition, flip, offset, shift } from '@floating-ui/dom'
+
+const result = toolkit.executeTool({
+  toolName,
+  input,
+  reviewOptions: {
+    mode: 'preview',
+    displayOptions: {
+      renderDecorations(options) {
+        const decorations = [...options.defaultRenderDecorations()]
+
+        // Add Accept and Reject buttons (same as the review changes guide)
+        // ...
+
+        // Show tooltip when selected and justification exists
+        const justification = options.suggestion.metadata?.operationMeta
+        if (options.isSelected && justification) {
+          decorations.push(
+            Decoration.widget(options.range.to, () => {
+              const container = document.createElement('span')
+              container.style.position = 'relative'
+
+              const tooltip = document.createElement('div')
+              tooltip.textContent = justification as string
+              tooltip.style.cssText =
+                'position:absolute;background:white;color:#1f2937;padding:8px 12px;border-radius:8px;border:1px solid #e5e7eb;font-size:13px;max-width:400px;width:max-content;z-index:50;pointer-events:none;box-shadow:0 4px 12px rgba(0,0,0,0.08),0 1px 3px rgba(0,0,0,0.06);'
+              container.appendChild(tooltip)
+
+              requestAnimationFrame(() => {
+                computePosition(container, tooltip, {
+                  placement: 'top',
+                  middleware: [offset(8), flip(), shift({ padding: 8 })],
+                }).then(({ x, y }) => {
+                  tooltip.style.left = `${x}px`
+                  tooltip.style.top = `${y}px`
+                })
+              })
+
+              return container
+            }),
+          )
+        }
+
+        return decorations
+      },
+    },
+  },
+})
+```
+
+## End result
+
+With these changes, AI-generated suggestions include floating tooltips that explain the rationale behind each change:
+
+<CodeDemo path="" isScrollable src="https://ai-toolkit-demos.vercel.app/justified-changes" />
+
+See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 3.0.0-alpha.32
+
+### Patch Changes
+
+- Reference the correct `@tiptap-pro/ai-toolkit-tool-definitions@3.0.0-alpha.30` dependency version.
+
+## 3.0.0-alpha.31
+
+### Minor Changes
+
+- Add `operationMeta` option to `toolDefinitions()` and `tiptapEditTool()`. When set, the AI includes a `meta` field in each edit operation with an explanation of why the change was made.
+
 ## 3.0.0-alpha.30
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 3.0.0-alpha.31
+
+### Minor Changes
+
+- Add `operationMeta` option to `toolDefinitions()` and `tiptapEditTool()`. When set, the AI includes a `meta` field in each edit operation with an explanation of why the change was made.
+
 ## 3.0.0-alpha.30
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 3.0.0-alpha.21
+
+### Patch Changes
+
+- Reference the correct `@tiptap-pro/ai-toolkit-tool-definitions@3.0.0-alpha.30` dependency version.
+
+## 3.0.0-alpha.20
+
+### Minor Changes
+
+- Add `operationMeta` option to `toolDefinitions()` and `tiptapEditTool()`. When set, the AI includes a `meta` field in each edit operation with an explanation of why the change was made.
+
 ## 3.0.0-alpha.19
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 3.0.0-alpha.20
+
+### Minor Changes
+
+- Add `operationMeta` option to `toolDefinitions()` and `tiptapEditTool()`. When set, the AI includes a `meta` field in each edit operation with an explanation of why the change was made.
+
 ## 3.0.0-alpha.19
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 3.0.0-alpha.26
+
+### Patch Changes
+
+- Reference the correct `@tiptap-pro/ai-toolkit-tool-definitions@3.0.0-alpha.30` dependency version.
+
+## 3.0.0-alpha.25
+
+### Minor Changes
+
+- Add `operationMeta` option to `toolDefinitions()` and `tiptapEditTool()`. When set, the AI includes a `meta` field in each edit operation with an explanation of why the change was made.
+
 ## 3.0.0-alpha.24
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 3.0.0-alpha.25
+
+### Minor Changes
+
+- Add `operationMeta` option to `toolDefinitions()` and `tiptapEditTool()`. When set, the AI includes a `meta` field in each edit operation with an explanation of why the change was made.
+
 ## 3.0.0-alpha.24
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 3.0.0-alpha.24
+
+### Minor Changes
+
+- Add `operationMeta` option to `toolDefinitions()` and `tiptapEditTool()`. When set, the AI includes a `meta` field in each edit operation with an explanation of why the change was made.
+
 ## 3.0.0-alpha.23
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 3.0.0-alpha.25
+
+### Patch Changes
+
+- Reference the correct `@tiptap-pro/ai-toolkit-tool-definitions@3.0.0-alpha.30` dependency version.
+
+## 3.0.0-alpha.24
+
+### Minor Changes
+
+- Add `operationMeta` option to `toolDefinitions()` and `tiptapEditTool()`. When set, the AI includes a `meta` field in each edit operation with an explanation of why the change was made.
+
 ## 3.0.0-alpha.23
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 3.0.0-alpha.30
+
+### Minor Changes
+
+- Add `operationMeta` option to `toolDefinitions()` and `tiptapEditTool()`. When set, the AI includes a `meta` field in each edit operation with an explanation of why the change was made.
+
 ## 3.0.0-alpha.29
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.70
+
+### Minor Changes
+
+- Add `operationMeta` option to `toolDefinitions()` and `tiptapEditTool()`. When set, the AI includes a `meta` field in each edit operation with an explanation of why the change was made.
+
 ## 3.0.0-alpha.69
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.71
+
+### Patch Changes
+
+- Fix empty paragraphs within a suggestion range not being visually marked.
+
 ## 3.0.0-alpha.70
 
 ### Minor Changes

--- a/src/content/content-ai/sidebar.ts
+++ b/src/content/content-ai/sidebar.ts
@@ -52,6 +52,10 @@ export const sidebarConfig: SidebarConfig = {
                   href: '/content-ai/capabilities/ai-toolkit/agents/review-changes',
                 },
                 {
+                  title: 'Justified changes',
+                  href: '/content-ai/capabilities/ai-toolkit/agents/justified-changes',
+                },
+                {
                   title: 'Review as summary',
                   href: '/content-ai/capabilities/ai-toolkit/agents/review-changes-as-summary',
                 },


### PR DESCRIPTION
## Summary

- Add a new "Justified changes" guide in the AI Toolkit Agents section, explaining how to enable `operationMeta` and display change justifications as floating tooltips
- Update all 6 AI Toolkit changelog pages with the new alpha version entries
- Add sidebar navigation entry after "Review changes"

## Test plan

- [ ] Verify the guide page renders at `/content-ai/capabilities/ai-toolkit/agents/justified-changes`
- [ ] Verify the sidebar shows "Justified changes" link after "Review changes"
- [ ] Verify all 6 changelog pages have the new version entries at the top
- [ ] Run `pnpm build` successfully