### PR TITLE
Added information to the docs about inline vs document mode

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot.mdx
@@ -119,6 +119,15 @@ Get your App ID and secret key on the [Server AI Toolkit settings](https://cloud
   track the document state across tool executions.
 </Callout>
 
+<Callout title="Document mode simplification" variant="info">
+  The Server AI Toolkit now supports **document mode**, where the server automatically fetches and
+  saves documents from the Document Server. This eliminates the need for the `getDocument`
+  and `updateDocument` helper functions shown below. See the
+  [comments guide](/content-ai/capabilities/server-ai-toolkit/agents/comments) for the simplified approach.
+
+  The tutorial below shows the **inline mode** approach where you manage document state yourself.
+</Callout>
+
 ### Helper functions
 
 Create helper functions to interact with the Server AI Toolkit API:
@@ -140,7 +149,11 @@ export function getTiptapCloudAiJwtToken(): string {
     throw new Error('TIPTAP_CLOUD_AI_SECRET environment variable is not set')
   }
 
-  const payload = {}
+  const payload = {
+    // Optional: Include these claims to enable document mode
+    // experimental_document_app_id: process.env.TIPTAP_CLOUD_APP_ID,
+    // experimental_document_secret: process.env.TIPTAP_CLOUD_DOCUMENT_MANAGEMENT_API_SECRET,
+  }
 
   return jwt.sign(payload, secret, { expiresIn: '1h' })
 }

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot.mdx
@@ -119,13 +119,13 @@ Get your App ID and secret key on the [Server AI Toolkit settings](https://cloud
   track the document state across tool executions.
 </Callout>
 
-<Callout title="Document mode simplification" variant="info">
-  The Server AI Toolkit now supports **document mode**, where the server automatically fetches and
-  saves documents from the Document Server. This eliminates the need for the `getDocument`
-  and `updateDocument` helper functions shown below. See the
-  [comments guide](/content-ai/capabilities/server-ai-toolkit/agents/comments) for the simplified approach.
+<Callout title="Approach with Tiptap Cloud documents" variant="info">
+  The Server AI Toolkit can now fetch and save Tiptap Cloud documents automatically when you
+  provide a `documentId` via `experimental_documentOptions`. This eliminates the need for the
+  `getDocument` and `updateDocument` helper functions shown below. See the
+  [comments guide](/content-ai/capabilities/server-ai-toolkit/agents/comments).
 
-  The tutorial below shows the **inline mode** approach where you manage document state yourself.
+  The tutorial below shows how to provide and manage the document yourself.
 </Callout>
 
 ### Helper functions
@@ -150,7 +150,7 @@ export function getTiptapCloudAiJwtToken(): string {
   }
 
   const payload = {
-    // Optional: Include these claims to enable document mode
+    // Optional: Include these claims to use Tiptap Cloud documents
     // experimental_document_app_id: process.env.TIPTAP_CLOUD_APP_ID,
     // experimental_document_secret: process.env.TIPTAP_CLOUD_DOCUMENT_MANAGEMENT_API_SECRET,
   }

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/comments.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/comments.mdx
@@ -54,19 +54,41 @@ const response = await fetch(`${apiBaseUrl}/toolkit/tools`, {
 
 ## Execute comment tools
 
-When executing comment tools, include the `experimental__commentsOptions` object in the request body. This object contains the configuration for connecting to the Tiptap Collaboration server and updating the collaborative document with the new comments.
+Comment tools require **document mode** because threads and comments are stored on the Tiptap Document Server. In document mode, you don't need to pass the `document` field — the server fetches and saves it automatically.
 
-- `documentId` (`string`): The ID of the document to create comments in.
-- `apiSecret` (`string`): The API secret for the Server AI Toolkit.
-- `userId` (`string`): The ID of the user creating comments.
-- `appId` (`string`, optional): The App ID for the Server AI Toolkit.
-- `baseUrl` (`string`, optional): The base URL for the Server AI Toolkit.
-- `threadData` (`Record<string, any>`, optional): Extra metadata of the AI-generated threads that are created with the `editThreads` tool. This metadata is attached to threads when they are created.
-- `commentData` (`Record<string, any>`, optional): Extra metadata of the AI-generated comments that are created with the `editThreads` tool. This metadata is attached to comments when they are created.
+### JWT requirements
 
-Either `appId` or `baseUrl` must be provided. If you are using Tiptap Cloud, use the `appId` property to connect to your deployment. If you deploy on your own infrastructure, use the `baseUrl` property to connect to the Tiptap Collaboration service.
+Your JWT must include Document Server credentials as claims:
+
+- `experimental_document_app_id` (`string`): The Tiptap Cloud app ID for the Document Server
+- `experimental_document_secret` (`string`): The admin API secret for the Document Server
+
+### Request body
+
+Include `experimental_documentOptions` in the request body:
+
+- `documentId` (`string`, required): The ID of the document
+- `userId` (`string`, optional): The ID of the user creating comments. If omitted, comments are created without user attribution.
+
+Optionally include `experimental_commentsOptions` for metadata:
+
+- `threadData` (`Record<string, any>`, optional): Metadata attached to new threads when they are created by the `editThreads` tool.
+- `commentData` (`Record<string, any>`, optional): Metadata attached to new comments when they are created by the `editThreads` tool.
 
 ```ts
+// JWT must include Document Server credentials
+import jwt from 'jsonwebtoken'
+
+const jwtToken = jwt.sign(
+  {
+    // Document Server credentials (required for comment tools)
+    experimental_document_app_id: 'your-document-app-id',
+    experimental_document_secret: 'your-document-api-secret',
+  },
+  TIPTAP_CLOUD_AI_SECRET,
+  { expiresIn: '1h' },
+)
+
 const result = await fetch(`${apiBaseUrl}/toolkit/execute-tool`, {
   method: 'POST',
   headers: {
@@ -77,14 +99,16 @@ const result = await fetch(`${apiBaseUrl}/toolkit/execute-tool`, {
   body: JSON.stringify({
     toolName: 'editThreads',
     input: {},
-    document,
     schemaAwarenessData,
-    // Required for comment tools
-    experimental__commentsOptions: {
+    // Required for comment tools (document mode)
+    experimental_documentOptions: {
       documentId: '123',
-      apiSecret: 'your-api-secret',
       userId: 'ai-assistant',
-      appId: 'your-app-id',
+    },
+    // Optional metadata
+    experimental_commentsOptions: {
+      threadData: { source: 'ai' },
+      commentData: { source: 'ai' },
     },
   }),
 })

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/comments.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/comments.mdx
@@ -54,7 +54,7 @@ const response = await fetch(`${apiBaseUrl}/toolkit/tools`, {
 
 ## Execute comment tools
 
-Comment tools require **document mode** because threads and comments are stored on the Tiptap Document Server. In document mode, you don't need to pass the `document` field — the server fetches and saves it automatically.
+Comment tools require a **Tiptap Cloud document** because threads and comments are stored on the Tiptap Document Server. You do **not** need to pass the `document` field when using `experimental_documentOptions` — the AI Server fetches it from the Document Server automatically.
 
 ### JWT requirements
 
@@ -100,7 +100,7 @@ const result = await fetch(`${apiBaseUrl}/toolkit/execute-tool`, {
     toolName: 'editThreads',
     input: {},
     schemaAwarenessData,
-    // Required for comment tools (document mode)
+    // Reference the Tiptap Cloud document
     experimental_documentOptions: {
       documentId: '123',
       userId: 'ai-assistant',

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/tools/index.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/tools/index.mdx
@@ -36,9 +36,10 @@ The tool uses an efficient format that allows making precise edits to the docume
 
 Retrieve all threads and comments in the document. This tool provides comprehensive information about existing discussions and feedback in the document.
 
-<Callout title="Requires document mode" variant="warning">
-  This tool requires `experimental_documentOptions` in the request body. It cannot be used with
-  inline mode because threads are stored on the Tiptap Document Server.
+<Callout title="Requires a Tiptap Cloud document" variant="warning">
+  This tool requires `experimental_documentOptions` in the request body because threads
+  are stored on the Tiptap Document Server. Pass a `documentId` referencing your
+  Tiptap Cloud document.
 </Callout>
 
 ### Parameters
@@ -53,9 +54,10 @@ The data of all the threads and comments in the document, including their conten
 
 Perform operations on threads and comments in the document. This tool enables comprehensive thread and comment management including creating, updating, and deleting threads and comments.
 
-<Callout title="Requires document mode" variant="warning">
-  This tool requires `experimental_documentOptions` in the request body. It cannot be used with
-  inline mode because threads are stored on the Tiptap Document Server.
+<Callout title="Requires a Tiptap Cloud document" variant="warning">
+  This tool requires `experimental_documentOptions` in the request body because threads
+  are stored on the Tiptap Document Server. Pass a `documentId` referencing your
+  Tiptap Cloud document.
 </Callout>
 
 ### Parameters

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/tools/index.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/tools/index.mdx
@@ -36,6 +36,11 @@ The tool uses an efficient format that allows making precise edits to the docume
 
 Retrieve all threads and comments in the document. This tool provides comprehensive information about existing discussions and feedback in the document.
 
+<Callout title="Requires document mode" variant="warning">
+  This tool requires `experimental_documentOptions` in the request body. It cannot be used with
+  inline mode because threads are stored on the Tiptap Document Server.
+</Callout>
+
 ### Parameters
 
 - `from` (`number`): The starting index of the thread to read from.
@@ -47,6 +52,11 @@ The data of all the threads and comments in the document, including their conten
 ## `editThreads`
 
 Perform operations on threads and comments in the document. This tool enables comprehensive thread and comment management including creating, updating, and deleting threads and comments.
+
+<Callout title="Requires document mode" variant="warning">
+  This tool requires `experimental_documentOptions` in the request body. It cannot be used with
+  inline mode because threads are stored on the Tiptap Document Server.
+</Callout>
 
 ### Parameters
 

--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
@@ -26,6 +26,15 @@ For production, always create JWTs **server-side** to keep your secret safe.
 --header 'X-App-Id: YOUR_APP_ID'
 ```
 
+### Document Server credentials (optional)
+
+To use document mode or comment tools, include Document Server credentials as JWT claims when generating your token:
+
+- `experimental_document_app_id`: Your Tiptap Cloud Document Server app ID
+- `experimental_document_secret`: Your Document Server admin API secret
+
+These credentials allow the AI Server to communicate with the Tiptap Document Server on your behalf.
+
 ## Base URL
 
 In the examples, `BASE_URL` is the base URL of the Tiptap Cloud AI service. The base URL of the Tiptap Cloud AI service is `https://api.tiptap.dev`. For on-premises deployments, this URL will be different.
@@ -103,6 +112,22 @@ Returns an object containing an array of tool definitions:
 
 Call this endpoint to execute a tool on a Tiptap document.
 
+### Inline mode vs Document mode
+
+The execute-tool endpoint supports two mutually exclusive modes:
+
+**Inline mode**: Pass the `document` field directly in the request body. The server processes it and returns the modified document in the response.
+
+**Document mode**: Pass `experimental_documentOptions` with a `documentId`. The server automatically fetches the document from the Tiptap Document Server, processes it, and saves changes back. This mode requires:
+1. JWT claims: `experimental_document_app_id` and `experimental_document_secret`
+2. The `experimental_documentOptions.documentId` field in the request body
+
+You must provide exactly one: either `document` or `experimental_documentOptions`.
+
+<Callout title="Thread tools require document mode" variant="info">
+  The `getThreads` and `editThreads` tools always require document mode (`experimental_documentOptions`).
+</Callout>
+
 ### Endpoint
 
 ```
@@ -110,6 +135,8 @@ POST /v3/ai/toolkit/execute-tool
 ```
 
 ### Request
+
+**Inline mode:**
 
 ```curl
 curl --location 'BASE_URL/v3/ai/toolkit/execute-tool' \
@@ -126,15 +153,43 @@ curl --location 'BASE_URL/v3/ai/toolkit/execute-tool' \
 }'
 ```
 
+**Document mode** (JWT must include `experimental_document_app_id` and `experimental_document_secret` claims):
+
+```curl
+curl --location 'BASE_URL/v3/ai/toolkit/execute-tool' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer YOUR_JWT_TOKEN' \
+--header 'X-App-Id: YOUR_APP_ID' \
+--data '{
+    "toolName": "tiptapRead",
+    "input": { /* tool input */ },
+    "experimental_documentOptions": {
+      "documentId": "your-document-id"
+    },
+    "schemaAwarenessData": { /* schema awareness data from getSchemaAwarenessData */ },
+    "chunkSize": 1000,
+    "format": "json"
+}'
+```
+
 ### Request body
 
 - `toolName` (`string`, required): The name of the tool to execute. Must be one of:
   - `"tiptapRead"`: Read part of the document using an efficient format
   - `"tiptapEdit"`: Edit the document using an efficient format
+  - `"getThreads"`: Retrieve all threads and comments in the document
+  - `"editThreads"`: Perform operations on threads and comments
 - `input` (`any`, required): The input parameters for the tool, as defined by the tool's input schema. The input format is optimized for efficient reading and editing operations.
-- `document` (`object`, required): The Tiptap JSON document to operate on
+- `document` (`object`, conditional): The Tiptap JSON document to operate on. Required when using **inline mode**. Mutually exclusive with `experimental_documentOptions`.
+- `experimental_documentOptions` (`object`, conditional): Configuration for **document mode**. Mutually exclusive with `document`. When provided, the server fetches and saves the document automatically from the Tiptap Document Server.
+  - `documentId` (`string`, required): The ID of the document on the Document Server
+  - `userId` (`string`, optional): User ID for attributing thread/comment authorship
+- `experimental_commentsOptions` (`object`, optional): Metadata for thread/comment operations.
+  - `threadData` (`Record<string, any>`, optional): Metadata attached to new threads
+  - `commentData` (`Record<string, any>`, optional): Metadata attached to new comments
 - `schemaAwarenessData` (`SchemaAwarenessData`, required): The schema awareness data obtained from `getSchemaAwarenessData`
 - `chunkSize?` (`number`, optional): The chunk size for reading operations. Default: `1000`
+- `tiptapEditSelectableNodes?` (`string[]`, optional): Custom selectable node types for tiptapEdit operations.
 - `format?` (`string`, optional): The format in which the AI reads and edits the document. Must be one of:
   - `"json"` (default): Standard JSON format
   - `"shorthand"`: Tiptap Shorthand format, which reduces AI token costs by up to 80% compared to standard JSON
@@ -196,7 +251,10 @@ Returns a prompt string that describes the document schema:
 
 If an error occurs, the API will return an error response with an appropriate HTTP status code:
 
-- `400 Bad Request`: Invalid request body or parameters
+- `400 Bad Request`: Invalid request body or parameters. This includes:
+  - Missing both `document` and `experimental_documentOptions` (or providing both)
+  - Using `getThreads`/`editThreads` without `experimental_documentOptions`
+  - Providing `experimental_documentOptions` without Document Server credentials in JWT (`missing_document_credentials`)
 - `401 Unauthorized`: Missing or invalid JWT token or App ID
 - `404 Not Found`: Tool not found
 - `500 Internal Server Error`: Server error during tool execution

--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
@@ -28,12 +28,12 @@ For production, always create JWTs **server-side** to keep your secret safe.
 
 ### Document Server credentials (optional)
 
-To use document mode or comment tools, include Document Server credentials as JWT claims when generating your token:
+To use Tiptap Cloud documents or comment tools, include Document Server credentials as JWT claims when generating your token:
 
 - `experimental_document_app_id`: Your Tiptap Cloud Document Server app ID
 - `experimental_document_secret`: Your Document Server admin API secret
 
-These credentials allow the AI Server to communicate with the Tiptap Document Server on your behalf.
+These credentials allow the AI Server to fetch and save documents from the Tiptap Document Server on your behalf.
 
 ## Base URL
 
@@ -112,20 +112,20 @@ Returns an object containing an array of tool definitions:
 
 Call this endpoint to execute a tool on a Tiptap document.
 
-### Inline mode vs Document mode
+### How to provide the document
 
-The execute-tool endpoint supports two mutually exclusive modes:
+There are two ways to provide the document to the execute-tool endpoint:
 
-**Inline mode**: Pass the `document` field directly in the request body. The server processes it and returns the modified document in the response.
+**Pass it directly** — Include the `document` field in the request body with your Tiptap JSON document. The server processes it and returns the modified document in the response.
 
-**Document mode**: Pass `experimental_documentOptions` with a `documentId`. The server automatically fetches the document from the Tiptap Document Server, processes it, and saves changes back. This mode requires:
+**Reference a Tiptap Cloud document** — Include `experimental_documentOptions` with a `documentId` instead of `document`. The server automatically fetches the document from the Tiptap Document Server, processes it, and saves changes back. This requires:
 1. JWT claims: `experimental_document_app_id` and `experimental_document_secret`
 2. The `experimental_documentOptions.documentId` field in the request body
 
-You must provide exactly one: either `document` or `experimental_documentOptions`.
+You must provide exactly one: either `document` or `experimental_documentOptions`. Providing both or neither will return a validation error.
 
-<Callout title="Thread tools require document mode" variant="info">
-  The `getThreads` and `editThreads` tools always require document mode (`experimental_documentOptions`).
+<Callout title="Thread tools require a Tiptap Cloud document" variant="info">
+  The `getThreads` and `editThreads` tools always require `experimental_documentOptions`.
 </Callout>
 
 ### Endpoint
@@ -136,7 +136,7 @@ POST /v3/ai/toolkit/execute-tool
 
 ### Request
 
-**Inline mode:**
+**Passing the document directly:**
 
 ```curl
 curl --location 'BASE_URL/v3/ai/toolkit/execute-tool' \
@@ -153,7 +153,7 @@ curl --location 'BASE_URL/v3/ai/toolkit/execute-tool' \
 }'
 ```
 
-**Document mode** (JWT must include `experimental_document_app_id` and `experimental_document_secret` claims):
+**Using a Tiptap Cloud document** (JWT must include `experimental_document_app_id` and `experimental_document_secret` claims):
 
 ```curl
 curl --location 'BASE_URL/v3/ai/toolkit/execute-tool' \
@@ -180,8 +180,8 @@ curl --location 'BASE_URL/v3/ai/toolkit/execute-tool' \
   - `"getThreads"`: Retrieve all threads and comments in the document
   - `"editThreads"`: Perform operations on threads and comments
 - `input` (`any`, required): The input parameters for the tool, as defined by the tool's input schema. The input format is optimized for efficient reading and editing operations.
-- `document` (`object`, conditional): The Tiptap JSON document to operate on. Required when using **inline mode**. Mutually exclusive with `experimental_documentOptions`.
-- `experimental_documentOptions` (`object`, conditional): Configuration for **document mode**. Mutually exclusive with `document`. When provided, the server fetches and saves the document automatically from the Tiptap Document Server.
+- `document` (`object`, conditional): The Tiptap JSON document to operate on. Pass this when providing your own document. Mutually exclusive with `experimental_documentOptions`.
+- `experimental_documentOptions` (`object`, conditional): Use this to reference a Tiptap Cloud document by ID. The server fetches and saves the document automatically. Mutually exclusive with `document`.
   - `documentId` (`string`, required): The ID of the document on the Document Server
   - `userId` (`string`, optional): User ID for attributing thread/comment authorship
 - `experimental_commentsOptions` (`object`, optional): Metadata for thread/comment operations.
@@ -258,3 +258,4 @@ If an error occurs, the API will return an error response with an appropriate HT
 - `401 Unauthorized`: Missing or invalid JWT token or App ID
 - `404 Not Found`: Tool not found
 - `500 Internal Server Error`: Server error during tool execution
+- `502 Bad Gateway`: Failed to communicate with the Document Server (`document_load_failed`, `document_save_failed`)

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,6 +8,23 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
+## AI Server — Document Mode
+
+### New features
+
+- **Document mode**: The `/v3/ai/toolkit/execute-tool` endpoint now supports server-managed documents. Pass `experimental_documentOptions` with a `documentId` instead of sending the document inline. The AI Server fetches and saves the document from/to the Tiptap Document Server automatically.
+- **New request field**: `experimental_documentOptions` with `documentId` (required) and `userId` (optional).
+- **New JWT claims**: `experimental_document_app_id` and `experimental_document_secret` for document mode authentication.
+
+### Breaking changes
+
+- **`experimental__commentsOptions` renamed** to `experimental_commentsOptions` (single underscore).
+- **Fields removed from `experimental_commentsOptions`**: `documentId`, `apiSecret`, `userId`, `appId`, `baseUrl`. These are no longer passed in the request body.
+- **`documentId` and `userId` moved** to the new `experimental_documentOptions` field.
+- **Document Server credentials moved to JWT**: `appId` and `apiSecret` are now provided as JWT claims (`experimental_document_app_id`, `experimental_document_secret`) instead of in the request body.
+- **Thread tools require `experimental_documentOptions`**: `getThreads` and `editThreads` now require `experimental_documentOptions` instead of `experimental__commentsOptions`.
+- **`createdBy` renamed to `userId`** in thread/comment output data.
+
 ## 3.0.0-alpha.4
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,23 +8,6 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
-## AI Server — Document Mode
-
-### New features
-
-- **Document mode**: The `/v3/ai/toolkit/execute-tool` endpoint now supports server-managed documents. Pass `experimental_documentOptions` with a `documentId` instead of sending the document inline. The AI Server fetches and saves the document from/to the Tiptap Document Server automatically.
-- **New request field**: `experimental_documentOptions` with `documentId` (required) and `userId` (optional).
-- **New JWT claims**: `experimental_document_app_id` and `experimental_document_secret` for document mode authentication.
-
-### Breaking changes
-
-- **`experimental__commentsOptions` renamed** to `experimental_commentsOptions` (single underscore).
-- **Fields removed from `experimental_commentsOptions`**: `documentId`, `apiSecret`, `userId`, `appId`, `baseUrl`. These are no longer passed in the request body.
-- **`documentId` and `userId` moved** to the new `experimental_documentOptions` field.
-- **Document Server credentials moved to JWT**: `appId` and `apiSecret` are now provided as JWT claims (`experimental_document_app_id`, `experimental_document_secret`) instead of in the request body.
-- **Thread tools require `experimental_documentOptions`**: `getThreads` and `editThreads` now require `experimental_documentOptions` instead of `experimental__commentsOptions`.
-- **`createdBy` renamed to `userId`** in thread/comment output data.
-
 ## 3.0.0-alpha.4
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/server-ai-toolkit/install.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/install.mdx
@@ -83,7 +83,7 @@ const TIPTAP_CLOUD_AI_APP_ID = 'your-app-id'
 // Generate JWT token from secret
 const JWT_TOKEN = jwt.sign(
   {
-    // Optional: include these for comment tools or server-managed documents mode
+    // Optional: include these for comment tools or Tiptap Cloud documents
     // experimental_document_app_id: 'your-document-app-id',
     // experimental_document_secret: 'your-document-api-secret',
   },
@@ -99,10 +99,10 @@ const headers = {
 }
 ```
 
-<Callout title="Document mode" variant="info">
-  To use document mode (server-managed documents or comment tools), include `experimental_document_app_id`
-  and `experimental_document_secret` as claims in your JWT. See the
-  [comments guide](/content-ai/capabilities/server-ai-toolkit/agents/comments) for details.
+<Callout title="Tiptap Cloud documents" variant="info">
+  To let the AI Server fetch and save documents from the Tiptap Document Server automatically,
+  include `experimental_document_app_id` and `experimental_document_secret` as claims in your JWT.
+  See the [comments guide](/content-ai/capabilities/server-ai-toolkit/agents/comments) for details.
 </Callout>
 
 ## Call API endpoints

--- a/src/content/content-ai/capabilities/server-ai-toolkit/install.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/install.mdx
@@ -81,7 +81,15 @@ const TIPTAP_CLOUD_AI_SECRET = 'your-secret-key'
 const TIPTAP_CLOUD_AI_APP_ID = 'your-app-id'
 
 // Generate JWT token from secret
-const JWT_TOKEN = jwt.sign({}, TIPTAP_CLOUD_AI_SECRET, { expiresIn: '1h' })
+const JWT_TOKEN = jwt.sign(
+  {
+    // Optional: include these for comment tools or server-managed documents mode
+    // experimental_document_app_id: 'your-document-app-id',
+    // experimental_document_secret: 'your-document-api-secret',
+  },
+  TIPTAP_CLOUD_AI_SECRET,
+  { expiresIn: '1h' },
+)
 
 // Request headers for the Server AI Toolkit API
 const headers = {
@@ -90,6 +98,12 @@ const headers = {
   'X-App-Id': TIPTAP_CLOUD_AI_APP_ID,
 }
 ```
+
+<Callout title="Document mode" variant="info">
+  To use document mode (server-managed documents or comment tools), include `experimental_document_app_id`
+  and `experimental_document_secret` as claims in your JWT. See the
+  [comments guide](/content-ai/capabilities/server-ai-toolkit/agents/comments) for details.
+</Callout>
 
 ## Call API endpoints
 

--- a/src/content/content-ai/capabilities/server-ai-toolkit/overview.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/overview.mdx
@@ -42,6 +42,8 @@ The Server AI Toolkit includes the building blocks for any custom AI functionali
 
 - **Tools** for building [AI agents](/content-ai/capabilities/server-ai-toolkit/agents) capable of complex tasks.
 - [**Workflows**](/content-ai/capabilities/ai-toolkit/workflows) where the AI has a single, well-defined task: insert content, proofread the document, and more.
+- **Inline mode** for passing documents directly in API requests.
+- **Document mode** for automatic document management via the Tiptap Document Server.
 
 <Callout title="Compatible with any AI model" variant="info">
   Use the Server AI Toolkit with any AI model capable of producing text, including open source and

--- a/src/content/content-ai/capabilities/server-ai-toolkit/overview.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/overview.mdx
@@ -42,8 +42,7 @@ The Server AI Toolkit includes the building blocks for any custom AI functionali
 
 - **Tools** for building [AI agents](/content-ai/capabilities/server-ai-toolkit/agents) capable of complex tasks.
 - [**Workflows**](/content-ai/capabilities/ai-toolkit/workflows) where the AI has a single, well-defined task: insert content, proofread the document, and more.
-- **Inline mode** for passing documents directly in API requests.
-- **Document mode** for automatic document management via the Tiptap Document Server.
+- Works with documents you provide directly or with **Tiptap Cloud documents** fetched automatically by ID.
 
 <Callout title="Compatible with any AI model" variant="info">
   Use the Server AI Toolkit with any AI model capable of producing text, including open source and


### PR DESCRIPTION
This pull request updates the documentation for the Server AI Toolkit to introduce and clarify support for "document mode," a new way for the server to automatically manage documents via the Tiptap Document Server. It also describes related breaking changes to API request structure, JWT authentication, and tool requirements, particularly for comment and thread tools. The changes aim to make the distinction between inline mode and document mode clear, update code samples and guides, and document new JWT claims and request fields.

**Key documentation updates:**

### Document mode introduction and usage

- Added explanations and callouts throughout the docs to introduce "document mode," where the server fetches and saves documents automatically, eliminating the need for manual document management in most cases. This includes updates to overviews, installation, and agent guides. [[1]](diffhunk://#diff-43fe6abe1d11a4a036af949cf3cee16be7a67305955e21d74e1810851a0fe6a5R122-R130) [[2]](diffhunk://#diff-539826124e24698e61818a46bfc39ab2aca860e6bd9ecffbbdffed9609005e49R45-R46) [[3]](diffhunk://#diff-673972c592675b39af12fe4dc297ae469fccbb9fd969bfd017c2c77487711931R102-R107)

- Updated JWT authentication instructions and code samples to show how to include Document Server credentials (`experimental_document_app_id` and `experimental_document_secret`) as claims for document mode. [[1]](diffhunk://#diff-c1b5f5275f1402ee63d383966568338bdda23c1b2b1cb077918f14b5ba0847e4R29-R37) [[2]](diffhunk://#diff-43fe6abe1d11a4a036af949cf3cee16be7a67305955e21d74e1810851a0fe6a5L143-R156) [[3]](diffhunk://#diff-673972c592675b39af12fe4dc297ae469fccbb9fd969bfd017c2c77487711931L84-R92)

### API and tool request structure changes

- Documented the new `experimental_documentOptions` request field for document mode, and clarified the mutual exclusivity with the inline `document` field. Updated all relevant examples and endpoint descriptions. [[1]](diffhunk://#diff-c1b5f5275f1402ee63d383966568338bdda23c1b2b1cb077918f14b5ba0847e4R115-R130) [[2]](diffhunk://#diff-c1b5f5275f1402ee63d383966568338bdda23c1b2b1cb077918f14b5ba0847e4R139-R140) [[3]](diffhunk://#diff-c1b5f5275f1402ee63d383966568338bdda23c1b2b1cb077918f14b5ba0847e4R156-R192)

- Updated error documentation to reflect new validation rules, such as requiring either `document` or `experimental_documentOptions`, and requiring document mode for thread/comment tools.

### Comment and thread tools requirements

- Updated the comments and thread tools documentation to require document mode, and clarified the necessary JWT claims and request body fields. Added callouts and revised code samples accordingly. [[1]](diffhunk://#diff-84ec582c90a1a0bc68e21c822fe819d927d3272bbcec0238e1a7c32dd86281e8L57-R91) [[2]](diffhunk://#diff-84ec582c90a1a0bc68e21c822fe819d927d3272bbcec0238e1a7c32dd86281e8L80-R111) [[3]](diffhunk://#diff-1cd812e867716ebbff070b456a8b6bde57fb1137505f832a97f46ee6c008f0bfR39-R43) [[4]](diffhunk://#diff-1cd812e867716ebbff070b456a8b6bde57fb1137505f832a97f46ee6c008f0bfR56-R60)

### Changelog and breaking changes

- Added a detailed changelog section listing all new features and breaking changes, including renaming and restructuring of request fields, and changes to how credentials and user IDs are provided.