### PR TITLE
Add ai-toolkit 3.0.0-alpha.72 changelog entry

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.72
+
+### Patch Changes
+
+- Fix browser compatibility issue with ES2025 Iterator Helpers (`Map.entries().filter()`, `.map()`) that caused `TypeError` in Safari < 18.4, Firefox < 131, and other browsers without Iterator Helpers support.
+
 ## 3.0.0-alpha.71
 
 ### Patch Changes


### PR DESCRIPTION
## Summary

- Add changelog entry for `@tiptap-pro/ai-toolkit` 3.0.0-alpha.72, which fixes a browser compatibility issue with ES2025 Iterator Helpers affecting Safari < 18.4, Firefox < 131, and other browsers.

## Test plan

- [x] Changelog format matches existing entries