### PR TITLE
Document optional context field in workflow guides and API reference

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/workflows.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/workflows.mdx
@@ -24,6 +24,7 @@ The workflow expects a user prompt as a JSON object with:
 
 - `content`: The content of the document to be proofread (see the client-side setup section on how to obtain it)
 - `task`: A string describing the task to complete
+- `context`: (Optional) Additional context or background information related to the task
 
 ### Returns
 
@@ -54,6 +55,7 @@ const result = streamText({
   prompt: JSON.stringify({
     content,
     task: 'Correct all grammar and spelling mistakes',
+    context: 'This is a formal business document',
   }),
   output: Output.object({ schema: workflow.zodOutputSchema }),
   // If you use gpt-5-mini, set the reasoning effort to minimal to improve the
@@ -183,6 +185,7 @@ The workflow expects a user prompt as a JSON object with:
 
 - `content`: The content of the document to be edited (obtained from `tiptapRead`)
 - `task`: A string describing the editing task to complete
+- `context`: (Optional) Additional context or background information related to the task
 
 ### Returns
 
@@ -206,7 +209,7 @@ const workflow = createTiptapEditWorkflow()
 const result = streamText({
   model: openai('gpt-5-mini'),
   system: workflow.systemPrompt,
-  prompt: JSON.stringify({ content, task }),
+  prompt: JSON.stringify({ content, task, context }),
   output: Output.object({ schema: workflow.zodOutputSchema }),
 })
 ```
@@ -365,6 +368,7 @@ Creates a ready-made workflow configuration for filling templates. Accepts an HT
 The workflow expects a user prompt as a JSON object with:
 
 - `task`: A string describing what content to generate for the template
+- `context`: (Optional) Additional context or background information related to the task
 
 ### Parameters
 
@@ -391,7 +395,7 @@ const workflow = createTemplateWorkflow({ htmlTemplate })
 const result = streamText({
   model: openai('gpt-5-mini'),
   system: workflow.systemPrompt,
-  prompt: JSON.stringify({ task }),
+  prompt: JSON.stringify({ task, context }),
   output: Output.object({ schema: workflow.zodOutputSchema }),
 })
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 3.0.0-alpha.33
+
+### Minor Changes
+
+- Add optional `context` field to the user prompt of `createProofreaderWorkflow`, `createTemplateWorkflow`, and `createTiptapEditWorkflow` workflows. This field allows developers to provide additional background information related to the task.
+
+## 3.0.0-alpha.32
+
+### Patch Changes
+
+- Clarify template workflow prompt to indicate that slot content replaces the entire slot element.
+
 ## 3.0.0-alpha.31
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/proofreader.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/proofreader.mdx
@@ -60,6 +60,7 @@ Additionally, you need include these two properties in the user message:
 
 - `content`: The content of the document to be proofread (see the client-side setup section on how to obtain it)
 - `task`: The task to be performed by the AI. For example, `Correct all grammar and spelling mistakes`.
+- `context`: (Optional) Additional context or background information related to the task.
 
 As the AI model generates its response, the API endpoint streams the suggestions to the client.
 
@@ -84,6 +85,7 @@ export async function POST(req: Request) {
     prompt: JSON.stringify({
       content,
       task: 'Correct all grammar and spelling mistakes',
+      context: 'This is a formal business document',
     }),
     output: Output.object({ schema: workflow.zodOutputSchema }),
     // If you use gpt-5-mini, set the reasoning effort to minimal to improve the

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/template.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/template.mdx
@@ -127,7 +127,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: openai('gpt-5-mini'),
     system: workflow.systemPrompt,
-    prompt: JSON.stringify({ task }),
+    prompt: JSON.stringify({ task, context: "Additional background information related to the task" }),
     output: Output.object({ schema: workflow.zodOutputSchema }),
   })
 

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit.mdx
@@ -60,6 +60,7 @@ Additionally, you need to include these two properties in the user message:
 
 - `content`: The content of the document to be edited (obtained from `tiptapRead`)
 - `task`: The task to be performed by the AI. For example, `Make the text more formal`.
+- `context`: (Optional) Additional context or background information related to the task.
 
 As the AI model generates its response, the API endpoint streams the operations to the client.
 
@@ -84,6 +85,7 @@ export async function POST(req: Request) {
     prompt: JSON.stringify({
       content,
       task,
+      context,
     }),
     output: Output.object({ schema: workflow.zodOutputSchema }),
     // If you use gpt-5-mini, set the reasoning effort to minimal to improve the


### PR DESCRIPTION
## Purpose

Documents the new optional `context` field added to the proofreader, template, and tiptap edit workflows in `@tiptap-pro/ai-toolkit-tool-definitions`.

## Changes

- Updated `workflows.mdx` API reference to list `context` in user prompt fields and code examples for all three server-side utilities
- Updated `proofreader.mdx` guide with `context` in the server setup bullet list and code example
- Updated `template.mdx` guide with `context` in the server setup code example
- Updated `tiptap-edit.mdx` guide with `context` in the server setup bullet list and code example
- Added changelog entries for `3.0.0-alpha.32` and `3.0.0-alpha.33`

## Related PRs

- Implementation: https://github.com/ueberdosis/tiptap-pro/pull/559

## Verification

- [ ] Verify all three workflow guide pages mention `context` in their server setup sections
- [ ] Verify the API reference lists `context` for all three server-side utilities
- [ ] Verify changelog entries are correct