### PR TITLE
Add ai-toolkit 3.0.0-alpha.74 changelog entry

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.74
+
+### Patch Changes
+
+- Fix suggestions not being removed when another user in a collaborative document deletes the content where the suggestion was placed.
+
 ## 3.0.0-alpha.73
 
 ### Minor Changes


### PR DESCRIPTION
## Summary

- Add changelog entry for `@tiptap-pro/ai-toolkit` 3.0.0-alpha.74.
- Fix: suggestions not being removed when another user in a collaborative document deletes the content where the suggestion was placed.

## Related

- https://github.com/ueberdosis/tiptap-pro/pull/560