### PR TITLE
Add review changes guide for Server AI Toolkit

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/review-changes.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/review-changes.mdx
@@ -1,0 +1,107 @@
+---
+title: Review changes
+meta:
+  title: Review Server AI Toolkit changes | Tiptap Content AI
+  description: Display a diff UI to review changes made by the Server AI Toolkit before applying them.
+  category: Content AI
+---
+
+import { Callout } from '@/components/ui/Callout'
+import { Requirements, RequirementItem } from '@/components/Requirements'
+
+<Requirements>
+  <RequirementItem label="1. Server AI Toolkit">
+    Set up the Server AI Toolkit by following the [AI agent chatbot
+    guide](/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot).
+  </RequirementItem>
+  <RequirementItem label="2. AI Toolkit extension">
+    Install the client-side [AI Toolkit extension](/content-ai/capabilities/ai-toolkit/install) in
+    your Tiptap editor.
+  </RequirementItem>
+</Requirements>
+
+After the Server AI Toolkit edits a document on the server, you can display a review UI on the client so users can accept or reject the changes before they are applied.
+
+This guide shows how to use the client-side AI Toolkit's `setSuggestions` method with the `compareDocuments` format to show a diff of the server-side changes.
+
+## How it works
+
+1. The Server AI Toolkit edits the document on the server and returns the updated document.
+2. On the client, you pass the updated document to the AI Toolkit's `setSuggestions` method using the `compareDocuments` format.
+3. The AI Toolkit compares the current editor document with the updated document and displays the differences as suggestions.
+4. Users can accept or reject individual changes, or accept/reject all changes at once.
+
+## Display the diff
+
+After receiving the updated document from the Server AI Toolkit, use `setSuggestions` to show the changes:
+
+```ts
+import { getAiToolkit } from '@tiptap-pro/ai-toolkit'
+import { Node } from '@tiptap/pm/model'
+
+// Get the AI Toolkit instance from the editor
+const toolkit = getAiToolkit(editor)
+
+// `doc` is the updated document returned by the Server AI Toolkit.
+// Convert it to a ProseMirror Node with the editor's schema.
+const otherDoc = Node.fromJSON(editor.state.schema, doc)
+
+// Display the diff
+toolkit.setSuggestions([
+  {
+    format: 'compareDocuments',
+    doc: otherDoc,
+  },
+])
+```
+
+<Callout title="Schema compatibility" variant="warning">
+  The document returned by the Server AI Toolkit must be converted to a ProseMirror `Node` using the
+  editor's schema. Use `Node.fromJSON(editor.state.schema, doc)` to ensure both documents share the
+  same schema.
+</Callout>
+
+The editor will now display the differences between the current document and the server-edited version, with deletions highlighted in red and insertions in green.
+
+## Style the diff
+
+Add CSS to style the suggestions as a red/green diff:
+
+```css
+/* Highlight deleted text in red */
+.tiptap-ai-suggestion,
+.tiptap-ai-suggestion > * {
+  background-color: oklch(80.8% 0.114 19.571);
+}
+
+/* Highlight inserted text in green */
+.tiptap-ai-suggestion-diff,
+.tiptap-ai-suggestion-diff > * {
+  background-color: oklch(87.1% 0.15 154.449);
+}
+```
+
+## Accept or reject changes
+
+Once the diff is displayed, users can accept or reject changes using the suggestion methods:
+
+```ts
+const toolkit = getAiToolkit(editor)
+
+// Accept all changes
+toolkit.acceptAllSuggestions()
+
+// Reject all changes
+toolkit.rejectAllSuggestions()
+
+// Or handle individual suggestions
+const suggestions = toolkit.getSuggestions()
+toolkit.acceptSuggestion(suggestions[0].id)
+toolkit.rejectSuggestion(suggestions[1].id)
+```
+
+## Next steps
+
+- Learn how to [style suggestions](/content-ai/capabilities/ai-toolkit/advanced-guides/style-suggestions) with custom CSS or React components
+- See the full [setSuggestions API reference](/content-ai/capabilities/ai-toolkit/api-reference/display-suggestions#setsuggestions--addsuggestions)
+- Explore the [Compare documents guide](/content-ai/capabilities/ai-toolkit/advanced-guides/compare-documents) for more advanced comparison options

--- a/src/content/content-ai/sidebar.ts
+++ b/src/content/content-ai/sidebar.ts
@@ -290,6 +290,10 @@ export const sidebarConfig: SidebarConfig = {
                   href: '/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot',
                 },
                 {
+                  title: 'Review changes',
+                  href: '/content-ai/capabilities/server-ai-toolkit/agents/review-changes',
+                },
+                {
                   title: 'Schema awareness',
                   href: '/content-ai/capabilities/server-ai-toolkit/agents/schema-awareness',
                 },


### PR DESCRIPTION
## Summary

- Add a new "Review changes" guide to the Server AI Toolkit Agents section explaining how to display a diff UI for reviewing server-side document edits
- The guide covers using the client-side AI Toolkit's `setSuggestions` method with the `compareDocuments` format to show changes, style the diff, and accept/reject modifications
- Update the sidebar navigation to include the new page

## Test plan

- [ ] Verify the new page renders correctly at `/content-ai/capabilities/server-ai-toolkit/agents/review-changes`
- [ ] Verify the sidebar navigation shows the new "Review changes" link under Server AI Toolkit > Agents
- [ ] Verify all internal links in the guide resolve correctly