### PR TITLE
Add AI Toolkit 3.0.0-alpha.77 changelog entry

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.77
+
+### Patch Changes
+
+- Fix bug where, when the user modified a document, the AI was not able to locate any content below the content that the user had modified, and was forced to read the document again.
+
 ## 3.0.0-alpha.76
 
 ### Patch Changes


### PR DESCRIPTION
## Summary
- add a new `3.0.0-alpha.77` patch section to the AI Toolkit changelog
- document the fix where document reads failed to locate content below user-modified areas
- keep the docs changelog aligned with the latest package release notes