### PR TITLE
Add AI Toolkit 3.0.0-alpha.78 changelog entry

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.78
+
+### Patch Changes
+
+- Reduce hash collision probability when identifying document nodes.
+
 ## 3.0.0-alpha.77
 
 ### Patch Changes


### PR DESCRIPTION
## Summary
- add the 3.0.0-alpha.78 section to the AI Toolkit changelog
- document the hash collision probability reduction for document node identification
- keep changelog ordering with newest release first