### PR TITLE
Align compare documents CSS snippet with style suggestions

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/compare-documents.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/compare-documents.mdx
@@ -49,9 +49,43 @@ The diff is displayed as [suggestions](/content-ai/capabilities/ai-toolkit/api-r
   background-color: oklch(87.1% 0.15 154.449);
 }
 
+/* Lighter background for change groups (sub-changes carry the stronger highlight) */
+.tiptap-ai-suggestion.tiptap-ai-suggestion--change-group,
+.tiptap-ai-suggestion.tiptap-ai-suggestion--change-group > *:not(.tiptap-ai-suggestion-sub-change) {
+  background-color: oklch(0.962 0.044 156.743);
+}
+
+/* Highlight sub-changes within inline groups */
+.tiptap-ai-suggestion.tiptap-ai-suggestion-sub-change {
+  background-color: oklch(87.1% 0.15 154.449);
+}
+
 /* Highlight deleted text in red */
 .tiptap-ai-suggestion-diff,
 .tiptap-ai-suggestion-diff > * {
+  background-color: oklch(80.8% 0.114 19.571);
+  color: oklch(0.396 0.141 25.723);
+}
+
+/* Lighter background for diff change groups (sub-changes carry the stronger highlight) */
+.tiptap-ai-suggestion-diff.tiptap-ai-suggestion-diff--change-group,
+.tiptap-ai-suggestion-diff.tiptap-ai-suggestion-diff--change-group
+  > *:not(.tiptap-ai-suggestion-diff-sub-change) {
+  background-color: oklch(0.936 0.032 17.717);
+}
+
+/* Highlight sub-changes within the replacement diff widget */
+.tiptap-ai-suggestion-diff-sub-change {
+  background-color: oklch(80.8% 0.114 19.571);
+}
+
+/* Render table row deletions correctly */
+.tiptap-ai-suggestion-diff:has(tr) {
+  display: contents;
+}
+
+.tiptap-ai-suggestion-diff:has(tr) td,
+.tiptap-ai-suggestion-diff:has(tr) th {
   background-color: oklch(80.8% 0.114 19.571);
 }
 ```


### PR DESCRIPTION
## Summary
- Sync the CSS example in the compare-documents guide with the canonical review-mode snippet from the style-suggestions guide.
- Add missing selectors for change groups and sub-changes on both suggestion and diff decorations.
- Include deleted-text color and table-row diff handling so compare-documents examples render consistently.