### PR TITLE
Update AI Toolkit changelog to 3.0.0-alpha.80

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.80
+
+### Patch Changes
+
+- Fix replacement sub-change marks spanning across node boundaries incorrectly.
+- Fix `simplifyChanges` incorrectly expanding changes across word boundaries. Changes adjacent to non-letter characters (like spaces or punctuation) are no longer absorbed into the change. Both the original and modified document are now checked when determining word boundaries.
+
 ## 3.0.0-alpha.79
 
 ### Patch Changes


### PR DESCRIPTION
## Summary

- Add changelog entry for `@tiptap-pro/ai-toolkit` version 3.0.0-alpha.80, including:
  - Fix for replacement sub-change marks spanning across node boundaries
  - Fix for `simplifyChanges` incorrectly expanding changes across word boundaries

## Test plan

- [ ] Verify changelog renders correctly on the docs site