### PR TITLE
Add tiptapReadChunks documentation

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/read-the-document.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/read-the-document.mdx
@@ -213,3 +213,34 @@ Used in the [Proofreader workflow](/content-ai/capabilities/ai-toolkit/workflows
 ### Returns (`TiptapReadResult`)
 
 - `content` (`string`): The content of the document in a format that allows the AI to make fast, efficient edits.
+
+## `tiptapReadChunks`
+
+Read the document in the Tiptap Read format, split into chunks for large-content processing.
+
+### Parameters
+
+- `options?` (`TiptapReadChunksOptions`): Options for the `tiptapReadChunks` method
+  - `chunkSize?` (`number`): Max characters per chunk. Defaults to 32,000 characters (8000 tokens \* 4 characters per token)
+  - `selectableNodeTypes?` (`string[]`): Array of node type names that the AI can select. By default, all block node types are seleectable. If set to `[]`, only top-level nodes can be selected
+
+### Returns
+
+`TiptapReadChunk[]`: Array of chunks, where each chunk contains:
+
+- `content` (`string`): HTML content in the Tiptap Read format
+- `range` (`Range`): The range in the document where the chunk starts and ends
+  - `from` (`number`): Start position in the document
+  - `to` (`number`): End position in the document
+- `nodeRange` (`NodeRange`): The node range where the chunk starts and ends
+  - `from` (`number`): Start node position in the document
+  - `to` (`number`): End node position in the document
+
+### Example
+
+```ts
+// Split the document into chunks
+const chunks = toolkit.tiptapReadChunks()
+// Split the document into smaller chunks
+const smallerChunks = toolkit.tiptapReadChunks({ chunkSize: 16000 })
+```

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.83
+
+### Minor Changes
+
+- Add `tiptapReadChunks` method
+
 ## 3.0.0-alpha.82
 
 ### Major Changes
@@ -86,6 +92,7 @@ meta:
 - Add `displayOptions.showSubChanges`, `displayOptions.subChangeAttributes`, and `displayOptions.replacementSubChangeAttributes` to customize grouped inline changes.
 - Add `isInlineGroup` to `Suggestion` for grouped inline changes.
 - In `proofreaderWorkflow`, inline changes are no longer grouped by default. Override with `reviewOptions.diffUtilityOptions.groupInlineChanges` when needed.
+
 ## 3.0.0-alpha.74
 
 ### Patch Changes


### PR DESCRIPTION
## Summary

- Add API reference documentation for the new `tiptapReadChunks` method in the "Read the document" page
- Add changelog entry for `3.0.0-alpha.83`

## Test plan

- [ ] Verify documentation renders correctly on the site