### PR TITLE
Add non-TypeScript backends guide for AI Toolkit

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends.mdx
@@ -10,15 +10,6 @@ import { Callout } from '@/components/ui/Callout'
 
 Use the AI Toolkit with any backend language. The `@tiptap-pro/ai-toolkit-tool-definitions` package includes a CLI that outputs tool definitions and workflow configurations as JSON, so you can use them in Python, Go, Ruby, or any other language.
 
-## Overview
-
-The AI Toolkit's server-side logic consists of two things:
-
-1. **Tool definitions** for AI agents: the name, description, and input schema for each tool.
-2. **Workflow configurations** for workflows: the system prompt and output schema that instruct the AI model.
-
-In TypeScript backends, you import these directly from the `@tiptap-pro/ai-toolkit-tool-definitions` package. For non-TypeScript backends, you use the CLI to generate JSON files, then load them in your backend.
-
 ## Setup
 
 Configure authentication for Tiptap's private npm registry. Follow the [private registry guide](/guides/pro-extensions) to set up your `.npmrc` file with your access token.
@@ -32,7 +23,7 @@ Configure authentication for Tiptap's private npm registry. Follow the [private 
 Run the CLI to generate a `tool-definitions.json` file with all default tools:
 
 ```bash
-npx @tiptap-pro/ai-toolkit-tool-definitions tool-definitions > tool-definitions.json
+npx @tiptap-pro/ai-toolkit-tool-definitions@latest tool-definitions > tool-definitions.json
 ```
 
 The output is a JSON array. Each entry contains:
@@ -46,7 +37,7 @@ The output is a JSON array. Each entry contains:
 Pass `--tools` to enable only the tools you need:
 
 ```bash
-npx @tiptap-pro/ai-toolkit-tool-definitions tool-definitions --tools tiptapRead tiptapEdit > tool-definitions.json
+npx @tiptap-pro/ai-toolkit-tool-definitions@latest tool-definitions --tools tiptapRead tiptapEdit > tool-definitions.json
 ```
 
 Available tool names: `tiptapRead`, `tiptapEdit`, `tiptapReadSelection`, `getThreads`, `editThreads`.
@@ -58,7 +49,7 @@ By default, `tiptapRead`, `tiptapEdit`, and `tiptapReadSelection` are enabled.
 Use `--operation-meta` to include a `meta` field in edit operations. The AI will use this field to explain why each change was made:
 
 ```bash
-npx @tiptap-pro/ai-toolkit-tool-definitions tool-definitions --operation-meta "Explanation of the change" > tool-definitions.json
+npx @tiptap-pro/ai-toolkit-tool-definitions@latest tool-definitions --operation-meta "Explanation of the change" > tool-definitions.json
 ```
 
 ### Use in your backend
@@ -92,7 +83,7 @@ Each workflow command outputs a JSON object with a `systemPrompt` (and optionall
 ### Insert content workflow
 
 ```bash
-npx @tiptap-pro/ai-toolkit-tool-definitions insert-content-workflow > insert-content-workflow.json
+npx @tiptap-pro/ai-toolkit-tool-definitions@latest insert-content-workflow > insert-content-workflow.json
 ```
 
 Output:
@@ -101,7 +92,7 @@ Output:
 ### Proofreader workflow
 
 ```bash
-npx @tiptap-pro/ai-toolkit-tool-definitions proofreader-workflow > proofreader-workflow.json
+npx @tiptap-pro/ai-toolkit-tool-definitions@latest proofreader-workflow > proofreader-workflow.json
 ```
 
 Output:
@@ -111,7 +102,7 @@ Output:
 ### Tiptap Edit workflow
 
 ```bash
-npx @tiptap-pro/ai-toolkit-tool-definitions tiptap-edit-workflow > tiptap-edit-workflow.json
+npx @tiptap-pro/ai-toolkit-tool-definitions@latest tiptap-edit-workflow > tiptap-edit-workflow.json
 ```
 
 Output:
@@ -121,7 +112,7 @@ Output:
 ### Comments workflow
 
 ```bash
-npx @tiptap-pro/ai-toolkit-tool-definitions edit-threads-workflow > edit-threads-workflow.json
+npx @tiptap-pro/ai-toolkit-tool-definitions@latest edit-threads-workflow > edit-threads-workflow.json
 ```
 
 Output:
@@ -133,7 +124,7 @@ Output:
 The template workflow requires an HTML template as input:
 
 ```bash
-npx @tiptap-pro/ai-toolkit-tool-definitions template-workflow --html-template '<p _templateslot="title">Title</p><p _templateslot="body">Body</p>' > template-workflow.json
+npx @tiptap-pro/ai-toolkit-tool-definitions@latest template-workflow --html-template '<p _templateslot="title">Title</p><p _templateslot="body">Body</p>' > template-workflow.json
 ```
 
 Output:
@@ -176,7 +167,7 @@ response = client.chat.completions.create(
 Generate tool definitions as JSON.
 
 ```bash
-npx @tiptap-pro/ai-toolkit-tool-definitions tool-definitions [options]
+npx @tiptap-pro/ai-toolkit-tool-definitions@latest tool-definitions [options]
 ```
 
 | Option | Description |
@@ -189,7 +180,7 @@ npx @tiptap-pro/ai-toolkit-tool-definitions tool-definitions [options]
 Generate the Tiptap Edit workflow configuration as JSON.
 
 ```bash
-npx @tiptap-pro/ai-toolkit-tool-definitions tiptap-edit-workflow [options]
+npx @tiptap-pro/ai-toolkit-tool-definitions@latest tiptap-edit-workflow [options]
 ```
 
 | Option | Description |
@@ -201,7 +192,7 @@ npx @tiptap-pro/ai-toolkit-tool-definitions tiptap-edit-workflow [options]
 Generate the Proofreader workflow configuration as JSON.
 
 ```bash
-npx @tiptap-pro/ai-toolkit-tool-definitions proofreader-workflow [options]
+npx @tiptap-pro/ai-toolkit-tool-definitions@latest proofreader-workflow [options]
 ```
 
 | Option | Description |
@@ -213,7 +204,7 @@ npx @tiptap-pro/ai-toolkit-tool-definitions proofreader-workflow [options]
 Generate the Template workflow configuration as JSON.
 
 ```bash
-npx @tiptap-pro/ai-toolkit-tool-definitions template-workflow --html-template <html>
+npx @tiptap-pro/ai-toolkit-tool-definitions@latest template-workflow --html-template <html>
 ```
 
 | Option | Description |
@@ -225,7 +216,7 @@ npx @tiptap-pro/ai-toolkit-tool-definitions template-workflow --html-template <h
 Generate the Comments workflow configuration as JSON.
 
 ```bash
-npx @tiptap-pro/ai-toolkit-tool-definitions edit-threads-workflow
+npx @tiptap-pro/ai-toolkit-tool-definitions@latest edit-threads-workflow
 ```
 
 No options.
@@ -235,7 +226,7 @@ No options.
 Generate the Insert content workflow configuration as JSON.
 
 ```bash
-npx @tiptap-pro/ai-toolkit-tool-definitions insert-content-workflow
+npx @tiptap-pro/ai-toolkit-tool-definitions@latest insert-content-workflow
 ```
 
 No options.

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends.mdx
@@ -32,26 +32,6 @@ The output is a JSON array. Each entry contains:
 - `description`: instructions for the AI model
 - `inputSchema`: [JSON Schema](https://json-schema.org/) describing the tool's input parameters
 
-### Select specific tools
-
-Pass `--tools` to enable only the tools you need:
-
-```bash
-npx @tiptap-pro/ai-toolkit-tool-definitions@latest tool-definitions --tools tiptapRead tiptapEdit > tool-definitions.json
-```
-
-Available tool names: `tiptapRead`, `tiptapEdit`, `tiptapReadSelection`, `getThreads`, `editThreads`.
-
-By default, `tiptapRead`, `tiptapEdit`, and `tiptapReadSelection` are enabled.
-
-### Add operation metadata
-
-Use `--operation-meta` to include a `meta` field in edit operations. The AI will use this field to explain why each change was made:
-
-```bash
-npx @tiptap-pro/ai-toolkit-tool-definitions@latest tool-definitions --operation-meta "Explanation of the change" > tool-definitions.json
-```
-
 ### Use in your backend
 
 Load the JSON file in your backend and convert the tool definitions to your AI provider's format. For example, in Python with the OpenAI SDK:

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends.mdx
@@ -1,0 +1,241 @@
+---
+title: Non-TypeScript backends
+meta:
+  title: Non-TypeScript backends | Tiptap Content AI
+  description: Use the AI Toolkit CLI to generate tool definitions and workflow configurations as JSON for non-TypeScript backends like Python, Go, or Ruby.
+  category: Content AI
+---
+
+import { Callout } from '@/components/ui/Callout'
+
+Use the AI Toolkit with any backend language. The `@tiptap-pro/ai-toolkit-tool-definitions` package includes a CLI that outputs tool definitions and workflow configurations as JSON, so you can use them in Python, Go, Ruby, or any other language.
+
+## Overview
+
+The AI Toolkit's server-side logic consists of two things:
+
+1. **Tool definitions** for AI agents: the name, description, and input schema for each tool.
+2. **Workflow configurations** for workflows: the system prompt and output schema that instruct the AI model.
+
+In TypeScript backends, you import these directly from the `@tiptap-pro/ai-toolkit-tool-definitions` package. For non-TypeScript backends, you use the CLI to generate JSON files, then load them in your backend.
+
+## Setup
+
+Configure authentication for Tiptap's private npm registry. Follow the [private registry guide](/guides/pro-extensions) to set up your `.npmrc` file with your access token.
+
+<Callout title="Node.js required" variant="hint">
+  The CLI requires Node.js 18 or later. You only need Node.js to run the CLI and generate the JSON files — your backend can use any language.
+</Callout>
+
+## Generate tool definitions
+
+Run the CLI to generate a `tool-definitions.json` file with all default tools:
+
+```bash
+npx @tiptap-pro/ai-toolkit-tool-definitions tool-definitions > tool-definitions.json
+```
+
+The output is a JSON array. Each entry contains:
+
+- `name`: unique identifier of the tool
+- `description`: instructions for the AI model
+- `inputSchema`: [JSON Schema](https://json-schema.org/) describing the tool's input parameters
+
+### Select specific tools
+
+Pass `--tools` to enable only the tools you need:
+
+```bash
+npx @tiptap-pro/ai-toolkit-tool-definitions tool-definitions --tools tiptapRead tiptapEdit > tool-definitions.json
+```
+
+Available tool names: `tiptapRead`, `tiptapEdit`, `tiptapReadSelection`, `getThreads`, `editThreads`.
+
+By default, `tiptapRead`, `tiptapEdit`, and `tiptapReadSelection` are enabled.
+
+### Add operation metadata
+
+Use `--operation-meta` to include a `meta` field in edit operations. The AI will use this field to explain why each change was made:
+
+```bash
+npx @tiptap-pro/ai-toolkit-tool-definitions tool-definitions --operation-meta "Explanation of the change" > tool-definitions.json
+```
+
+### Use in your backend
+
+Load the JSON file in your backend and convert the tool definitions to your AI provider's format. For example, in Python with the OpenAI SDK:
+
+```python
+import json
+
+with open("tool-definitions.json") as f:
+    tool_definitions = json.load(f)
+
+# Convert to OpenAI tool format
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": tool["name"],
+            "description": tool["description"],
+            "parameters": tool["inputSchema"],
+        },
+    }
+    for tool in tool_definitions
+]
+```
+
+## Generate workflow configurations
+
+Each workflow command outputs a JSON object with a `systemPrompt` (and optionally a `jsonOutputSchema`) that you pass to your AI provider.
+
+### Insert content workflow
+
+```bash
+npx @tiptap-pro/ai-toolkit-tool-definitions insert-content-workflow > insert-content-workflow.json
+```
+
+Output:
+- `systemPrompt`: instructions for the AI model
+
+### Proofreader workflow
+
+```bash
+npx @tiptap-pro/ai-toolkit-tool-definitions proofreader-workflow > proofreader-workflow.json
+```
+
+Output:
+- `systemPrompt`: instructions for the AI model
+- `jsonOutputSchema`: [JSON Schema](https://json-schema.org/) for validating the AI output
+
+### Tiptap Edit workflow
+
+```bash
+npx @tiptap-pro/ai-toolkit-tool-definitions tiptap-edit-workflow > tiptap-edit-workflow.json
+```
+
+Output:
+- `systemPrompt`: instructions for the AI model
+- `jsonOutputSchema`: [JSON Schema](https://json-schema.org/) for validating the AI output
+
+### Comments workflow
+
+```bash
+npx @tiptap-pro/ai-toolkit-tool-definitions edit-threads-workflow > edit-threads-workflow.json
+```
+
+Output:
+- `systemPrompt`: instructions for the AI model
+- `jsonOutputSchema`: [JSON Schema](https://json-schema.org/) for validating the AI output
+
+### Template workflow
+
+The template workflow requires an HTML template as input:
+
+```bash
+npx @tiptap-pro/ai-toolkit-tool-definitions template-workflow --html-template '<p _templateslot="title">Title</p><p _templateslot="body">Body</p>' > template-workflow.json
+```
+
+Output:
+- `systemPrompt`: instructions for the AI model (includes the template)
+- `jsonOutputSchema`: [JSON Schema](https://json-schema.org/) for validating the AI output
+
+### Use workflows in your backend
+
+Load the JSON file and pass the system prompt and schema to your AI provider. For example, in Python with the OpenAI SDK:
+
+```python
+import json
+
+with open("proofreader-workflow.json") as f:
+    workflow = json.load(f)
+
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[
+        {"role": "system", "content": workflow["systemPrompt"]},
+        {"role": "user", "content": json.dumps({
+            "content": "<p _hash='abc123'>Document content here</p>",
+            "task": "Correct all grammar and spelling mistakes",
+        })},
+    ],
+    response_format={
+        "type": "json_schema",
+        "json_schema": {
+            "name": "proofreader_output",
+            "schema": workflow["jsonOutputSchema"],
+        },
+    },
+)
+```
+
+## CLI reference
+
+### `tool-definitions`
+
+Generate tool definitions as JSON.
+
+```bash
+npx @tiptap-pro/ai-toolkit-tool-definitions tool-definitions [options]
+```
+
+| Option | Description |
+| --- | --- |
+| `--tools <names...>` | Space-separated list of tool names to enable. When omitted, the default set is used. Valid names: `tiptapRead`, `tiptapEdit`, `tiptapReadSelection`, `getThreads`, `editThreads`. |
+| `--operation-meta <description>` | Description for the `meta` field in edit operations. |
+
+### `tiptap-edit-workflow`
+
+Generate the Tiptap Edit workflow configuration as JSON.
+
+```bash
+npx @tiptap-pro/ai-toolkit-tool-definitions tiptap-edit-workflow [options]
+```
+
+| Option | Description |
+| --- | --- |
+| `--operation-meta <description>` | Description for the `meta` field in edit operations. |
+
+### `proofreader-workflow`
+
+Generate the Proofreader workflow configuration as JSON.
+
+```bash
+npx @tiptap-pro/ai-toolkit-tool-definitions proofreader-workflow [options]
+```
+
+| Option | Description |
+| --- | --- |
+| `--operation-meta <description>` | Description for the `meta` field in operations. |
+
+### `template-workflow`
+
+Generate the Template workflow configuration as JSON.
+
+```bash
+npx @tiptap-pro/ai-toolkit-tool-definitions template-workflow --html-template <html>
+```
+
+| Option | Description |
+| --- | --- |
+| `--html-template <html>` | **(Required)** The HTML template string. |
+
+### `edit-threads-workflow`
+
+Generate the Comments workflow configuration as JSON.
+
+```bash
+npx @tiptap-pro/ai-toolkit-tool-definitions edit-threads-workflow
+```
+
+No options.
+
+### `insert-content-workflow`
+
+Generate the Insert content workflow configuration as JSON.
+
+```bash
+npx @tiptap-pro/ai-toolkit-tool-definitions insert-content-workflow
+```
+
+No options.

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/ai-agent-chatbot.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/ai-agent-chatbot.mdx
@@ -63,7 +63,7 @@ npm install @tiptap-pro/ai-toolkit @tiptap-pro/ai-toolkit-ai-sdk
 
 ## API endpoint
 
-Create an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to call the OpenAI model. Include the [tool definitions](/content-ai/capabilities/ai-toolkit/tools/ai-sdk) for the Tiptap AI Toolkit.
+Create an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to call the OpenAI model. Include the [tool definitions](/content-ai/capabilities/ai-toolkit/tools/ai-sdk) for the Tiptap AI Toolkit. If your backend is not TypeScript, see [Non-TypeScript backends](/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends).
 
 ```ts
 // app/api/chat/route.ts

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/comments.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/comments.mdx
@@ -22,7 +22,7 @@ First, build a Tiptap Editor with comments by following the [comments guide](/co
 
 ## API endpoint
 
-Create an API endpoint that calls the AI model. In our example, we build the API endpoint with the [Next.js framework](https://nextjs.org/), and use the [AI SDK by Vercel](https://ai-sdk.dev/) to call the AI model.
+Create an API endpoint that calls the AI model. In our example, we build the API endpoint with the [Next.js framework](https://nextjs.org/), and use the [AI SDK by Vercel](https://ai-sdk.dev/) to call the AI model. If your backend is not TypeScript, see [Non-TypeScript backends](/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends).
 
 Provide the [tool definitions](/content-ai/capabilities/ai-toolkit/agents/tools/ai-sdk) for the Tiptap AI Toolkit. Enable the `getThreads` and `editThreads` tools so that the AI agent can read and edit comments in your document.
 

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/multi-document.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/multi-document.mdx
@@ -77,7 +77,7 @@ npm install @tiptap-pro/ai-toolkit @tiptap-pro/ai-toolkit-ai-sdk
 
 ## Server setup
 
-We'll define an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to call the OpenAI model.
+We'll define an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to call the OpenAI model. If your backend is not TypeScript, see [Non-TypeScript backends](/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends).
 
 Include the [tool definitions](/content-ai/capabilities/ai-toolkit/agents/tools/ai-sdk) for the Tiptap AI Toolkit (`...toolDefinitions()`), and combine them with the custom tools we'll define below:
 

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/tools/other-providers.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/tools/other-providers.mdx
@@ -8,27 +8,29 @@ meta:
 
 The Tiptap AI Toolkit provides tool definitions for the most popular AI provider libraries, like the [AI SDK by Vercel](https://ai-sdk.dev/). If your AI provider is not supported, [reach out to the Tiptap team](mailto:humans@tiptap.dev) with your request.
 
-Another option is to get all tool definitions as a JSON object and convert them to your AI provider's format. This can be useful if you've built your AI agent in another language (for example, Python) and you want to use the tool definitions from the Tiptap AI Toolkit.
-
-For a complete guide on using the AI Toolkit with non-TypeScript backends, including workflow configurations, see the [Non-TypeScript backends](/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends) guide.
+Another option is to get all tool definitions as a generic JSON object and convert them to your AI provider's format.
 
 ## Get tool definitions
 
-First, configure authentication for Tiptap's private npm registry. Follow the [private registry guide](/guides/pro-extensions) to set up your `.npmrc` file with your access token.
+Use the `toolDefinitions()` function from the `@tiptap-pro/ai-toolkit-tool-definitions` package to get the tool definitions in a generic format:
 
-Once authenticated, use the CLI to generate a JSON file with the tool definitions:
+```ts
+import { toolDefinitions } from '@tiptap-pro/ai-toolkit-tool-definitions'
 
-```bash
-npx @tiptap-pro/ai-toolkit-tool-definitions@latest tool-definitions > tool-definitions.json
+const tools = toolDefinitions()
 ```
 
-The command creates a `tool-definitions.json` file with the tool definitions. Each tool definition is an object with the following properties:
+Each tool definition is an object with the following properties:
 
 - `name`: The name of the tool. This is its unique identifier.
 - `description`: The description of the tool, to be read by the AI model.
-- `inputSchema`: A [JSON schema](https://json-schema.org/) describing the input parameters of the tool.
+- `inputSchema`: A [JSON Schema](https://json-schema.org/) describing the input parameters of the tool.
 
 Use this data to build the tool definitions in your AI provider's format.
+
+### Non-TypeScript backends
+
+If your backend is not TypeScript, you can use the CLI to generate a JSON file with the tool definitions. See the [Non-TypeScript backends](/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends) guide.
 
 ## API reference
 

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/tools/other-providers.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/tools/other-providers.mdx
@@ -10,24 +10,19 @@ The Tiptap AI Toolkit provides tool definitions for the most popular AI provider
 
 Another option is to get all tool definitions as a JSON object and convert them to your AI provider's format. This can be useful if you've built your AI agent in another language (for example, Python) and you want to use the tool definitions from the Tiptap AI Toolkit.
 
+For a complete guide on using the AI Toolkit with non-TypeScript backends, including workflow configurations, see the [Non-TypeScript backends](/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends) guide.
+
 ## Get tool definitions
 
 First, configure authentication for Tiptap's private npm registry. Follow the [private registry guide](/guides/pro-extensions) to set up your `.npmrc` file with your access token.
 
-Once authenticated, run this shell script in the directory where `.npmrc` is located:
+Once authenticated, use the CLI to generate a JSON file with the tool definitions:
 
 ```bash
-ORIG_DIR=$(pwd) && cd $(mktemp -d) && cp $ORIG_DIR/.npmrc . && \
-  npm init -y && \
-  npm install @tiptap-pro/ai-toolkit-tool-definitions && \
-  node --input-type=module -e \
-    "import {toolDefinitions} from '@tiptap-pro/ai-toolkit-tool-definitions'; \
-    console.log(JSON.stringify(toolDefinitions(), null, 2))" \
-  > "$ORIG_DIR/tool-definitions.json" && \
-  cd $ORIG_DIR
+npx @tiptap-pro/ai-toolkit-tool-definitions tool-definitions > tool-definitions.json
 ```
 
-The script creates a `tool-definitions.json` file with the tool definitions. Each tool definition is an object with the following properties:
+The command creates a `tool-definitions.json` file with the tool definitions. Each tool definition is an object with the following properties:
 
 - `name`: The name of the tool. This is its unique identifier.
 - `description`: The description of the tool, to be read by the AI model.

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/tools/other-providers.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/tools/other-providers.mdx
@@ -19,7 +19,7 @@ First, configure authentication for Tiptap's private npm registry. Follow the [p
 Once authenticated, use the CLI to generate a JSON file with the tool definitions:
 
 ```bash
-npx @tiptap-pro/ai-toolkit-tool-definitions tool-definitions > tool-definitions.json
+npx @tiptap-pro/ai-toolkit-tool-definitions@latest tool-definitions > tool-definitions.json
 ```
 
 The command creates a `tool-definitions.json` file with the tool definitions. Each tool definition is an object with the following properties:

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 3.0.0-alpha.34
+
+### Minor Changes
+
+- Add CLI utility. The package can now be used as a command-line tool via `npx @tiptap-pro/ai-toolkit-tool-definitions`. Available commands: `tool-definitions`, `tiptap-edit-workflow`, `proofreader-workflow`, `template-workflow`, `edit-threads-workflow`, and `insert-content-workflow`. Each command outputs JSON to stdout.
+
 ## 3.0.0-alpha.33
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/comments.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/comments.mdx
@@ -58,7 +58,7 @@ npm install @tiptap-pro/ai-toolkit @tiptap-pro/ai-toolkit-tool-definitions @tipt
 
 ## Server setup
 
-Create an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to call the Anthropic model.
+Create an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to call the Anthropic model. If your backend is not TypeScript, see [Non-TypeScript backends](/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends).
 
 Inside the API endpoint, create and configure the Comments workflow using the `createEditThreadsWorkflow` function. The workflow includes a ready-to-use system prompt that instructs the AI model on how to manage comments.
 

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/insert-content.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/insert-content.mdx
@@ -52,7 +52,7 @@ npm install @tiptap-pro/ai-toolkit @tiptap-pro/ai-toolkit-tool-definitions
 
 ## Server setup
 
-Create an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to call the OpenAI model.
+Create an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to call the OpenAI model. If your backend is not TypeScript, see [Non-TypeScript backends](/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends).
 
 Inside the API endpoint, create and configure the insert content workflow, using the `createInsertContentWorkflow` function. The workflow includes a ready-to-use system prompt that instructs the AI model on how to generate the content.
 

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/proofreader.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/proofreader.mdx
@@ -52,7 +52,7 @@ npm install @tiptap-pro/ai-toolkit @tiptap-pro/ai-toolkit-tool-definitions
 
 ## Server setup
 
-Create an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to call the OpenAI model.
+Create an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to call the OpenAI model. If your backend is not TypeScript, see [Non-TypeScript backends](/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends).
 
 Inside the API endpoint, create and configure the proofreader workflow, using the `createProofreaderWorkflow` function. The workflow includes a ready-to-use system prompt that instructs the AI model on how to generate the content.
 

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/template.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/template.mdx
@@ -107,7 +107,7 @@ npm install @tiptap-pro/ai-toolkit @tiptap-pro/ai-toolkit-tool-definitions
 
 ## Server setup
 
-Create an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to call the OpenAI model.
+Create an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to call the OpenAI model. If your backend is not TypeScript, see [Non-TypeScript backends](/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends).
 
 Inside the API endpoint, convert the HTML template to a workflow configuration using `createTemplateWorkflow`. The function auto-extracts all template keys from the HTML, generates the system prompt, and creates the output schema.
 

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit.mdx
@@ -52,7 +52,7 @@ npm install @tiptap-pro/ai-toolkit @tiptap-pro/ai-toolkit-tool-definitions
 
 ## Server setup
 
-Create an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to call the OpenAI model.
+Create an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to call the OpenAI model. If your backend is not TypeScript, see [Non-TypeScript backends](/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends).
 
 Inside the API endpoint, create and configure the Tiptap Edit workflow using the `createTiptapEditWorkflow` function. The workflow includes a ready-to-use system prompt that instructs the AI model on how to generate edit operations.
 

--- a/src/content/content-ai/sidebar.ts
+++ b/src/content/content-ai/sidebar.ts
@@ -174,6 +174,10 @@ export const sidebarConfig: SidebarConfig = {
                   href: '/content-ai/capabilities/ai-toolkit/advanced-guides/ai-caret',
                 },
                 {
+                  title: 'Non-TypeScript backends',
+                  href: '/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends',
+                },
+                {
                   title: 'Migration guides',
                   href: '/content-ai/capabilities/ai-toolkit/advanced-guides/migration-guides',
                   children: [


### PR DESCRIPTION
## Summary

- Add a new advanced guide explaining how to use the AI Toolkit with non-TypeScript backends (Python, Go, Ruby, etc.) using the new CLI in `@tiptap-pro/ai-toolkit-tool-definitions`
- Update the "Other providers" page to use the new CLI command instead of the old shell script
- Add a brief link to the non-TypeScript backends guide in all server setup / API endpoint sections across 8 pages (5 workflow guides + 3 agent guides)
- Update the tool-definitions changelog with the `3.0.0-alpha.34` entry

## Pages modified

| Page | Change |
|------|--------|
| `advanced-guides/non-typescript-backends.mdx` | **New** — full guide with CLI usage, examples, and CLI reference |
| `sidebar.ts` | Add navigation entry under Advanced guides |
| `agents/tools/other-providers.mdx` | Replace shell script with `npx` CLI command, add link to guide |
| `workflows/insert-content.mdx` | Add link to non-TypeScript backends guide |
| `workflows/proofreader.mdx` | Add link to non-TypeScript backends guide |
| `workflows/tiptap-edit.mdx` | Add link to non-TypeScript backends guide |
| `workflows/comments.mdx` | Add link to non-TypeScript backends guide |
| `workflows/template.mdx` | Add link to non-TypeScript backends guide |
| `agents/ai-agent-chatbot.mdx` | Add link to non-TypeScript backends guide |
| `agents/multi-document.mdx` | Add link to non-TypeScript backends guide |
| `agents/comments.mdx` | Add link to non-TypeScript backends guide |
| `changelog/ai-toolkit-tool-definitions.mdx` | Add 3.0.0-alpha.34 changelog entry |

## Test plan

- [x] `pnpm build` succeeds
- [ ] Verify the new page renders correctly at `/content-ai/capabilities/ai-toolkit/advanced-guides/non-typescript-backends`
- [ ] Verify sidebar navigation shows "Non-TypeScript backends" under Advanced guides
- [ ] Verify all cross-links work correctly