### PR TITLE
Add AI Toolkit 3.0.0-alpha.84 changelog entry

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.84
+
+### Patch Changes
+
+- Fix bug where changes would show up in completely different places of the document if `groupInlineChanges` was activated
+
 ## 3.0.0-alpha.83
 
 ### Minor Changes


### PR DESCRIPTION
## Summary

- Add changelog entry for `@tiptap-pro/ai-toolkit` version 3.0.0-alpha.84, documenting a patch fix for `groupInlineChanges` causing changes to appear in wrong positions in the document.

## Test plan

- [ ] Verify the changelog page renders correctly