### PR TITLE
Add AI Toolkit v3.0.0-alpha.86 changelog entry

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,16 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.86
+
+### Minor Changes
+
+- Add `expandBlockChanges` option to `diffUtility` and `ExternalDiffUtilityOptions`. When a matched node's type is in the provided list and all of its inline content has changed, the individual inline changes are replaced by a single block-level change spanning the whole node. Defaults to `['listItem']`. Only applies when mode is 'smart'.
+
+### Patch Changes
+
+- Fix crash in replacement decoration rendering when a diff change spans nodes that aren't valid as direct `doc` content (e.g. `listItem` nodes without a wrapping `bulletList`). The rendering now wraps the content in the required parent nodes before applying sub-change marks.
+
 ## 3.0.0-alpha.85
 
 ### Minor Changes


### PR DESCRIPTION
## Summary

- Add changelog entry for `@tiptap-pro/ai-toolkit` v3.0.0-alpha.86, documenting the new `expandBlockChanges` diff utility option and a fix for a crash when rendering replacement decorations for nodes not valid as direct `doc` content.

## Test plan

- [ ] Verify the changelog page renders correctly