### PR TITLE
Add invertSuggestions API reference and changelog entry

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/display-suggestions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/display-suggestions.mdx
@@ -383,3 +383,35 @@ toolkit.setMarkdownSuggestions({
   range: { from: 0, to: 500 },
 })
 ```
+
+## `invertSuggestions`
+
+Applies all current suggestions to a copy of the document and returns the resulting document along with inverted suggestions that would undo those changes. This is a dry-run operation — the editor document is not modified.
+
+For each original suggestion, the replacement is applied to produce the new document and an inverted suggestion is created. Accepting the inverted suggestion on the new document would revert the change. Preview mode suggestions become review mode in the inverted result, and vice versa. Each inverted suggestion preserves the id, metadata, and display options of the original.
+
+### Parameters
+
+- `options?` (`InvertSuggestionsOptions`): Optional configuration
+  - `schema?` (`Schema`): A target ProseMirror schema. When provided, the returned document and all suggestion replacement slices are translated to this schema. This is useful when the inverted result will be used in an editor whose schema differs from the current one.
+
+### Returns
+
+`InvertSuggestionsResult`
+
+Returns an object containing:
+
+- `doc` (`Node`): The document after applying all suggestions. This document is not applied to the editor.
+- `suggestions` (`Suggestion[]`): Inverted suggestions that would undo the applied changes when set on the returned document.
+
+### Example
+
+```ts
+const toolkit = getAiToolkit(editor)
+
+// Get the inverted result without modifying the editor
+const { doc, suggestions } = toolkit.invertSuggestions()
+
+// Translate the result to a different editor's schema
+const { doc, suggestions } = toolkit.invertSuggestions({ schema: otherEditor.schema })
+```

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 3.0.0-alpha.87
+
+### Minor Changes
+
+- Add `invertSuggestions` method. This method performs a dry run that applies all current suggestions to a copy of the document and returns the resulting document along with inverted suggestions that would undo those changes. The inverted suggestions preserve the metadata of the original suggestions. Preview mode suggestions become review mode in the inverted result, and vice versa.
+
 ## 3.0.0-alpha.86
 
 ### Minor Changes


### PR DESCRIPTION
## Summary

- Add API reference for the new `invertSuggestions` method to the display suggestions page, documenting its parameters, return type, and usage examples.
- Add v3.0.0-alpha.87 changelog entry for the AI Toolkit package.

## Test plan

- [ ] Verify the API reference renders correctly on the docs site
- [ ] Verify the changelog entry appears at the top of the AI Toolkit changelog