### PR TITLE
Clarify UniqueID defaults and document `types: 'all'`

### DIFF
--- a/src/content/editor/extensions/functionality/uniqueid.mdx
+++ b/src/content/editor/extensions/functionality/uniqueid.mdx
@@ -23,7 +23,7 @@ meta:
 
 import { CodeDemo } from '@/components/CodeDemo'
 
-The `UniqueID` extension adds unique IDs to the node types you configure. By default, it does not add IDs to any nodes (`types: []`).
+The `UniqueID` extension adds unique IDs to the node types you configure.
 The extension keeps track of your nodes, even if you split them, merge them, undo/redo changes, crop content, paste content … It just works.
 Also, you can configure which node types get an unique ID, and which not, and you can customize how those IDs are generated.
 

--- a/src/content/editor/extensions/functionality/uniqueid.mdx
+++ b/src/content/editor/extensions/functionality/uniqueid.mdx
@@ -23,7 +23,8 @@ meta:
 
 import { CodeDemo } from '@/components/CodeDemo'
 
-The `UniqueID` extension adds unique IDs to all nodes. The extension keeps track of your nodes, even if you split them, merge them, undo/redo changes, crop content, paste content … It just works.
+The `UniqueID` extension adds unique IDs to the node types you configure. By default, it does not add IDs to any nodes (`types: []`).
+The extension keeps track of your nodes, even if you split them, merge them, undo/redo changes, crop content, paste content … It just works.
 Also, you can configure which node types get an unique ID, and which not, and you can customize how those IDs are generated.
 
 <CodeDemo path="/Extensions/UniqueID" />
@@ -50,13 +51,20 @@ UniqueID.configure({
 
 ### types
 
-All types that should get a unique ID, for example `['heading', 'paragraph']`
+All node types that should get a unique ID, for example `['heading', 'paragraph']`.
+You can also pass `'all'` to add IDs to every node type in the document except `doc` and `text`.
 
 Default: `[]`
 
 ```js
 UniqueID.configure({
   types: ['heading', 'paragraph'],
+})
+```
+
+```js
+UniqueID.configure({
+  types: 'all',
 })
 ```
 


### PR DESCRIPTION
## Summary
- update UniqueID docs to clarify default behavior (`types: []` means no nodes get IDs)
- document the new `types: 'all'` option
- explain that `'all'` targets all node types except `doc` and `text`

## Why
Keeps docs aligned with extension behavior and reduces ambiguity around defaults and the new shorthand option.

## Related PRs
- Extension change: https://github.com/ueberdosis/tiptap/pull/7559

## Validation
- `corepack pnpm lint`
