### PR TITLE
docs: add Paste Handler extension documentation

### DIFF
--- a/src/content/editor/extensions/functionality/paste-handler.mdx
+++ b/src/content/editor/extensions/functionality/paste-handler.mdx
@@ -1,0 +1,76 @@
+---
+title: Paste Handler
+tags:
+  - type: team
+meta:
+  category: Editor
+  title: Paste Handler extension | Tiptap Editor Docs
+  description: Automatically clean and normalize pasted content from Microsoft Excel, Word, and Google Docs in your Tiptap editor.
+extension:
+  name: Paste Handler
+  description: Automatically clean and normalize pasted content from external sources like Microsoft Excel, Word, and Google Docs.
+  type: extension
+  icon: ClipboardPaste
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+import { Callout } from '@/components/ui/Callout'
+
+The `PasteHandler` extension intelligently transforms pasted HTML to ensure compatibility with content from external sources. It runs a series of transformations on pasted content to clean up source-specific formatting artifacts while preserving user intent.
+
+<CodeDemo isPro path="/Extensions/PasteHandler" />
+
+## Supported sources
+
+The extension handles paste content from the following sources:
+
+- **Microsoft Excel** (macOS & SharePoint Web)
+- **Microsoft Word** (SharePoint Web & desktop)
+- **Google Docs**
+
+## Install
+
+```bash
+npm install @tiptap-pro/extension-paste-handler
+```
+
+## Usage
+
+The extension requires no configuration. Just add it to your editor and it works automatically.
+
+```js
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import PasteHandler from '@tiptap-pro/extension-paste-handler'
+
+const editor = new Editor({
+  extensions: [
+    StarterKit,
+    PasteHandler,
+  ],
+})
+```
+
+## What it handles
+
+The extension applies a series of transformations to pasted HTML, executed in a specific order:
+
+| Transformation | Description |
+| --- | --- |
+| CSS class resolution | Resolves class-based CSS formatting (e.g. from Excel) to inline styles |
+| Office markup cleanup | Removes Microsoft Office-specific elements and properties like `<o:p>` tags and `mso-*` styles |
+| Bookmark removal | Strips Word bookmark markers and empty bookmark anchors |
+| Table cell text styles | Ensures text formatting in table cells is properly recognized by the editor |
+| Background color conversion | Converts `background-color` styles to highlight marks for the Highlight extension |
+| ARIA heading conversion | Transforms ARIA heading elements (from SharePoint Word) to semantic HTML headings |
+| Horizontal rule detection | Detects text-based horizontal rules (e.g. from Google Docs) and converts them to `<hr>` elements |
+| Soft line break merging | Merges consecutive zero-margin paragraphs (from Google Docs) into proper line breaks |
+| Nested list reconstruction | Rebuilds flat list structures (from SharePoint) into properly nested lists |
+| Ordered list normalization | Removes inline `list-style-type` to let your editor's CSS control list styling |
+| Orphan break cleanup | Removes stray `<br>` tags between block elements that cause unwanted spacing |
+
+<Callout title="Error handling" variant="info">
+  If any transformation fails, the extension gracefully falls back to the original pasted HTML to
+  ensure paste functionality is never broken.
+</Callout>
+

--- a/src/content/editor/extensions/functionality/paste-handler.mdx
+++ b/src/content/editor/extensions/functionality/paste-handler.mdx
@@ -22,11 +22,13 @@ The `PasteHandler` extension intelligently transforms pasted HTML to ensure comp
 
 ## Supported sources
 
-The extension handles paste content from the following sources:
-
-- **Microsoft Excel** (macOS & SharePoint Web)
-- **Microsoft Word** (SharePoint Web & desktop)
-- **Google Docs**
+| Source | macOS Desktop | Windows Desktop | Web (Browser) |
+| --- | :---: | :---: | :---: |
+| Microsoft Excel | ✓ | ✓ | ✓ (SharePoint) |
+| Microsoft Word | ✓ | ✓ | ✓ (SharePoint) |
+| Microsoft Outlook | ✓ | ✓ | ✓ (Outlook Web) |
+| Google Docs | — | — | ✓ |
+| Google Sheets | — | — | ✓ |
 
 ## Install
 

--- a/src/content/editor/sidebar.ts
+++ b/src/content/editor/sidebar.ts
@@ -368,6 +368,11 @@ export const sidebarConfig: SidebarConfig = {
               tags: ['Team'],
             },
             {
+              href: '/editor/extensions/functionality/paste-handler',
+              title: 'Paste Handler',
+              tags: ['Team'],
+            },
+            {
               href: '/editor/extensions/functionality/placeholder',
               title: 'Placeholder',
             },


### PR DESCRIPTION
## Summary
- Added comprehensive documentation for the Paste Handler extension
- Registered the extension in the editor extensions sidebar as a Team tier feature
- Documentation covers supported sources (Excel, Word, Google Docs), installation, usage, and all 11 transformations

The Paste Handler intelligently cleans and normalizes pasted HTML from external sources. It requires zero configuration and works automatically when added to the editor.