### PR TITLE
Fix typo in Svelte installation guide

### DIFF
--- a/src/content/editor/getting-started/install/svelte.mdx
+++ b/src/content/editor/getting-started/install/svelte.mdx
@@ -6,7 +6,7 @@ meta:
   category: Editor
 ---
 
-Learn how to integrate Tiptap with your SvelteKit project using this step-by-sep guide. Alternatively, check out our [Svelte text editor example](/examples/basics/default-text-editor).
+Learn how to integrate Tiptap with your SvelteKit project using this step-by-step guide. Alternatively, check out our [Svelte text editor example](/examples/basics/default-text-editor).
 
 ## Take a shortcut: Svelte REPL with Tiptap
 


### PR DESCRIPTION
Not adding a changeset because it's a single character fix in the docs.