### PR TITLE
Fix broken internal docs links

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -133,6 +133,31 @@ const nextConfig = {
         permanent: true,
       },
       {
+        source: '/conversion/import-export/docx',
+        destination: '/conversion/getting-started/overview',
+        permanent: true,
+      },
+      {
+        source: '/conversion/import-export/docx/custom-node-conversion',
+        destination: '/conversion/import/docx/custom-node-conversion',
+        permanent: true,
+      },
+      {
+        source: '/conversion/import-export/docx/custom-page-layout',
+        destination: '/conversion/export/docx/custom-page-layout',
+        permanent: true,
+      },
+      {
+        source: '/conversion/import-export/docx/preserve-images',
+        destination: '/conversion/import/docx/preserve-images',
+        permanent: true,
+      },
+      {
+        source: '/conversion/import-export/docx/rest-api',
+        destination: '/conversion/getting-started/install',
+        permanent: true,
+      },
+      {
         source: '/content-ai/capabilities/generation',
         destination: '/content-ai/capabilities/generation/overview',
         permanent: true,

--- a/src/content/examples/experiments/linting.mdx
+++ b/src/content/examples/experiments/linting.mdx
@@ -14,7 +14,7 @@ import { Callout } from '@/components/ui/Callout'
 </Callout>
 
 <Callout variant="info" title="Use the AI Suggestion extension instead">
-  With the [AI Toolkit](/docs/content-ai/capabilities/ai-toolkit/workflows/proofreader) you can
+  With the [AI Toolkit](/content-ai/capabilities/ai-toolkit/workflows/proofreader) you can
   build a complex proofreader application. The AI Toolkit's proofreader workflow is compatible with
   AI models and traditional linting rules like the ones shown in this example.
 </Callout>


### PR DESCRIPTION
## Summary
- fix the broken proofreader link in the linting example
- add redirects for the reported legacy DOCX and proofreader docs URLs
- preserve compatibility for broken links whose source pages are not authored in this repo

## Testing
- pnpm lint
- pnpm build