### PR TITLE
chore: bump all package version references for export import

### DIFF
--- a/src/content/conversion/export/doc/custom-page-layout.mdx
+++ b/src/content/conversion/export/doc/custom-page-layout.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.2.0
+    label: v0.3.0
 meta:
     title: Custom page layouts in DOC | Tiptap Conversion
     description: Learn how to customize your DOC page and margin sizes using the Export DOC extension.

--- a/src/content/conversion/export/doc/editor-export.mdx
+++ b/src/content/conversion/export/doc/editor-export.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.2.0
+    label: v0.3.0
 meta:
     title: Export DOC | Tiptap Conversion
     description: Learn how to export Tiptap editor content to DOC (legacy Word) files using the Export DOC extension in our docs.
@@ -44,7 +44,7 @@ The Conversion extensions are published in Tiptap's private npm registry. Integr
 Once done you can install and import the **Export DOC** extension package.
 
 ```bash
-npm i @tiptap-pro/extension-export-doc@beta
+npm i @tiptap-pro/extension-export-doc
 ```
 
 ```js

--- a/src/content/conversion/export/doc/export-styles.mdx
+++ b/src/content/conversion/export/doc/export-styles.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.2.0
+    label: v0.3.0
 meta:
     title: Export styles to DOC | Tiptap Conversion
     description: Learn how to export custom styles from Tiptap JSON to DOC using the Export DOC extension.

--- a/src/content/conversion/export/doc/headers-footers.mdx
+++ b/src/content/conversion/export/doc/headers-footers.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.2.0
+    label: v0.3.0
 meta:
     title: Extend your DOC export with Headers & Footers | Tiptap Conversion
     description: Learn how to extend your DOC exports with custom Headers & Footers using the Export DOC extension.

--- a/src/content/conversion/export/docx/custom-node-conversion.mdx
+++ b/src/content/conversion/export/docx/custom-node-conversion.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.12.0
+    label: v0.13.0
 meta:
     title: Export custom nodes to DOCX | Tiptap Conversion
     description: Learn how to export custom nodes to DOCX (Word) files using the Export extension.

--- a/src/content/conversion/export/docx/custom-page-layout.mdx
+++ b/src/content/conversion/export/docx/custom-page-layout.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.12.0
+    label: v0.13.0
 meta:
     title: Custom page layouts in DOCX | Tiptap Conversion
     description: Learn how to customize your DOCX (Word) page and margin sizes using the Export extension.

--- a/src/content/conversion/export/docx/editor-export.mdx
+++ b/src/content/conversion/export/docx/editor-export.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.12.0
+    label: v0.13.0
 meta:
     title: Export DOCX | Tiptap Conversion
     description: Learn how to export Tiptap editor content to DOCX (Word) files using the Export extension in our docs.
@@ -43,7 +43,7 @@ The Conversion extensions are published in Tiptap’s private npm registry. Inte
 Once done you can install and import the **Export DOCX** extension package
 
 ```bash
-npm i @tiptap-pro/extension-export-docx@beta
+npm i @tiptap-pro/extension-export-docx
 ```
 
 Using the export extension does not require any Tiptap Conversion credentials, since the conversion is handled right away in the extension.

--- a/src/content/conversion/export/docx/export-styles.mdx
+++ b/src/content/conversion/export/docx/export-styles.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.12.0
+    label: v0.13.0
 meta:
     title: Export styles | Tiptap Conversion
     description: Learn how to export custom styles from Tiptap JSON to DOCX in our documentation.

--- a/src/content/conversion/export/docx/headers-footers.mdx
+++ b/src/content/conversion/export/docx/headers-footers.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.12.0
+    label: v0.13.0
 meta:
     title: Extend your DOCX export with Headers & Footers | Tiptap Conversion
     description: Learn how to extend your DOCX exports with Headers & Footers

--- a/src/content/conversion/export/epub/custom-page-layout.mdx
+++ b/src/content/conversion/export/epub/custom-page-layout.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.2.0
+    label: v0.3.0
 meta:
     title: Custom page layouts in EPUB | Tiptap Conversion
     description: Learn how to customize your EPUB page and margin sizes using the Export EPUB extension.

--- a/src/content/conversion/export/epub/editor-export.mdx
+++ b/src/content/conversion/export/epub/editor-export.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.2.0
+    label: v0.3.0
 meta:
     title: Export EPUB | Tiptap Conversion
     description: Learn how to export Tiptap editor content to EPUB files using the Export EPUB extension in our docs.
@@ -39,7 +39,7 @@ The Conversion extensions are published in Tiptap's private npm registry. Integr
 Once done you can install and import the **Export EPUB** extension package.
 
 ```bash
-npm i @tiptap-pro/extension-export-epub@beta
+npm i @tiptap-pro/extension-export-epub
 ```
 
 ```js

--- a/src/content/conversion/export/epub/export-styles.mdx
+++ b/src/content/conversion/export/epub/export-styles.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.2.0
+    label: v0.3.0
 meta:
     title: Export styles to EPUB | Tiptap Conversion
     description: Learn how to export custom styles from Tiptap JSON to EPUB using the Export EPUB extension.

--- a/src/content/conversion/export/epub/headers-footers.mdx
+++ b/src/content/conversion/export/epub/headers-footers.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.2.0
+    label: v0.3.0
 meta:
     title: Extend your EPUB export with Headers & Footers | Tiptap Conversion
     description: Learn how to extend your EPUB exports with custom Headers & Footers using the Export EPUB extension.

--- a/src/content/conversion/export/markdown/editor-export.mdx
+++ b/src/content/conversion/export/markdown/editor-export.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.1.0
+    label: v0.2.0
 meta:
     title: Export Markdown | Tiptap Conversion
     description: Learn how to export Tiptap editor content to Markdown files using the Export Markdown extension in our docs.
@@ -40,7 +40,7 @@ The Conversion extensions are published in Tiptap's private npm registry. Integr
 Once done you can install and import the **Export Markdown** extension package.
 
 ```bash
-npm i @tiptap-pro/extension-export-markdown@beta
+npm i @tiptap-pro/extension-export-markdown
 ```
 
 <Callout title="Required peer dependency" variant="hint">

--- a/src/content/conversion/export/odt/custom-page-layout.mdx
+++ b/src/content/conversion/export/odt/custom-page-layout.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.2.0
+    label: v0.3.0
 meta:
     title: Custom page layouts in ODT | Tiptap Conversion
     description: Learn how to customize your ODT page and margin sizes using the Export ODT extension.

--- a/src/content/conversion/export/odt/editor-export.mdx
+++ b/src/content/conversion/export/odt/editor-export.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.2.0
+    label: v0.3.0
 meta:
     title: Export ODT | Tiptap Conversion
     description: Learn how to export Tiptap editor content to ODT (OpenDocument) files using the Export ODT extension in our docs.
@@ -39,7 +39,7 @@ The Conversion extensions are published in Tiptap's private npm registry. Integr
 Once done you can install and import the **Export ODT** extension package.
 
 ```bash
-npm i @tiptap-pro/extension-export-odt@beta
+npm i @tiptap-pro/extension-export-odt
 ```
 
 ```js

--- a/src/content/conversion/export/odt/export-styles.mdx
+++ b/src/content/conversion/export/odt/export-styles.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.2.0
+    label: v0.3.0
 meta:
     title: Export styles to ODT | Tiptap Conversion
     description: Learn how to export custom styles from Tiptap JSON to ODT using the Export ODT extension.

--- a/src/content/conversion/export/odt/headers-footers.mdx
+++ b/src/content/conversion/export/odt/headers-footers.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.2.0
+    label: v0.3.0
 meta:
     title: Extend your ODT export with Headers & Footers | Tiptap Conversion
     description: Learn how to extend your ODT exports with custom Headers & Footers using the Export ODT extension.

--- a/src/content/conversion/export/pdf/custom-page-layout.mdx
+++ b/src/content/conversion/export/pdf/custom-page-layout.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.2.0
+    label: v0.3.0
 meta:
     title: Custom page layouts in PDF | Tiptap Conversion
     description: Learn how to customize your PDF page and margin sizes using the Export PDF extension.

--- a/src/content/conversion/export/pdf/editor-export.mdx
+++ b/src/content/conversion/export/pdf/editor-export.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.2.0
+    label: v0.3.0
 meta:
     title: Export PDF | Tiptap Conversion
     description: Learn how to export Tiptap editor content to PDF files using the Export PDF extension in our docs.
@@ -40,7 +40,7 @@ The Conversion extensions are published in Tiptap's private npm registry. Integr
 Once done you can install and import the **Export PDF** extension package.
 
 ```bash
-npm i @tiptap-pro/extension-export-pdf@beta
+npm i @tiptap-pro/extension-export-pdf
 ```
 
 ```js

--- a/src/content/conversion/export/pdf/export-styles.mdx
+++ b/src/content/conversion/export/pdf/export-styles.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.2.0
+    label: v0.3.0
 meta:
     title: Export styles to PDF | Tiptap Conversion
     description: Learn how to export custom styles from Tiptap JSON to PDF using the Export PDF extension.

--- a/src/content/conversion/export/pdf/headers-footers.mdx
+++ b/src/content/conversion/export/pdf/headers-footers.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.2.0
+    label: v0.3.0
 meta:
     title: Extend your PDF export with Headers & Footers | Tiptap Conversion
     description: Learn how to extend your PDF exports with custom Headers & Footers using the Export PDF extension.

--- a/src/content/conversion/import/docx/custom-mark-conversion.mdx
+++ b/src/content/conversion/import/docx/custom-mark-conversion.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.0
+    label: v0.7.0
 meta:
     title: DOCX mark import | Tiptap Conversion
     description: Learn how to import custom marks from DOCX (Word) files using the Import extension in our docs.

--- a/src/content/conversion/import/docx/custom-node-conversion.mdx
+++ b/src/content/conversion/import/docx/custom-node-conversion.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.0
+    label: v0.7.0
 meta:
     title: Import custom nodes from DOCX | Tiptap Conversion
     description: Learn how to import custom nodes from DOCX (Word) files using the Import extension.

--- a/src/content/conversion/import/docx/editor-import.mdx
+++ b/src/content/conversion/import/docx/editor-import.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.0
+    label: v0.7.0
 meta:
     title: Import DOCX | Tiptap Conversion
     description: Learn how to import DOCX (Word) documents into a Tiptap editor using the Import extension in our docs.
@@ -41,7 +41,7 @@ The Conversion extensions are published in Tiptap’s private npm registry. Inte
 Install the Tiptap Import extension package:
 
 ```bash
-npm i @tiptap-pro/extension-import-docx@beta
+npm i @tiptap-pro/extension-import-docx
 ```
 
 Ensure your editor includes all necessary Tiptap extensions to handle content from DOCX. For example, include the Image extension for inline images, and the Table extension for tables.

--- a/src/content/conversion/import/docx/preserve-images.mdx
+++ b/src/content/conversion/import/docx/preserve-images.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.0
+    label: v0.7.0
 meta:
     title: Preserve images | Tiptap Conversion
     description: Preserve images in your converted documents by providing an image upload callback url. Learn more in the docs.


### PR DESCRIPTION
This pull request updates documentation for multiple Tiptap Conversion export extensions to reflect new stable package versions and recent releases. The main changes are updating the version labels in the docs, removing the `@beta` tag from installation instructions, and bumping the documented extension version numbers.

Version and stability updates across export extension docs:

* DOC, EPUB, ODT, PDF export docs: Updated version labels in `tags:` from `v0.2.0` to `v0.3.0` for DOC, EPUB, ODT, PDF, and from `v0.1.0` to `v0.2.0` for Markdown. [[1]](diffhunk://#diff-b9e7d6ecef4b730eb5db4d0b7aa6eefc9c0248523410b439fbc999e99794893bL7-R7) [[2]](diffhunk://#diff-c3cc6bc3093a4284c30af5a6f9f08ae1c16525a94cb2539a357517774d5cd05aL7-R7) [[3]](diffhunk://#diff-bc6ac4d22e534ec2a1056da110ff05a93897a3cd15b7375efc7a111e2ddbfcabL7-R7) [[4]](diffhunk://#diff-8138302fc597b26b620842fce25712b4fb4fbdbee0cf7fecf1c681c41f5308adL7-R7) [[5]](diffhunk://#diff-510de7bf7fa413ca35780212e50d69d9d8314ff4caa2dc4e398aa4cc03526558L7-R7)
* DOCX export docs: Updated version labels in `tags:` from `v0.12.0` to `v0.13.0`. [[1]](diffhunk://#diff-c151841f8ce1b2b7e3c52ecf20a3a37c5ca00ce5bf34b28eacd662e306d65bf2L7-R7) [[2]](diffhunk://#diff-60994387ff30f7dd7d6cfcd1d1298299fdfe3866ebe20f5edf9f40114fb2c2fcL7-R7) [[3]](diffhunk://#diff-974694a34e497ca082766602bdf0b86e211b08d1cfd90d9f2013a185773fb510L7-R7) [[4]](diffhunk://#diff-b0a92a9cede2ba303e562a9787b176e6dd46cddbb7ecb6efaf61a136b490f12bL7-R7) [[5]](diffhunk://#diff-fa899acb7011c08ea7a71d02ec40454d5859dd9218a8c5a26c14b49e3126640aL7-R7)

Installation instructions:

* All export extension docs: Removed the `@beta` tag from npm installation commands, now referencing the stable package (e.g., `npm i @tiptap-pro/extension-export-doc` instead of `npm i @tiptap-pro/extension-export-doc@beta`). [[1]](diffhunk://#diff-60a493aa289bbf407beae0323d4a5aad2cf88e72a4f48f5c177d4645f3dc6c12L47-R47) [[2]](diffhunk://#diff-ef304cc484cf87c007379c4ab707a4031cd191c498643efbd5e4f27aa8fb91a9L42-R42) [[3]](diffhunk://#diff-3df01bdc43e1e31f2e2abc0a861fd280f140a51f14162dcfebeaa6530c57f06cL42-R42) [[4]](diffhunk://#diff-ddf26dd02fa6268093f0f66b1fd3dbd41727c4eaa81e251d3d790603785c0b5eL43-R43) [[5]](diffhunk://#diff-974694a34e497ca082766602bdf0b86e211b08d1cfd90d9f2013a185773fb510L46-R46) [[6]](diffhunk://#diff-510de7bf7fa413ca35780212e50d69d9d8314ff4caa2dc4e398aa4cc03526558L43-R43)

Consistency improvements:

* Updated version labels in related style and header/footer documentation files for all supported export extensions to match the new stable versions. [[1]](diffhunk://#diff-dca1fa574984097b11f2162b212106a17317012f244d0df04be0c3d3b0573112L7-R7) [[2]](diffhunk://#diff-29498cdb8987cacf0bab9142ff0f1da770503de3e2b70864b1633acf8e7819e6L7-R7) [[3]](diffhunk://#diff-d5bb5e64e1733b0f68c7e1c4f743b21b64cb891ab795335620702082d75351d4L7-R7) [[4]](diffhunk://#diff-a3de297baf4e3aa2f642c9b25ae663eb79383738f64596fafadda386b42fa0d0L7-R7) [[5]](diffhunk://#diff-e8154e195762b5e2f53091045f5a206bce4ac5dbc8e5116dbeea32d9c1e719d5L7-R7) [[6]](diffhunk://#diff-58600917f14b43990aa2ab25ec30c2b7fab22e3e155806ae1166f9779feae5bbL7-R7)

These changes ensure the documentation is up-to-date with the latest stable releases and installation instructions for Tiptap Conversion export extensions.