### PR TITLE
Correct chunkSize default value in REST API docs

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
@@ -161,7 +161,7 @@ curl --location 'BASE_URL/v3/ai/toolkit/execute-tool' \
       "documentId": "your-document-id"
     },
     "schemaAwarenessData": { /* schema awareness data from getSchemaAwarenessData */ },
-    "chunkSize": 1000,
+    "chunkSize": 32000,
     "format": "json"
 }'
 ```
@@ -178,7 +178,7 @@ curl --location 'BASE_URL/v3/ai/toolkit/execute-tool' \
     "input": { /* tool input */ },
     "document": { /* Tiptap JSON document */ },
     "schemaAwarenessData": { /* schema awareness data from getSchemaAwarenessData */ },
-    "chunkSize": 1000,
+    "chunkSize": 32000,
     "format": "json"
 }'
 ```
@@ -199,7 +199,7 @@ curl --location 'BASE_URL/v3/ai/toolkit/execute-tool' \
   - `threadData` (`Record<string, any>`, optional): Metadata attached to new threads
   - `commentData` (`Record<string, any>`, optional): Metadata attached to new comments
 - `schemaAwarenessData` (`SchemaAwarenessData`, required): The schema awareness data obtained from `getSchemaAwarenessData`
-- `chunkSize?` (`number`, optional): The chunk size for reading operations. Default: `1000`
+- `chunkSize?` (`number`, optional): The chunk size for reading operations. Default: `32000`
 - `tiptapEditSelectableNodes?` (`string[]`, optional): Custom selectable node types for tiptapEdit operations.
 - `format?` (`string`, optional): The format in which the AI reads and edits the document. Must be one of:
   - `"json"` (default): Standard JSON format


### PR DESCRIPTION
## Summary
- Fixed the documented default value for `chunkSize` in the Server AI Toolkit REST API reference from `1000` to `32000`
- Updated both code examples and the parameter description

## Test plan
- [x] Verify the REST API page renders correctly with the updated values