### PR TITLE
Update AI toolkit changelogs

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,17 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 0.1.0
+
+### Minor Changes
+
+- Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
+
+### Patch Changes
+
+- Updated dependencies
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.1.0
+
 ## 3.0.0-alpha.33
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 0.1.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,17 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 0.1.0
+
+### Minor Changes
+
+- Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
+
+### Patch Changes
+
+- Updated dependencies
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.1.0
+
 ## 3.0.0-alpha.22
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 0.1.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,17 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 0.1.0
+
+### Minor Changes
+
+- Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
+
+### Patch Changes
+
+- Updated dependencies
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.1.0
+
 ## 3.0.0-alpha.27
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 0.1.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 0.1.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,17 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 0.1.0
+
+### Minor Changes
+
+- Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
+
+### Patch Changes
+
+- Updated dependencies
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.1.0
+
 ## 3.0.0-alpha.26
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 0.1.0
+
+### Minor Changes
+
+- Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
+
 ## 3.0.0-alpha.36
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,8 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,23 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 0.1.0
+
+### Minor Changes
+
+- Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
+
+## 3.0.0-alpha.89
+
+### Minor Changes
+
+- Add Tracked Changes review mode to AI Toolkit. When enabled, AI edits are written as tracked changes instead of standard review suggestions, and AI-generated change explanations can be attached as linked comments when the Comments extension is available.
+- In tracked changes review mode, `tiptapRead` now returns the document as it looks after applying all tracked changes, so AI tools read the effective document content instead of the tracked-change markup.
+
+### Patch Changes
+
+- Fix the diffing process used when rebuilding tracked changes so overlapping later edits are merged correctly and extra suggestions or duplicate tracked changes are not created.
+
 ## 3.0.0-alpha.88
 
 ### Major Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,15 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 0.1.1
+
+### Patch Changes
+
+- Ensure all selectable nodes are correctly set up when the `tiptapRead` tool is called. Fixes a bug where not all selectable nodes were set up in the returned content of the `tiptapRead` tool.
+- Fixed a bug where empty paragraphs accumulated in the document on every page reload when using the AiToolkit extension with the Collaboration extension and an externally created Yjs provider.
+- Fix tiptapRead returning corrupted content after a preview-mode tiptapEdit that changes the document's node structure
+- Fixed table insertion failing with "Invalid HTML content" error when AI-generated HTML includes standard table wrapper elements like `<tbody>`, `<thead>`, or `<tfoot>`.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
+## 0.1.0
+
+### Minor Changes
+
+- Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
+
 ## 3.0.0-alpha.4
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,6 +8,8 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
+## 0.1.1
+
 ## 0.1.0
 
 ### Minor Changes


### PR DESCRIPTION
## Summary

- Add `0.1.1` changelog entries across all AI toolkit packages (bug fixes for tiptapRead, collaboration, table insertion)
- Add `0.1.0` entries across all AI toolkit and server AI toolkit packages (new unified versioning scheme)
- Add `3.0.0-alpha.89` entry for `@tiptap-pro/ai-toolkit` (tracked changes review mode)

Updated packages:
- `@tiptap-pro/ai-toolkit`
- `@tiptap-pro/ai-toolkit-ai-sdk`
- `@tiptap-pro/ai-toolkit-openai`
- `@tiptap-pro/ai-toolkit-langchain`
- `@tiptap-pro/ai-toolkit-anthropic`
- `@tiptap-pro/ai-toolkit-tool-definitions`
- `@tiptap-pro/server-ai-toolkit`

## Test plan

- [x] Verify changelog pages render correctly in the docs site