### PR TITLE
Add tracked changes guide for AI Toolkit

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -362,7 +362,12 @@ const nextConfig = {
       },
       {
         source: '/content-ai/capabilities/ai-toolkit/guides/tool-streaming',
-        destination: '/content-ai/capabilities/ai-toolkit/agents/tool-streaming',
+        destination: '/content-ai/capabilities/ai-toolkit/agents/streaming',
+        permanent: true,
+      },
+      {
+        source: '/content-ai/capabilities/ai-toolkit/agents/tool-streaming',
+        destination: '/content-ai/capabilities/ai-toolkit/agents/streaming',
         permanent: true,
       },
       // Live demo moved to advanced-guides

--- a/src/components/UseCasesGrid.tsx
+++ b/src/components/UseCasesGrid.tsx
@@ -81,7 +81,7 @@ const USE_CASES: UseCase[] = [
   {
     title: 'Stream edits',
     description: 'Display AI tool calls and document changes in real-time as the agent works.',
-    href: '/content-ai/capabilities/ai-toolkit/agents/tool-streaming',
+    href: '/content-ai/capabilities/ai-toolkit/agents/streaming',
     tags: ['AI Agents'],
     icon: Workflow,
   },

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/ai-engineering.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/ai-engineering.mdx
@@ -129,7 +129,7 @@ To improve the speed of the AI Toolkit, you can use the following strategies:
 
 ### Implement response streaming
 
-Streaming the content into the editor makes the response feel faster to the user. Follow the [tool streaming guide](/content-ai/capabilities/ai-toolkit/agents/tool-streaming) to implement it.
+Streaming the content into the editor makes the response feel faster to the user. Follow the [streaming guide](/content-ai/capabilities/ai-toolkit/agents/streaming) to implement it.
 
 ### Choose a faster model or provider
 

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/migration-guides/ai-assistant.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/migration-guides/ai-assistant.mdx
@@ -12,9 +12,9 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
 The AI Assistant extension lets you integrate an AI chatbot that can make edits to the document based on a user-defined task.
 
-You can implement the same functionality with the AI Toolkit by following the [AI agent chatbot guide](/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot).
+You can implement the same functionality with the AI Toolkit by following the [AI agent chatbot guide](/content-ai/capabilities/ai-toolkit/agents/ai-agent-chatbot).
 
-To review the changes made by the AI chatbot, you can use the [review changes guide](/content-ai/capabilities/ai-toolkit/guides/review-changes). The AI Toolkit has a built-in system to display suggestions that users can accept or reject, so it is not necessary to combine it with the AI Changes or the AI Suggestion extensions to implement this feature.
+To review the changes made by the AI chatbot, you can use the [review changes guide](/content-ai/capabilities/ai-toolkit/agents/review-changes). The AI Toolkit has a built-in system to display suggestions that users can accept or reject, so it is not necessary to combine it with the AI Changes or the AI Suggestion extensions to implement this feature.
 
 ## Implementing checkpoints
 

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/migration-guides/ai-generation.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/migration-guides/ai-generation.mdx
@@ -96,7 +96,7 @@ await toolkit.streamHtml(readableStream, {
 })
 ```
 
-Learn more about review options in the [review changes guide](/content-ai/capabilities/ai-toolkit/guides/review-changes) and in the [API reference](/content-ai/capabilities/ai-toolkit/api-reference/edit-the-document#streamhtml) of the `streamHtml` method.
+Learn more about review options in the [review changes guide](/content-ai/capabilities/ai-toolkit/agents/review-changes) and in the [API reference](/content-ai/capabilities/ai-toolkit/api-reference/edit-the-document#streamhtml) of the `streamHtml` method.
 
 ## Implement autocompletion
 
@@ -142,4 +142,4 @@ await toolkit.acceptSuggestion(suggestions[0].id)
 ## Next steps
 
 - See a demo of how to implement inline edits with the AI Toolkit in the [Insert Content workflow](/content-ai/capabilities/ai-toolkit/workflows/insert-content).
-- Build an AI assistant that can edit Tiptap documents in the [AI agent chatbot guide](/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot).
+- Build an AI assistant that can edit Tiptap documents in the [AI agent chatbot guide](/content-ai/capabilities/ai-toolkit/agents/ai-agent-chatbot).

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/ai-agent-chatbot.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/ai-agent-chatbot.mdx
@@ -208,6 +208,6 @@ See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
 
 ## Next steps
 
-- Let your users review AI-generated changes with the [review changes guide](/content-ai/capabilities/ai-toolkit/guides/review-changes)
-- Add real-time tool streaming to see changes as they happen with the [tool streaming guide](/content-ai/capabilities/ai-toolkit/guides/tool-streaming)
+- Let your users review AI-generated changes with the [review changes guide](/content-ai/capabilities/ai-toolkit/agents/review-changes)
+- Add real-time tool streaming to see changes as they happen with the [streaming guide](/content-ai/capabilities/ai-toolkit/agents/streaming)
 - Does your document contain custom nodes and marks? Learn how make your AI agent understand them with the [schema awareness guide](/content-ai/capabilities/ai-toolkit/api-reference/schema-awareness).

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/comments.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/comments.mdx
@@ -152,6 +152,10 @@ Never resolve threads, even if the user asks you to. Only users can resolve thre
 
 Learn more about prompt engineering in the [AI engineering guide](/content-ai/capabilities/ai-toolkit/advanced-guides/ai-engineering).
 
+## Combine comments with tracked changes
+
+Want to make document edits and associate them with comments? See the [tracked changes guide](/content-ai/capabilities/ai-toolkit/agents/tracked-changes) to learn how to combine AI-generated tracked changes with comment threads that explain each change.
+
 ## Roadmap
 
 In future releases, we aim to support streaming comments into the editor, to allow for a faster user experience. We are also exploring ways to improve token usage, speed, and developer experience.

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/index.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/index.mdx
@@ -38,7 +38,7 @@ With the AI Toolkit, you can build agents with a wide range of capabilities:
     </div>
   </Link>
   <Link
-    href="/content-ai/capabilities/ai-toolkit/agents/tool-streaming"
+    href="/content-ai/capabilities/ai-toolkit/agents/streaming"
     className="flex flex-col p-4 border border-grayAlpha-200 rounded-lg hover:border-grayAlpha-300 transition-colors cursor-pointer no-underline"
   >
     <div className="flex items-center justify-between mb-2">

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/multi-document.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/multi-document.mdx
@@ -435,4 +435,4 @@ The document structure can be improved by allowing the AI to create folders to o
 Finally, the multi-document system can be combined with any of the following AI Toolkit capabilities:
 
 - Let your users review AI-generated changes with the [review changes guide](/content-ai/capabilities/ai-toolkit/agents/review-changes)
-- Add real-time tool streaming to see changes as they happen with the [tool streaming guide](/content-ai/capabilities/ai-toolkit/agents/tool-streaming)
+- Add real-time tool streaming to see changes as they happen with the [streaming guide](/content-ai/capabilities/ai-toolkit/agents/streaming)

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/review-changes.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/review-changes.mdx
@@ -493,7 +493,7 @@ With the `reviewOptions.mode` parameter you can control when the changes are app
 
 See a complete reference of the `reviewOptions` parameter in the [API reference](/content-ai/capabilities/ai-toolkit/api-reference/execute-tool) for the `executeTool` method.
 
-You can combine this guide with [Tool streaming](/content-ai/capabilities/ai-toolkit/agents/tool-streaming) to stream operations and keep the assistant responsive while suggestions are reviewed.
+You can combine this guide with [Streaming](/content-ai/capabilities/ai-toolkit/agents/streaming) to stream operations and keep the assistant responsive while suggestions are reviewed.
 
 ### Customize how suggestions are displayed
 

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/streaming.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/streaming.mdx
@@ -1,8 +1,8 @@
 ---
-title: Tool streaming
+title: Streaming
 meta:
-  title: Tool streaming | Tiptap Content AI
-  description: Add real-time tool streaming to your AI agent chatbot to see changes as they happen.
+  title: Streaming | Tiptap Content AI
+  description: Add real-time streaming to your AI agent chatbot to see changes as they happen.
   category: Content AI
 ---
 
@@ -11,7 +11,7 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 <Callout title="Continuation from the AI agent chatbot guide" variant="info">
   This guide continues the [AI agent chatbot
-  guide](/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot). Read it first.
+  guide](/content-ai/capabilities/ai-toolkit/agents/ai-agent-chatbot). Read it first.
 </Callout>
 
 Activate the AI Toolkit's tool streaming capabilities to update the document in real-time while the AI is generating content.
@@ -22,7 +22,7 @@ See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
 
 ## Key changes
 
-To add streaming to the AI agent chatbot we built in [the previous guide](/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot), we need to replace the `executeTool` method with the `streamTool` method.
+To add streaming to the AI agent chatbot we built in [the previous guide](/content-ai/capabilities/ai-toolkit/agents/ai-agent-chatbot), we need to replace the `executeTool` method with the `streamTool` method.
 
 First, while the tool call is streaming, you can call `streamTool` repeatedly, every time a new streaming part is received. This will update the document incrementally.
 
@@ -52,7 +52,7 @@ const result = aiToolkit.streamTool({
 })
 ```
 
-To implement this process in the AI agent chatbot we built in [the previous guide](/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot), follow these steps:
+To implement this process in the AI agent chatbot we built in [the previous guide](/content-ai/capabilities/ai-toolkit/agents/ai-agent-chatbot), follow these steps:
 
 ### 1. Handle streaming updates
 

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/tracked-changes.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/tracked-changes.mdx
@@ -1,0 +1,205 @@
+---
+title: Tracked changes
+meta:
+  title: Tracked changes | Tiptap Content AI
+  description: Display AI-generated changes as tracked changes that users can accept or reject individually.
+  category: Content AI
+sidebars:
+  hideSecondary: true
+---
+
+import { Callout } from '@/components/ui/Callout'
+import { CodeDemo } from '@/components/CodeDemo'
+
+<Callout title="Continuation from the AI agent chatbot guide" variant="info">
+  This guide continues the [AI agent chatbot
+  guide](/content-ai/capabilities/ai-toolkit/agents/ai-agent-chatbot). Read it first.
+</Callout>
+
+Display AI-generated changes as tracked changes, so your users can review and accept or reject them individually. This integrates the AI Toolkit with the [Tracked Changes](/tracked-changes/getting-started/overview) extension.
+
+## Show tracked changes
+
+To display AI edits as tracked changes, set `reviewOptions.mode` to `'trackedChanges'` when executing a tool.
+
+### API endpoint
+
+The API endpoint is the same as in the [AI agent chatbot guide](/content-ai/capabilities/ai-toolkit/agents/ai-agent-chatbot). No changes are needed on the server side to enable tracked changes.
+
+```ts
+// app/api/tracked-changes/route.ts
+import { openai } from '@ai-sdk/openai'
+import { toolDefinitions } from '@tiptap-pro/ai-toolkit-ai-sdk'
+import { createAgentUIStreamResponse, ToolLoopAgent, type UIMessage } from 'ai'
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json()
+
+  const agent = new ToolLoopAgent({
+    model: openai('gpt-4o-mini'),
+    instructions:
+      'You are an assistant that can edit rich text documents. Use tiptapRead before tiptapEdit.',
+    tools: toolDefinitions(),
+  })
+
+  return createAgentUIStreamResponse({
+    agent,
+    uiMessages: messages,
+  })
+}
+```
+
+### Client-side setup
+
+On the client, add the `TrackedChanges` extension and pass `reviewOptions` with mode `'trackedChanges'` to the `executeTool` method.
+
+The `TrackedChanges` extension must be configured with `enabled: false` — the AI Toolkit enables it automatically when needed.
+
+```tsx
+import { useChat } from '@ai-sdk/react'
+import { EditorContent, useEditor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import { AiToolkit, getAiToolkit } from '@tiptap-pro/ai-toolkit'
+import { TrackedChanges } from '@tiptap-pro/extension-tracked-changes'
+import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from 'ai'
+
+export default function Page() {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [
+      StarterKit,
+      TrackedChanges.configure({
+        enabled: false,
+      }),
+      AiToolkit,
+    ],
+    content: `<p>Ask the AI to improve this document.</p>`,
+  })
+
+  const { messages, sendMessage, addToolOutput } = useChat({
+    transport: new DefaultChatTransport({ api: '/api/tracked-changes' }),
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+    async onToolCall({ toolCall }) {
+      if (!editor) return
+
+      const toolkit = getAiToolkit(editor)
+      const result = toolkit.executeTool({
+        toolName: toolCall.toolName,
+        input: toolCall.input,
+        reviewOptions: {
+          mode: 'trackedChanges',
+          trackedChangesOptions: {
+            userId: 'ai-assistant',
+            userMetadata: {
+              name: 'AI',
+            },
+          },
+        },
+      })
+
+      addToolOutput({
+        tool: toolCall.toolName,
+        toolCallId: toolCall.toolCallId,
+        output: result.output,
+      })
+    },
+  })
+
+  // ... render editor and chat UI
+}
+```
+
+After the AI edits the document, the changes appear as tracked changes. Users can accept or reject them using the `acceptSuggestion`, `rejectSuggestion`, `acceptAllSuggestions`, and `rejectAllSuggestions` commands from the Tracked Changes extension.
+
+### End result
+
+<CodeDemo isLarge path="" isScrollable src="https://ai-toolkit-demos.vercel.app/tracked-changes" />
+
+See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
+
+## Add comments with tracked changes
+
+You can make the AI provide a justification for each change. Each justification becomes a comment thread linked to its tracked change, using the [Comments](/comments/getting-started/overview) extension.
+
+### API endpoint
+
+On the server, pass the `operationMeta` option to `toolDefinitions` to add a `meta` field to edit operations. Then instruct the AI to provide a justification in the `meta` field.
+
+```ts
+// app/api/tracked-changes-comments/route.ts
+import { openai } from '@ai-sdk/openai'
+import { toolDefinitions } from '@tiptap-pro/ai-toolkit-ai-sdk'
+import { createAgentUIStreamResponse, ToolLoopAgent, type UIMessage } from 'ai'
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json()
+
+  const agent = new ToolLoopAgent({
+    model: openai('gpt-4o-mini'),
+    instructions: `You are an assistant that can edit rich text documents.
+Rule: Use tiptapRead before tiptapEdit.
+Rule: When editing the document, ALWAYS provide a brief justification for each change in the meta field.`,
+    tools: toolDefinitions({
+      operationMeta:
+        'Brief justification explaining why this change improves the document.',
+    }),
+  })
+
+  return createAgentUIStreamResponse({
+    agent,
+    uiMessages: messages,
+  })
+}
+```
+
+### Client-side setup
+
+On the client, add the `CommentsKit` extension and pass `commentsOptions` to the `executeTool` method. The `commentsOptions` property configures the thread and comment metadata for the AI-generated comments.
+
+```tsx
+import { AiToolkit, getAiToolkit } from '@tiptap-pro/ai-toolkit'
+import { CommentsKit } from '@tiptap-pro/extension-comments'
+import { TrackedChanges } from '@tiptap-pro/extension-tracked-changes'
+
+const editor = useEditor({
+  extensions: [
+    StarterKit,
+    TrackedChanges.configure({ enabled: false }),
+    AiToolkit,
+    CommentsKit.configure({
+      provider, // Your TiptapCollabProvider instance
+    }),
+  ],
+})
+
+// Inside onToolCall:
+const result = toolkit.executeTool({
+  toolName: toolCall.toolName,
+  input: toolCall.input,
+  reviewOptions: {
+    mode: 'trackedChanges',
+    trackedChangesOptions: {
+      userId: 'ai-assistant',
+      userMetadata: { name: 'AI' },
+    },
+  },
+  commentsOptions: {
+    threadData: { userName: 'AI' },
+    commentData: { userName: 'AI' },
+  },
+})
+```
+
+Each non-empty `meta` field in the edit operations becomes a comment thread linked to its tracked change. Users can review the change and read the AI's justification in the comments sidebar.
+
+### End result
+
+<CodeDemo isLarge path="" isScrollable src="https://ai-toolkit-demos.vercel.app/tracked-changes-comments" />
+
+See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
+
+## Next steps
+
+- Learn more about [review options](/content-ai/capabilities/ai-toolkit/api-reference/review-options) in the API reference.
+- Add real-time streaming with the [streaming guide](/content-ai/capabilities/ai-toolkit/agents/streaming).
+- Learn about the [Tracked Changes](/tracked-changes/getting-started/overview) extension for styling and configuration options.

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/tracked-changes.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/tracked-changes.mdx
@@ -11,6 +11,10 @@ sidebars:
 import { Callout } from '@/components/ui/Callout'
 import { CodeDemo } from '@/components/CodeDemo'
 
+<Callout title="Experimental" variant="warning">
+  This guide uses the [Tracked Changes](/tracked-changes/getting-started/overview) extension, which is under active development. The API may change in future releases.
+</Callout>
+
 <Callout title="Continuation from the AI agent chatbot guide" variant="info">
   This guide continues the [AI agent chatbot
   guide](/content-ai/capabilities/ai-toolkit/agents/ai-agent-chatbot). Read it first.

--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/execute-tool.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/execute-tool.mdx
@@ -45,7 +45,7 @@ const result = toolkit.executeTool({
 })
 ```
 
-For a complete hands-on tutorial, see the [AI agent chatbot guide](/content-ai/capabilities/ai-toolkit/guides/ai-agent-chatbot).
+For a complete hands-on tutorial, see the [AI agent chatbot guide](/content-ai/capabilities/ai-toolkit/agents/ai-agent-chatbot).
 
 ## `streamTool`
 
@@ -101,7 +101,7 @@ const finalResult = toolkit.streamTool({
 })
 ```
 
-For a complete hands-on tutorial on tool streaming, see the [AI agent chatbot with tool streaming guide](/content-ai/capabilities/ai-toolkit/guides/tool-streaming).
+For a complete hands-on tutorial on streaming, see the [streaming guide](/content-ai/capabilities/ai-toolkit/agents/streaming).
 
 ## `getActiveSelection`
 

--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/review-options.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/review-options.mdx
@@ -24,11 +24,14 @@ The `reviewOptions` property takes a `ReviewOptions` configuration object.
 
 ## `ReviewOptions`
 
-- `mode?` (`'disabled' | 'review' | 'preview'`): Whether to review the changes before or after applying them. Default: `'disabled'`
+- `mode?` (`'disabled' | 'review' | 'preview' | 'trackedChanges'`): Whether to review the changes before or after applying them. Default: `'disabled'`
   - `'disabled'`: No review UI is displayed.
   - `'review'`: The changes are applied first, then a review UI is displayed allowing the user to undo them.
   - `'preview'`: A preview UI is displayed before applying the changes, allowing the user to accept or reject them.
+  - `'trackedChanges'`: AI-generated changes are encoded as tracked changes using the [Tracked Changes](/tracked-changes/getting-started/overview) extension, allowing users to accept or reject individual changes.
 - `displayOptions?` (`DisplayOptions`): Customize how suggestions are displayed in the editor UI. Sets the `displayOptions` property of the [`Suggestion`](/content-ai/capabilities/ai-toolkit/api-reference/display-suggestions#the-suggestion-object) type. [See available options](/content-ai/capabilities/ai-toolkit/api-reference/display-suggestions#the-suggestion-object).
 - `metadata?` (`Record<string, any>`): Extra metadata for the suggestions that can be used to store additional information about them (e.g. their source or their category). It is not used internally by the extension but it may help developers customize how the suggestions are displayed in the UI.
+- `trackedChangesOptions?` (`{ userId: string, userMetadata?: Record<string, unknown> | null }`): Configuration for the `trackedChanges` mode. `userId` identifies the author of the tracked changes. `userMetadata` stores additional information about the author.
+- `commentsOptions?` (`{ threadData?: Record<string, unknown>, commentData?: Record<string, unknown> }`): When provided alongside the `trackedChanges` mode, operation metadata (the `meta` field in edit operations) becomes a comment thread linked to each tracked change. Requires the [Comments](/comments/getting-started/overview) extension.
 - `useDiffUtility?` (`boolean`): Whether to use the [Diff Utility](/content-ai/capabilities/ai-toolkit/api-reference/diff-utility) to compare the documents before and after the change, displaying the deleted and added content as a rich diff. If `false`, the deleted content and added content are displayed in a whole block, as a single change. Default: `true`
 - `diffUtilityOptions?` ([`ExternalDiffUtilityOptions`](/content-ai/capabilities/ai-toolkit/api-reference/diff-utility#parameters-diffutilityoptions)): Options for comparing the documents with the diff utility. [See available options](/content-ai/capabilities/ai-toolkit/api-reference/diff-utility#parameters-diffutilityoptions).

--- a/src/content/content-ai/capabilities/ai-toolkit/overview.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/overview.mdx
@@ -127,7 +127,7 @@ Build [AI agents](/content-ai/capabilities/ai-toolkit/agents) that can perform c
     </div>
   </Link>
   <Link
-    href="/content-ai/capabilities/ai-toolkit/agents/tool-streaming"
+    href="/content-ai/capabilities/ai-toolkit/agents/streaming"
     className="flex flex-col p-4 border border-grayAlpha-200 rounded-lg hover:border-grayAlpha-300 transition-colors cursor-pointer no-underline"
   >
     <div className="flex items-center justify-between mb-2">

--- a/src/content/content-ai/sidebar.ts
+++ b/src/content/content-ai/sidebar.ts
@@ -56,12 +56,16 @@ export const sidebarConfig: SidebarConfig = {
                   href: '/content-ai/capabilities/ai-toolkit/agents/justified-changes',
                 },
                 {
-                  title: 'Tool streaming',
-                  href: '/content-ai/capabilities/ai-toolkit/agents/tool-streaming',
+                  title: 'Streaming',
+                  href: '/content-ai/capabilities/ai-toolkit/agents/streaming',
                 },
                 {
                   title: 'Add comments',
                   href: '/content-ai/capabilities/ai-toolkit/agents/comments',
+                },
+                {
+                  title: 'Tracked changes',
+                  href: '/content-ai/capabilities/ai-toolkit/agents/tracked-changes',
                 },
                 {
                   title: 'Multi-document',


### PR DESCRIPTION
## Summary

- Add new **Tracked changes** guide in the AI Toolkit agents section, covering how to display AI-generated changes as tracked changes and how to combine tracked changes with comment threads
- Update **ReviewOptions** API reference with the new `trackedChanges` mode, `trackedChangesOptions`, and `commentsOptions` properties
- Rename **Tool streaming** to **Streaming** (file, sidebar entry, and redirects)
- Fix stale internal links that still referenced the old `/guides/` path prefix
- Add cross-link from the comments guide to the tracked changes guide

## Test plan

- [x] Verify the new tracked changes page renders correctly at `/content-ai/capabilities/ai-toolkit/agents/tracked-changes`
- [x] Verify the streaming page renders at `/content-ai/capabilities/ai-toolkit/agents/streaming`
- [x] Verify redirect from `/content-ai/capabilities/ai-toolkit/agents/tool-streaming` works
- [x] Verify CodeDemo embeds load (depends on https://github.com/ueberdosis/ai-toolkit-demos/pull/36 being merged and deployed)
- [x] Verify ReviewOptions API reference page shows the new `trackedChanges` mode
- [x] Verify sidebar shows "Streaming" and "Tracked changes" entries in the correct position