### PR TITLE
Clarify that appId is the Document server ID in Cloud dashboard

### DIFF
--- a/src/content/collaboration/documents/content-injection.mdx
+++ b/src/content/collaboration/documents/content-injection.mdx
@@ -83,7 +83,7 @@ it to the update call as `?checksum=${checksum}`. If the document has been updat
 // Define the document name, secret, and application ID
 const docName = '' // URI-encoded if necessary
 const secret = ''
-const appId = '';
+const appId = ''; // Your document server ID from the Cloud dashboard
 
 // Construct the base URL
 const url = `https://${appId}.collab.tiptap.cloud`

--- a/src/content/collaboration/documents/rest-api.mdx
+++ b/src/content/collaboration/documents/rest-api.mdx
@@ -31,6 +31,9 @@ The REST API is exposed directly from your Document server at your custom URL:
 ```bash
 https://YOUR_APP_ID.collab.tiptap.cloud/
 ```
+
+Replace `YOUR_APP_ID` with your document server ID, which is labeled "Document server ID" in the [Cloud dashboard](https://cloud.tiptap.dev/v2/configuration/document-server).
+
 ### Authentication
 Authenticate your API requests by including your API secret in the `Authorization` header. You can find your API secret in
 the [settings](https://cloud.tiptap.dev/v2/configuration/document-server) of your Tiptap Cloud dashboard.

--- a/src/content/collaboration/getting-started/install.mdx
+++ b/src/content/collaboration/getting-started/install.mdx
@@ -109,7 +109,7 @@ npm install @tiptap-pro/provider
 Next, configure the provider in your index.jsx file with your server details:
 
 - **name**: Serves as the document identifier for synchronization.
-- **appID**: Found in your [Cloud account](https://cloud.tiptap.dev/v2/configuration/document-server) after you started your document server. For on-premises setups replace `appID` with `baseUrl`.
+- **appID**: Your document server ID, found in your [Cloud dashboard](https://cloud.tiptap.dev/v2/configuration/document-server) under the label "Document server ID". For on-premises setups replace `appID` with `baseUrl`.
 - **token**: Use the JWT from your [Cloud interface](https://cloud.tiptap.dev/v2/configuration/document-server) for testing, but generate your own JWT for production.
 
 <Callout title="Adding initial content" variant="hint">
@@ -162,7 +162,7 @@ export default () => {
   useEffect(() => {
     const provider = new TiptapCollabProvider({
       name: 'document.name', // Unique document identifier for syncing. This is your document name.
-      appId: '7j9y6m10', // Your Cloud Dashboard AppID or `baseURL` for on-premises
+      appId: '7j9y6m10', // Your document server ID from the Cloud dashboard, or use `baseURL` for on-premises
       token: 'notoken', // Your JWT
       document: doc,
     })
@@ -213,7 +213,7 @@ export default () => {
   useEffect(() => {
     const provider = new TiptapCollabProvider({
       name: 'document.name', // Unique document identifier for syncing. This is your document name.
-      appId: '7j9y6m10', // Your Cloud Dashboard AppID or `baseURL` for on-premises
+      appId: '7j9y6m10', // Your document server ID from the Cloud dashboard, or use `baseURL` for on-premises
       token: 'notoken', // Your JWT
       document: doc,
 

--- a/src/content/collaboration/operations/configure.mdx
+++ b/src/content/collaboration/operations/configure.mdx
@@ -40,7 +40,7 @@ Several settings can be adjusted dynamically:
 
 ## Managing settings via API
 
-The collaboration platform offers a straightforward API for managing these settings. Replace `:key` with the setting key you wish to update.
+The collaboration platform offers a straightforward API for managing these settings. Replace `:key` with the setting key you wish to update and `YOUR_APP_ID` with your document server ID (labeled "Document server ID" in the [Cloud dashboard](https://cloud.tiptap.dev/v2/configuration/document-server)).
 
 ### Create or overwrite settings
 

--- a/src/content/collaboration/operations/metrics.mdx
+++ b/src/content/collaboration/operations/metrics.mdx
@@ -25,6 +25,8 @@ The REST API is exposed directly from your Document server at your custom URL:
 https://YOUR_APP_ID.collab.tiptap.cloud/
 ```
 
+Replace `YOUR_APP_ID` with your document server ID, which is labeled "Document server ID" in the [Cloud dashboard](https://cloud.tiptap.dev/v2/configuration/document-server).
+
 ### Authentication
 Authenticate your API requests by including your API secret in the `Authorization` header. You can find your API secret in
 the [settings](https://cloud.tiptap.dev/v2/configuration/document-server) of your Tiptap Cloud dashboard.

--- a/src/content/collaboration/provider/events.mdx
+++ b/src/content/collaboration/provider/events.mdx
@@ -33,7 +33,7 @@ To track events immediately, pass event listeners directly to the provider's con
 
 ```ts
 const provider = new TiptapCollabProvider({
-  appId: '', // Use for cloud setups, replace with baseUrl in case of on-prem
+  appId: '', // Your document server ID (for cloud setups), replace with baseUrl for on-prem
   name: 'example-document', // Document identifier
   token: '', // Your authentication JWT
   document: ydoc,

--- a/src/content/collaboration/provider/integration.mdx
+++ b/src/content/collaboration/provider/integration.mdx
@@ -26,7 +26,7 @@ Note that you need to follow the instructions [here](https://cloud.tiptap.dev/pr
 npm install @tiptap-pro/provider
 ```
 
-For a basic setup, connect to the Collaboration backend by specifying the document's name, your document server ID (for cloud setups), or the base URL (for on-premises), along with your JWT.
+For a basic setup, connect to the Collaboration backend by specifying the document's name, your document server ID (labeled "Document server ID" in your [Cloud dashboard](https://cloud.tiptap.dev/v2/configuration/document-server)) for cloud setups, or the base URL for on-premises, along with your JWT.
 
 Depending on your framework, register a callback to the Collaboration backend, such as `useEffect()` in React or `onMounted()` in Vue.js.
 
@@ -36,7 +36,7 @@ const doc = new Y.Doc()
 useEffect(() => {
   const provider = new TiptapCollabProvider({
     name: note.id, // Document identifier
-    appId: 'YOUR_APP_ID', // replace with YOUR_APP_ID from Cloud dashboard
+    appId: 'YOUR_APP_ID', // replace with your document server ID from the Cloud dashboard
     token: 'YOUR_JWT', // Authentication token
     document: doc,
     user: userId,
@@ -55,7 +55,7 @@ The Tiptap Collaboration provider offers several settings for custom configurati
 
 | Setting              | Default Value | Description                                                                                                     |
 | -------------------- | ------------- |-----------------------------------------------------------------------------------------------------------------|
-| `appId`              | `''` (empty)  | Document server ID for Collaboration Cloud setups                                                                           |
+| `appId`              | `''` (empty)  | Your document server ID (labeled "Document server ID" in the [Cloud dashboard](https://cloud.tiptap.dev/v2/configuration/document-server)) for Collaboration Cloud setups |
 | `baseUrl`            | `''` (empty)  | URL for connecting to on-premises servers. Used as an alternative to `appId` for on-prem setups                 |
 | `shardKey`            | `''` (empty)  | Only use this if you use Tiptap Collab HA. Usually this would then be set to the document name, or a team id   |
 | `name`               | `''` (empty)  | The document's name                                                                                             |

--- a/src/content/comments/integrate/rest-api.mdx
+++ b/src/content/comments/integrate/rest-api.mdx
@@ -32,6 +32,8 @@ The REST API is exposed directly from your Document server, available at your cu
 https://YOUR_APP_ID.collab.tiptap.cloud/
 ```
 
+Replace `YOUR_APP_ID` with your document server ID, which is labeled "Document server ID" in the [Cloud dashboard](https://cloud.tiptap.dev/v2/configuration/document-server).
+
 Authentication is done using an API secret which you can find in
 the [settings](https://cloud.tiptap.dev/v2/configuration/document-server) of your Document server. The secret must be sent as
 an `Authorization` header.

--- a/src/content/guides/collaboration-api.mdx
+++ b/src/content/guides/collaboration-api.mdx
@@ -12,7 +12,7 @@ meta:
 
 In order to add initial content to a document (or create an empty document), you can use our create document API.
 
-Note that you need to replace `APP_ID`, `DOCUMENT_NAME` and `API_SECRET` with your own values.
+Note that you need to replace `APP_ID`, `DOCUMENT_NAME` and `API_SECRET` with your own values. The `APP_ID` is your document server ID, labeled "Document server ID" in the [Cloud dashboard](https://cloud.tiptap.dev/v2/configuration/document-server).
 If you want to just create an empty document, you can send an empty array as `content`.
 
 The payload of the request should be Tiptap JSON, which you can get by calling `editor.getJSON()` (see [Get JSON](/guides/output-json-html#option-1-json))

--- a/src/content/pages/guides/collaboration-with-pages.mdx
+++ b/src/content/pages/guides/collaboration-with-pages.mdx
@@ -46,7 +46,7 @@ const doc = new Y.Doc() // Initialize Y.Doc for shared editing
 
 const provider = new TiptapCollabProvider({
   name: 'document.name', // Unique document identifier for syncing. This is your document name.
-  appId: 'your-app-id', // Your Cloud Dashboard AppID or `baseURL` for on-premises
+  appId: 'your-app-id', // Your document server ID from the Cloud dashboard, or use `baseURL` for on-premises
   token: 'your-jwt', // Your JWT
   document: doc,
 })
@@ -66,7 +66,7 @@ const doc = new Y.Doc() // Initialize Y.Doc for shared editing
 
 const provider = new TiptapCollabProvider({
   name: 'document.name', // Unique document identifier for syncing. This is your document name.
-  appId: 'your-app-id', // Your Cloud Dashboard AppID or `baseURL` for on-premises
+  appId: 'your-app-id', // Your document server ID from the Cloud dashboard, or use `baseURL` for on-premises
   token: 'your-jwt', // Your JWT
   document: doc,
 })


### PR DESCRIPTION
## Summary

- Clarified across 10 documentation pages that the `appId` parameter corresponds to the **"Document server ID"** label shown in the Tiptap Cloud dashboard
- Updated code comments, configuration tables, and prose in collaboration, comments, pages, and guide docs to make this mapping explicit
- Added explicit notes with links to the Cloud dashboard where users can find the value

## Context

A customer (GoClai) was confused because the docs reference "app ID" / `appId` but the Tiptap Cloud dashboard labels this field as "Document server ID". This PR ensures users can easily find the correct value in their dashboard.

## Test plan

- [x] Verify all changed pages render correctly
- [x] Confirm links to `https://cloud.tiptap.dev/v2/configuration/document-server` work