### PR TITLE
Add git commit hash and branch name to HTTP headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,11 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+ARG GIT_COMMIT_SHA
+ARG GIT_COMMIT_REF_NAME
+ENV GIT_COMMIT_SHA=$GIT_COMMIT_SHA
+ENV GIT_COMMIT_REF_NAME=$GIT_COMMIT_REF_NAME
+
 RUN pnpm run build
 
 # 2.5 ;) Dev runner
@@ -80,7 +85,7 @@ USER nextjs
 
 EXPOSE 3000
 
-ENV PORT 3000
-ENV HOSTNAME 0.0.0.0
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
 
 CMD ["node", "server.js"]

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -35,6 +35,19 @@ const nextConfig = {
   pageExtensions: ['js', 'jsx', 'mdx', 'ts', 'tsx'],
   images: { unoptimized: true },
   basePath: process.env.BASE_PATH ?? '',
+  async headers() {
+    const commitSha = process.env.GIT_COMMIT_SHA || 'unknown';
+    const shortSha = commitSha.substring(0, 7);
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'X-Git-Commit', value: shortSha },
+          { key: 'X-Git-Branch', value: process.env.GIT_COMMIT_REF_NAME || 'unknown' },
+        ],
+      },
+    ]
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
The application runs in different environments and for different branches (main, v2, next) behind reverse proxies. To identify the current release I added two HTTP headers to the project:

```http
X-Git-Branch: main
X-Git-Commit: 0d4b0e9
```