### PR TITLE
docs: add split view guide and API reference

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/split-view.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/split-view.mdx
@@ -1,0 +1,145 @@
+---
+title: Split view
+meta:
+  title: Split view | Tiptap Content AI
+  description: Build a side-by-side diff view to compare documents with visual alignment.
+  category: Content AI
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+import { Callout } from '@/components/ui/Callout'
+
+Build a side-by-side comparison that shows the original and AI-modified versions of a document next to each other. Each change block is highlighted and can be individually accepted or rejected. Both panels stay vertically aligned via automatically computed spacers.
+
+<CodeDemo
+  isPro
+  isLarge
+  src="https://compare-doc-inky.vercel.app/"
+/>
+
+## How it works
+
+The split view uses three editors: a **main editor** (holds the document and tracked changes, typically hidden during split view), a **left editor** (shows the original), and a **right editor** (shows the modified version). Two separate panel editors are required because each loads a different document snapshot with different decorations.
+
+`createSplitView()` wires all three together. It derives the before/after snapshots from the main editor's tracked changes, loads them into the panel editors, renders highlights, and keeps both panels vertically aligned with spacers. Scroll sync and hover highlighting are handled automatically when scroll containers are provided.
+
+## Set up the editors
+
+The main editor needs `AiToolkit` and `TrackedChanges`. The panel editors only need `AiToolkit` and are read-only.
+
+```ts
+import { useEditor } from '@tiptap/react'
+import { AiToolkit } from '@tiptap-pro/ai-toolkit'
+import { TrackedChanges } from '@tiptap-pro/extension-tracked-changes'
+
+const mainEditor = useEditor({
+  extensions: [
+    // ... your content extensions
+    AiToolkit.configure({ /* ... */ }),
+    TrackedChanges,
+  ],
+})
+
+const leftEditor = useEditor({
+  editable: false,
+  extensions: [
+    // ... same content extensions (without TrackedChanges)
+    AiToolkit.configure({ /* ... */ }),
+  ],
+})
+
+const rightEditor = useEditor({
+  editable: false,
+  extensions: [
+    // ... same content extensions (without TrackedChanges)
+    AiToolkit.configure({ /* ... */ }),
+  ],
+})
+```
+
+## Create the split view
+
+```ts
+import { getAiToolkit } from '@tiptap-pro/ai-toolkit'
+
+const splitView = getAiToolkit(mainEditor).createSplitView({
+  leftEditor,
+  rightEditor,
+  leftContainer: leftScrollRef.current,   // optional: enables scroll sync
+  rightContainer: rightScrollRef.current, // optional: enables scroll sync
+})
+
+// Re-sync whenever the main editor's tracked changes update
+mainEditor.on('update', () => splitView.sync())
+
+// Tear down when the component unmounts
+return () => splitView.destroy()
+```
+
+## Accept and reject changes
+
+```ts
+// Accept or reject a single entry
+splitView.acceptEntry('diff-tc-abc123')
+splitView.rejectEntry('diff-tc-abc123')
+
+// Accept or reject all at once
+splitView.acceptAll()
+splitView.rejectAll()
+```
+
+To react when the list of entries changes:
+
+```ts
+splitView.on('sync', (entries) => {
+  setDiffEntries(entries)
+
+  if (entries.length === 0) {
+    closeSplitView()
+  }
+})
+```
+
+## CSS
+
+```css
+.split-diff-deletion {
+  background-color: rgba(161, 161, 170, 0.15);
+  color: #71717a;
+  text-decoration: line-through;
+  text-decoration-color: rgba(161, 161, 170, 0.5);
+  cursor: pointer;
+}
+
+.split-diff-insertion {
+  background-color: rgba(34, 197, 94, 0.2);
+  color: #16a34a;
+  cursor: pointer;
+}
+
+.split-diff-deletion.split-diff-highlight {
+  background-color: rgba(161, 161, 170, 0.3);
+}
+
+.split-diff-insertion.split-diff-highlight {
+  background-color: rgba(34, 197, 94, 0.35);
+}
+
+.split-diff-spacer {
+  background-color: rgba(244, 244, 245, 0.6);
+  border-radius: 6px;
+}
+```
+
+## Example demo
+
+<CodeDemo
+  isPro
+  isLarge
+  src="https://compare-doc-inky.vercel.app/"
+/>
+
+## Next steps
+
+- [Split view API reference](/content-ai/capabilities/ai-toolkit/api-reference/split-view)
+- [Compare documents](/content-ai/capabilities/ai-toolkit/advanced-guides/compare-documents): for the inline single-editor approach

--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/split-view.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/split-view.mdx
@@ -7,7 +7,6 @@ meta:
 ---
 
 import { CodeDemo } from '@/components/CodeDemo'
-import { Callout } from '@/components/ui/Callout'
 
 Build a side-by-side comparison that shows the original and AI-modified versions of a document next to each other. Each change block is highlighted and can be individually accepted or rejected. Both panels stay vertically aligned via automatically computed spacers.
 
@@ -68,9 +67,6 @@ const splitView = getAiToolkit(mainEditor).createSplitView({
   leftContainer: leftScrollRef.current,   // optional: enables scroll sync
   rightContainer: rightScrollRef.current, // optional: enables scroll sync
 })
-
-// Re-sync whenever the main editor's tracked changes update
-mainEditor.on('update', () => splitView.sync())
 
 // Tear down when the component unmounts
 return () => splitView.destroy()

--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/index.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/index.mdx
@@ -111,4 +111,16 @@ Below is a list of the available methods:
       Compute changes between two documents programmatically.
     </div>
   </Link>
+  <Link
+    href="/content-ai/capabilities/ai-toolkit/api-reference/split-view"
+    className="flex flex-col p-4 border border-grayAlpha-200 rounded-lg hover:border-grayAlpha-300 transition-colors cursor-pointer no-underline"
+  >
+    <div className="flex items-center justify-between mb-2">
+      <h4 className="font-semibold text-black">Split view</h4>
+      <span className="text-sm text-blue-600 font-medium whitespace-nowrap ml-4">More →</span>
+    </div>
+    <div className="text-sm text-grayAlpha-700">
+      API reference for createSplitView and the SplitView instance methods.
+    </div>
+  </Link>
 </div>

--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/split-view.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/split-view.mdx
@@ -1,0 +1,188 @@
+---
+title: Split view
+meta:
+  title: Split view API reference | Tiptap Content AI
+  description: API reference for createSplitView and the SplitView instance methods.
+  category: Content AI
+---
+
+import { Callout } from '@/components/ui/Callout'
+
+This page is the API reference for `createSplitView` and the `SplitView` instance.
+
+If you're new to the split view, start with the [split view guide](/content-ai/capabilities/ai-toolkit/advanced-guides/split-view).
+
+## `createSplitView`
+
+Creates a split view instance that wires together three editors for side-by-side change review.
+
+Called on the AI Toolkit instance:
+
+```ts
+const toolkit = getAiToolkit(mainEditor)
+const splitView = toolkit.createSplitView(options)
+```
+
+### Parameters
+
+- `options` (`CreateSplitViewOptions`): Configuration for the split view
+  - `leftEditor` (`Editor`): The left panel editor (shows the original document). Must have `AiToolkit` installed.
+  - `rightEditor` (`Editor`): The right panel editor (shows the modified document). Must have `AiToolkit` installed.
+  - `leftContainer?` (`HTMLElement`): Scroll container for the left panel. When provided together with `rightContainer`, enables automatic scroll synchronization.
+  - `rightContainer?` (`HTMLElement`): Scroll container for the right panel. When provided together with `leftContainer`, enables automatic scroll synchronization.
+  - `diffOptions?` (`SplitViewDiffOptions`): Options for the internal diff algorithm
+    - `mode?` (`'smart' | 'inline' | 'block'`): Diff algorithm mode. Defaults to `'smart'`.
+    - `groupInlineChanges?` (`number`): Threshold for grouping inline changes into block-level changes. Defaults to `0`.
+
+### Returns (`SplitView`)
+
+Returns a `SplitView` instance. See the [SplitView methods](#splitview-methods) section below.
+
+### Example
+
+```ts
+import { getAiToolkit } from '@tiptap-pro/ai-toolkit'
+
+const splitView = getAiToolkit(mainEditor).createSplitView({
+  leftEditor,
+  rightEditor,
+  leftContainer: leftScrollRef.current,
+  rightContainer: rightScrollRef.current,
+})
+```
+
+## `SplitView` methods
+
+### `sync`
+
+Recomputes the diff from the main editor's tracked changes and updates both panels. Loads the before/after snapshots into the left and right editors, then renders highlight decorations and spacers.
+
+Call this whenever the main editor's tracked changes have changed (for example after a new AI suggestion is applied).
+
+```ts
+splitView.sync()
+```
+
+### `getEntries`
+
+Returns the current list of diff entries computed by the last `sync()` call.
+
+```ts
+const entries = splitView.getEntries()
+// SplitDiffEntry[]
+```
+
+See [`SplitDiffEntry`](#splitdiffentry) for the shape of each entry.
+
+### `acceptEntry`
+
+Accepts a single diff entry by applying its underlying tracked change to the main editor, then re-syncs.
+
+```ts
+const accepted = splitView.acceptEntry('diff-tc-abc123')
+// Returns false if the entry was not found
+```
+
+### `rejectEntry`
+
+Rejects a single diff entry by reverting its underlying tracked change in the main editor, then re-syncs.
+
+```ts
+const rejected = splitView.rejectEntry('diff-tc-abc123')
+// Returns false if the entry was not found
+```
+
+### `acceptAll`
+
+Accepts all remaining tracked changes at once, then re-syncs.
+
+```ts
+splitView.acceptAll()
+```
+
+### `rejectAll`
+
+Rejects all remaining tracked changes at once, then re-syncs.
+
+```ts
+splitView.rejectAll()
+```
+
+### `setHighlight`
+
+Sets the highlighted diff entry ID for cross-editor hover highlighting. This is called automatically by the built-in hover listeners when `data-diff-id` elements are hovered. Only use this if you are implementing custom hover logic.
+
+```ts
+splitView.setHighlight('diff-tc-abc123') // highlight an entry
+splitView.setHighlight(null)             // clear highlight
+```
+
+### `on` / `off`
+
+Registers or removes an event listener.
+
+```ts
+const handler = (entries) => {
+  // entries: SplitDiffEntry[]
+  console.log(`${entries.length} diff entries remaining`)
+}
+
+splitView.on('sync', handler)
+splitView.off('sync', handler)
+```
+
+Currently supported events:
+
+| Event | Payload | Description |
+|---|---|---|
+| `sync` | `SplitDiffEntry[]` | Fires after each sync with the updated list of entries |
+
+### `destroy`
+
+Tears down the instance: cancels any pending animation frames, clears all decorations from both editors, and removes all event listeners.
+
+```ts
+splitView.destroy()
+```
+
+Always call `destroy()` when the split view is no longer needed (for example on component unmount).
+
+## `SplitDiffEntry`
+
+Each entry in the list returned by `getEntries()` has the following shape:
+
+```ts
+interface SplitDiffEntry {
+  /** Unique identifier, e.g. `"diff-tc-abc123"` */
+  id: string
+
+  /** Range of this change in the left (original) document */
+  rangeInBefore: { from: number; to: number }
+
+  /** Range of this change in the right (modified) document */
+  rangeInAfter: { from: number; to: number }
+
+  /** IDs of the tracked changes that make up this diff entry */
+  trackedChangeIds: string[]
+
+  /** Change type */
+  type?: 'add' | 'delete' | 'replace'
+}
+```
+
+## CSS decoration classes
+
+The split view applies the following CSS classes to the editor DOM. You must define styles for these classes in your own stylesheet.
+
+| Class | Applied to | Description |
+|---|---|---|
+| `split-diff-deletion` | Left editor | Highlights blocks that were deleted or modified |
+| `split-diff-insertion` | Right editor | Highlights blocks that were added or modified |
+| `split-diff-highlight` | Both editors | Added alongside deletion/insertion on the currently hovered entry |
+| `split-diff-spacer` | Both editors | Widget elements that maintain vertical alignment between panels |
+
+All decorated elements include a `data-diff-id` attribute set to the entry ID, which you can use for custom click and hover handling.
+
+<Callout title="Do not override spacer margins">
+  The split view sets `margin: 0` on each spacer element via inline style. Overriding this in CSS will break vertical alignment because the spacer height already accounts for the full visual gap including surrounding block margins.
+</Callout>

--- a/src/content/content-ai/sidebar.ts
+++ b/src/content/content-ai/sidebar.ts
@@ -166,6 +166,10 @@ export const sidebarConfig: SidebarConfig = {
                   href: '/content-ai/capabilities/ai-toolkit/advanced-guides/compare-documents',
                 },
                 {
+                  title: 'Split view',
+                  href: '/content-ai/capabilities/ai-toolkit/advanced-guides/split-view',
+                },
+                {
                   title: 'Tiptap Edit hooks',
                   href: '/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks',
                 },
@@ -236,6 +240,10 @@ export const sidebarConfig: SidebarConfig = {
                 {
                   title: 'Diff utility',
                   href: '/content-ai/capabilities/ai-toolkit/api-reference/diff-utility',
+                },
+                {
+                  title: 'Split view',
+                  href: '/content-ai/capabilities/ai-toolkit/api-reference/split-view',
                 },
               ],
             },


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for the split view feature in AI Toolkit:

- **Split view guide** (`advanced-guides/split-view.mdx`): Architecture overview, editor setup, creating split view instances, accept/reject operations, CSS styling, and live demo
- **API reference** (`api-reference/split-view.mdx`): Complete API documentation for `createSplitView()`, all SplitView instance methods, event listeners, SplitDiffEntry types, and CSS decoration classes
- **Navigation updates**: Added entries to sidebar and API reference index

The split view enables side-by-side document comparison with tracked changes, automatic vertical alignment, scroll sync, and individual change review.

## Test plan

- [ ] Documentation builds without errors
- [ ] Split view guide and API reference pages are accessible
- [ ] Sidebar navigation links work correctly
- [ ] Live demo embed loads properly