### PR TITLE
Update AI Toolkit workflow docs for refactor-tiptap-edit

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/workflows.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/workflows.mdx
@@ -131,6 +131,7 @@ Applies a list of proofreading operations to the document.
   - `workflowId` (`unknown`): Unique ID for this workflow run
   - `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/ai-toolkit/api-reference/review-options)): Control preview/review behavior. [See available options](/content-ai/capabilities/ai-toolkit/api-reference/review-options).
     - In this method, `diffUtilityOptions.groupInlineChanges` defaults to `2` instead of `1`, so edits are shown as inline changes by default.
+    - `mode: 'trackedChanges'` is supported when the [Tracked Changes](/tracked-changes/getting-started/overview) extension is installed.
   - `range?` (`Range`): The range to apply the proofreading operations to
     - `from` (`number`): Start position
     - `to` (`number`): End position
@@ -138,11 +139,10 @@ Applies a list of proofreading operations to the document.
 ### Returns (`ProofreaderWorkflowResult`)
 
 - `doc` (`Node`): The modified document after applying operations
-- `operations` (`ProofreaderOperationResult[]`): Array of operation results, in the same order as the input operations. Each result contains:
-  - `delete` (`string`): The text that was deleted (or supposed to be deleted)
-  - `insert` (`string`): The text that was inserted (or supposed to be inserted)
+- `operationResults` (`OperationResult[]`): Array of operation results, in the same order as the input operations. Each result contains:
+  - `target` (`string`): The target hash associated with the operation result
   - `success` (`boolean`): Whether the operation was successful
-  - `error?` (`string`): Error message if the operation failed
+  - `error` (`string | null`): Error message if the operation failed, otherwise `null`
 
 ### Example
 
@@ -178,7 +178,7 @@ The workflow expects a user prompt as a JSON object with:
 ### Returns
 
 - `systemPrompt` (`string`): Ready-to-use system prompt that instructs the AI model on how to generate edit operations
-- `zodOutputSchema` (`ZodObject`): Zod schema for validating the AI output
+- `zodOutputSchema` (`ZodObject`): Zod schema for validating the AI output. This schema validates the streamed `operations` object returned by your model.
 - `jsonOutputSchema` (`object`): JSON schema for validating the AI output
 
 ### Example
@@ -210,21 +210,26 @@ Applies a list of edit operations to the document.
 
 - `options` (`TiptapEditWorkflowOptions`): Configuration options
   - `hasFinished` (`boolean`): Whether streaming has finished. Pass `false` while operations are still streaming and `true` for the final call.
-  - `operations` (`PartialTiptapEditOperation[]`): Array of edit operations. Each operation is a tuple `[type, target, content]`:
+  - `operations` (`PartialTiptapEditOperation[]`): Array of edit operations. Each operation is an object with:
     - `type`: `'replace'` | `'insertBefore'` | `'insertAfter'`
     - `target`: The 6-character hash of the node (from `tiptapRead`) or `'doc'` for entire document
     - `content`: HTML string with the content to insert
   - `workflowId` (`unknown`): Unique ID for this workflow run
   - `tiptapReadResult` (`TiptapReadResult`): Result returned by `tiptapRead`, used for stale-read detection while applying edit operations.
-  - `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/ai-toolkit/api-reference/review-options)): Control preview/review behavior
+  - `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/ai-toolkit/api-reference/review-options)): Control preview/review behavior.
+    - `mode: 'trackedChanges'` is supported when the [Tracked Changes](/tracked-changes/getting-started/overview) extension is installed.
+  - `streamingOptions?` (`StreamingOptions`): Controls how streamed operations are applied.
+    - `disableTypingEffect?` (`boolean`): Disables the typing effect while streamed operations are applied.
   - `tiptapEditHooks?` (`TiptapEditHooks`): Hooks for intercepting and modifying operations. See the [Tiptap Edit hooks guide](/content-ai/capabilities/ai-toolkit/advanced-guides/tiptap-edit-hooks) for details.
     - `beforeOperation?` (`(context: BeforeOperationContext) => BeforeOperationResult`): Called before each operation is applied. Return `{ action: 'accept' }` to apply the operation (optionally with `fragment` or `operationType` overrides), or `{ action: 'reject', error }` to skip it.
 
 ### Returns (`TiptapEditWorkflowResult`)
 
 - `doc` (`Node`): The modified document after applying operations
-- `successful` (`string[]`): Array of successfully processed operations
-- `failed` (`{ target: string; error?: string }[]`): Array of failed operations with error messages
+- `operationResults` (`OperationResult[]`): Array of operation results, in execution order. Each result contains:
+  - `target` (`string`): The target hash associated with the operation result
+  - `success` (`boolean`): Whether the operation completed successfully
+  - `error` (`string | null`): Error message if the operation failed, otherwise `null`
 
 ### Example
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,37 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [e3082aa]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.2.0
+
+## 0.1.4
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.4
+
+## 0.1.3
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.3
+
+## 0.1.2
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.2
+
+## 0.1.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,21 +8,15 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
-## 0.1.1
-
-### Patch Changes
-
-- @tiptap-pro/ai-toolkit-tool-definitions@0.1.1
-
 ## 0.1.0
 
 ### Minor Changes
 
-- Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
+- e214bc6: Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
 
 ### Patch Changes
 
-- Updated dependencies
+- Updated dependencies [e214bc6]
   - @tiptap-pro/ai-toolkit-tool-definitions@0.1.0
 
 ## 3.0.0-alpha.33

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,37 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [e3082aa]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.2.0
+
+## 0.1.4
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.4
+
+## 0.1.3
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.3
+
+## 0.1.2
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.2
+
+## 0.1.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,21 +8,15 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
-## 0.1.1
-
-### Patch Changes
-
-- @tiptap-pro/ai-toolkit-tool-definitions@0.1.1
-
 ## 0.1.0
 
 ### Minor Changes
 
-- Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
+- e214bc6: Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
 
 ### Patch Changes
 
-- Updated dependencies
+- Updated dependencies [e214bc6]
   - @tiptap-pro/ai-toolkit-tool-definitions@0.1.0
 
 ## 3.0.0-alpha.22

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,21 +8,15 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
-## 0.1.1
-
-### Patch Changes
-
-- @tiptap-pro/ai-toolkit-tool-definitions@0.1.1
-
 ## 0.1.0
 
 ### Minor Changes
 
-- Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
+- e214bc6: Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
 
 ### Patch Changes
 
-- Updated dependencies
+- Updated dependencies [e214bc6]
   - @tiptap-pro/ai-toolkit-tool-definitions@0.1.0
 
 ## 3.0.0-alpha.27

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,37 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [e3082aa]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.2.0
+
+## 0.1.4
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.4
+
+## 0.1.3
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.3
+
+## 0.1.2
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.2
+
+## 0.1.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,21 +8,15 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
-## 0.1.1
-
-### Patch Changes
-
-- @tiptap-pro/ai-toolkit-tool-definitions@0.1.1
-
 ## 0.1.0
 
 ### Minor Changes
 
-- Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
+- e214bc6: Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
 
 ### Patch Changes
 
-- Updated dependencies
+- Updated dependencies [e214bc6]
   - @tiptap-pro/ai-toolkit-tool-definitions@0.1.0
 
 ## 3.0.0-alpha.26

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,37 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [e3082aa]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.2.0
+
+## 0.1.4
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.4
+
+## 0.1.3
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.3
+
+## 0.1.2
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.2
+
+## 0.1.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,34 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 0.2.0
+
+### Minor Changes
+
+- e3082aa: Standardize `tiptapEdit` operation reporting around an `operationResults` array that returns one result per attempted operation, including the target, success state, and any error message.
+
+  Add `streamingOptions` field to `streamTool` and `tiptapEditWorkflow`, to customize how content is streamed.
+
+  Show a "typing effect" when streaming content in review mode or in preview mode. This "typing effect" can be disabled by configuring `streamingOptions.disableTypingEffect`.
+
+  Add Tracked Changes support to the Tiptap Edit workflow and the Proofreader workflow.
+
+  Add streaming support when using the AI Toolkit with Tracked Changes. When streaming content with tracked changes, streaming support does not show a "typing effect". Instead, it streams content on a per-operation basis.
+
+  **Breaking changes:**
+
+  - The `tiptapEdit` tool output now includes the `operationResults` property instead of `successful` and `failed`.
+  - `tiptapEditWorkflow` now returns `operationResults` instead of `successful` and `failed`.
+  - `proofreaderWorkflow` now returns `operationResults` instead of `operations`.
+
+## 0.1.4
+
+## 0.1.3
+
+## 0.1.2
+
+## 0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,13 +8,11 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
-## 0.1.1
-
 ## 0.1.0
 
 ### Minor Changes
 
-- Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
+- e214bc6: Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
 
 ## 3.0.0-alpha.36
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,54 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 0.2.0
+
+### Minor Changes
+
+- e3082aa: Standardize `tiptapEdit` operation reporting around an `operationResults` array that returns one result per attempted operation, including the target, success state, and any error message.
+
+  Add `streamingOptions` field to `streamTool` and `tiptapEditWorkflow`, to customize how content is streamed.
+
+  Show a "typing effect" when streaming content in review mode or in preview mode. This "typing effect" can be disabled by configuring `streamingOptions.disableTypingEffect`.
+
+  Add Tracked Changes support to the Tiptap Edit workflow and the Proofreader workflow.
+
+  Add streaming support when using the AI Toolkit with Tracked Changes. When streaming content with tracked changes, streaming support does not show a "typing effect". Instead, it streams content on a per-operation basis.
+
+  **Breaking changes:**
+
+  - The `tiptapEdit` tool output now includes the `operationResults` property instead of `successful` and `failed`.
+  - `tiptapEditWorkflow` now returns `operationResults` instead of `successful` and `failed`.
+  - `proofreaderWorkflow` now returns `operationResults` instead of `operations`.
+
+## 0.1.4
+
+### Patch Changes
+
+- cc227d4: Integrate AI Toolkit Tracked Changes feature with the Comments extension by following the official approach of emmitting events and setting a "suggestionReason" field on the thread.
+
+## 0.1.3
+
+### Patch Changes
+
+- eec70b8: Fix broken table rendering when streaming in review mode. Streaming now applies per-operation instead of per-character in review mode, temporarily removing the typing effect. The typing effect will return in a future release.
+
+## 0.1.2
+
+### Patch Changes
+
+- bdbdab4: Fixed a bug where all node hashes were regenerated instead of only duplicates after the first Yjs sync when using the AiToolkit hash extension with Collaboration.
+- 8016488: Fixed suggestions disappearing when undoing or redoing changes with the collaboration extension active.
+
+## 0.1.1
+
+### Patch Changes
+
+- 46addf3: Ensure all selectable nodes are correctly set up when the `tiptapRead` tool is called. Fixes a bug where not all selectable nodes were set up in the returned content of the `tiptapRead` tool.
+- b95990d: Fixed a bug where empty paragraphs accumulated in the document on every page reload when using the AiToolkit extension with the Collaboration extension and an externally created Yjs provider.
+- de48513: Fix tiptapRead returning corrupted content after a preview-mode tiptapEdit that changes the document's node structure
+- 27eb52a: Fixed table insertion failing with "Invalid HTML content" error when AI-generated HTML includes standard table wrapper elements like `<tbody>`, `<thead>`, or `<tfoot>`.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,20 +8,11 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
-## 0.1.1
-
-### Patch Changes
-
-- Ensure all selectable nodes are correctly set up when the `tiptapRead` tool is called. Fixes a bug where not all selectable nodes were set up in the returned content of the `tiptapRead` tool.
-- Fixed a bug where empty paragraphs accumulated in the document on every page reload when using the AiToolkit extension with the Collaboration extension and an externally created Yjs provider.
-- Fix tiptapRead returning corrupted content after a preview-mode tiptapEdit that changes the document's node structure
-- Fixed table insertion failing with "Invalid HTML content" error when AI-generated HTML includes standard table wrapper elements like `<tbody>`, `<thead>`, or `<tfoot>`.
-
 ## 0.1.0
 
 ### Minor Changes
 
-- Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
+- e214bc6: Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
 
 ## 3.0.0-alpha.89
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -28,6 +28,14 @@ meta:
   - `tiptapEditWorkflow` now returns `operationResults` instead of `successful` and `failed`.
   - `proofreaderWorkflow` now returns `operationResults` instead of `operations`.
 
+- ecc8c58: Add split-view for side-by-side tracked changes review
+
+### Patch Changes
+
+- df85690: Add compatibility for tracked mark-change suggestions in AI Toolkit tracked-changes readers.
+
+  The AI Toolkit tracked-changes read layer now recognizes the `markChange` suggestion type and updated tracked-changes suggestion unions so tracked mark-only suggestions are parsed without being rejected or misclassified.
+
 ## 0.1.4
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/index.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/index.mdx
@@ -6,6 +6,8 @@ meta:
   category: Content AI
 ---
 
+import { Callout } from '@/components/ui/Callout'
+
 # Changelog
 
 The AI Toolkit consists of multiple packages. Each package has its own changelog:
@@ -17,3 +19,8 @@ The AI Toolkit consists of multiple packages. Each package has its own changelog
   - [@tiptap-pro/ai-toolkit-openai](/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai) - OpenAI
   - [@tiptap-pro/ai-toolkit-anthropic](/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic) - Anthropic
   - [@tiptap-pro/ai-toolkit-tool-definitions](/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions) - Generic format
+
+<Callout title="Install the same version of all packages" variant="hint">
+  Since version `0.1.0`, we recommend to install all AI Toolkit packages on the same version number.
+  This ensures compatibility between packages.
+</Callout>

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/proofreader.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/proofreader.mdx
@@ -266,6 +266,26 @@ toolkit.proofreaderWorkflow({
 toolkit.acceptAllSuggestions()
 ```
 
+If you need per-operation execution status after applying the workflow, read `result.operationResults`.
+
+## Review changes as tracked changes
+
+If the [Tracked Changes](/tracked-changes/getting-started/overview) extension is installed, `proofreaderWorkflow` can apply corrections as tracked changes instead of preview suggestions.
+
+```tsx
+toolkit.proofreaderWorkflow({
+  operations,
+  workflowId,
+  hasFinished: true,
+  reviewOptions: {
+    mode: 'trackedChanges',
+    trackedChangesOptions: {
+      userId: 'ai-proofreader',
+    },
+  },
+})
+```
+
 See the [Suggestions](/content-ai/capabilities/ai-toolkit/advanced-guides/suggestions) guide to learn more about suggestions.
 
 ## Related guides

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit.mdx
@@ -258,6 +258,27 @@ toolkit.tiptapEditWorkflow({
 toolkit.acceptAllSuggestions()
 ```
 
+If you need per-operation execution status after applying the workflow, read `result.operationResults`.
+
+## Review changes as tracked changes
+
+If the [Tracked Changes](/tracked-changes/getting-started/overview) extension is installed, `tiptapEditWorkflow` can apply AI edits as tracked changes instead of preview suggestions.
+
+```tsx
+toolkit.tiptapEditWorkflow({
+  operations,
+  workflowId,
+  hasFinished: true,
+  tiptapReadResult: readResult,
+  reviewOptions: {
+    mode: 'trackedChanges',
+    trackedChangesOptions: {
+      userId: 'ai-assistant',
+    },
+  },
+})
+```
+
 See the [Suggestions](/content-ai/capabilities/ai-toolkit/advanced-guides/suggestions) guide to learn more about suggestions.
 
 ## Related guides

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,13 +8,11 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
-## 0.1.1
-
 ## 0.1.0
 
 ### Minor Changes
 
-- Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
+- e214bc6: Start a new versioning scheme that aligns all AI toolkit and server AI toolkit packages on the same version.
 
 ## 3.0.0-alpha.4
 

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,6 +8,16 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
+## 0.2.0
+
+## 0.1.4
+
+## 0.1.3
+
+## 0.1.2
+
+## 0.1.1
+
 ## 0.1.0
 
 ### Minor Changes


### PR DESCRIPTION
Update AI Toolkit changelog

Update API reference to adjust for version `0.2.0` of the AI Toolkit.

Mention Tracked Changes support for AI Toolkit workflows.
