### PR TITLE
docs: explain skipTrailingNode transaction meta

### DIFF
--- a/src/content/editor/extensions/functionality/trailing-node.mdx
+++ b/src/content/editor/extensions/functionality/trailing-node.mdx
@@ -71,6 +71,23 @@ TrailingNode.configure({
 })
 ```
 
+## Skipping trailing node creation on transactions
+
+You can skip the automatic trailing node insertion for a specific transaction by setting the `skipTrailingNode` meta flag on that transaction.
+
+```ts
+editor
+  .chain()
+  .command(({ tr }) => {
+    tr.setMeta('skipTrailingNode', true)
+
+    return true
+  })
+  .run()
+```
+
+This is useful when you intentionally want a transaction to leave the document without the extra trailing node.
+
 ## Source code
 
 [packages/extensions/src/trailing-node/](https://github.com/ueberdosis/tiptap/blob/main/packages/extensions/src/trailing-node/)


### PR DESCRIPTION
## Summary
- document how to skip trailing node creation on a transaction with the `skipTrailingNode` meta flag
- add a code example for setting the transaction meta in the Trailing Node docs
- rename the new section heading to describe the transaction-specific behavior clearly