### PR TITLE
Document skipTrailingNode for tracked changes

### DIFF
--- a/src/content/editor/extensions/functionality/tracked-changes.mdx
+++ b/src/content/editor/extensions/functionality/tracked-changes.mdx
@@ -56,7 +56,7 @@ const editor = new Editor({
 
 ## Programmatic suggestions
 
-In addition to interactive review workflows, the extension also exposes commands for creating tracked suggestions directly from application logic. Use these commands when you need to insert, delete, or replace content as suggestions without turning tracked changes mode on for every editor interaction. You can also attach a `reason` to programmatic suggestions, which is emitted with the creation event for downstream workflows. Insert and replace commands accept full Tiptap `Content`, so they can work with JSON nodes such as images, not just plain text.
+In addition to interactive review workflows, the extension also exposes commands for creating tracked suggestions directly from application logic. Use these commands when you need to insert, delete, or replace content as suggestions without turning tracked changes mode on for every editor interaction. You can also attach a `reason` to programmatic suggestions, which is emitted with the creation event for downstream workflows. Insert and replace commands accept full Tiptap `Content`, so they can work with JSON nodes such as images, not just plain text. If you also use the [TrailingNode](/editor/extensions/functionality/trailing-node) extension, `addTrackedInsertion()` and `addTrackedReplacement()` can set `skipTrailingNode: true` to forward that transaction meta onto the emitted tracked-changes transaction.
 
 ```js
 editor.commands.addTrackedInsertion({
@@ -76,6 +76,7 @@ editor.commands.addTrackedReplacement({
   to: 12,
   content: 'earth',
   reason: 'Standardized terminology',
+  skipTrailingNode: true,
 })
 ```
 

--- a/src/content/tracked-changes/api-reference/commands.mdx
+++ b/src/content/tracked-changes/api-reference/commands.mdx
@@ -150,19 +150,21 @@ editor.commands.rejectSuggestionsByUser({ userId: 'user-123' })
 
 ## addTrackedInsertion()
 
-Insert content as a tracked suggestion without enabling tracked changes mode for the whole editor. This is useful when you need to create suggestions programmatically and want the result to match a normal tracked typing transaction. The `content` argument accepts any Tiptap `Content` value, including text, HTML, or JSON node content such as an image node.
+Insert content as a tracked suggestion without enabling tracked changes mode for the whole editor. This is useful when you need to create suggestions programmatically and want the result to match a normal tracked typing transaction. The `content` argument accepts any Tiptap `Content` value, including text, HTML, or JSON node content such as an image node. When `skipTrailingNode` is `true`, the emitted transaction also sets `skipTrailingNode: true`, which is useful with the [TrailingNode](/editor/extensions/functionality/trailing-node) extension.
 
-| Argument  | Type      | Description                                                                           |
-| --------- | --------- | ------------------------------------------------------------------------------------- |
-| `from`    | `number`  | Document position where the tracked insertion should be added                         |
-| `content` | `Content` | The content to insert as a suggestion                                                 |
-| `reason`  | `string`  | Optional description included in the `trackedChanges:suggestionCreated` event payload |
+| Argument           | Type      | Description                                                                           |
+| ------------------ | --------- | ------------------------------------------------------------------------------------- |
+| `from`             | `number`  | Document position where the tracked insertion should be added                         |
+| `content`          | `Content` | The content to insert as a suggestion                                                 |
+| `reason`           | `string`  | Optional description included in the `trackedChanges:suggestionCreated` event payload |
+| `skipTrailingNode` | `boolean` | Optional flag that sets `skipTrailingNode: true` on the emitted tracked transaction   |
 
 ```js
 editor.commands.addTrackedInsertion({
   from: 7,
   content: 'big ',
   reason: 'Applied AI rewrite',
+  skipTrailingNode: true,
 })
 ```
 
@@ -200,14 +202,15 @@ editor.commands.addTrackedDeletion({
 
 ## addTrackedReplacement()
 
-Replace an existing range with a tracked replacement suggestion. The replaced content becomes the deletion part of the suggestion, and the new content becomes the insertion part. The `content` argument accepts any Tiptap `Content` value, so you can replace text with a different node by passing JSON content.
+Replace an existing range with a tracked replacement suggestion. The replaced content becomes the deletion part of the suggestion, and the new content becomes the insertion part. The `content` argument accepts any Tiptap `Content` value, so you can replace text with a different node by passing JSON content. When `skipTrailingNode` is `true`, the emitted transaction also sets `skipTrailingNode: true`, which is useful with the [TrailingNode](/editor/extensions/functionality/trailing-node) extension.
 
-| Argument  | Type      | Description                                                                           |
-| --------- | --------- | ------------------------------------------------------------------------------------- |
-| `from`    | `number`  | Start position of the range to replace                                                |
-| `to`      | `number`  | End position of the range to replace                                                  |
-| `content` | `Content` | Replacement content to insert as a tracked suggestion                                 |
-| `reason`  | `string`  | Optional description included in the `trackedChanges:suggestionCreated` event payload |
+| Argument           | Type      | Description                                                                           |
+| ------------------ | --------- | ------------------------------------------------------------------------------------- |
+| `from`             | `number`  | Start position of the range to replace                                                |
+| `to`               | `number`  | End position of the range to replace                                                  |
+| `content`          | `Content` | Replacement content to insert as a tracked suggestion                                 |
+| `reason`           | `string`  | Optional description included in the `trackedChanges:suggestionCreated` event payload |
+| `skipTrailingNode` | `boolean` | Optional flag that sets `skipTrailingNode: true` on the emitted tracked transaction   |
 
 ```js
 editor.commands.addTrackedReplacement({
@@ -215,6 +218,7 @@ editor.commands.addTrackedReplacement({
   to: 12,
   content: 'earth',
   reason: 'Replaced with approved terminology',
+  skipTrailingNode: true,
 })
 ```
 


### PR DESCRIPTION
## Summary
- document the `skipTrailingNode` option for tracked insertion and replacement commands
- explain that the option forwards `skipTrailingNode: true` onto the emitted tracked-changes transaction
- add examples that show how to use the option alongside the TrailingNode extension

Docs of https://github.com/ueberdosis/tiptap/pull/7639