### PR TITLE
Update Server AI Toolkit tracked changes guide for refactor

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/tools/index.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/tools/index.mdx
@@ -32,6 +32,10 @@ Edit the document using an efficient format optimized for editing operations.
 
 The tool uses an efficient format that allows making precise edits to the document without replacing the entire content, reducing token usage and improving performance.
 
+### Result
+
+`tiptapEdit` returns `operationResults`, one entry per attempted operation. Each result includes the target, whether the operation succeeded, and any error message if it failed.
+
 ## `getThreads`
 
 Retrieve all threads and comments in the document. This tool provides comprehensive information about existing discussions and feedback in the document.
@@ -66,4 +70,4 @@ Perform operations on threads and comments in the document. This tool enables co
 
 ### Result
 
-A success message if the operations were successful, or an error message if they were not.
+An output object that includes `success` and `operationResults` for the attempted thread and comment operations.

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
@@ -27,7 +27,8 @@ Display server-side AI edits as tracked changes, so your users can review and ac
 1. The client creates a **session** via the Server AI Toolkit API.
 2. The AI reads the document with `tiptapRead` and the session records a snapshot.
 3. The AI edits the document with `tiptapEdit` in `trackedChanges` mode — the server writes tracked change marks instead of directly mutating the document.
-4. The client displays the tracked changes and lets users accept or reject them.
+4. If the edit operations include `meta`, the server turns that metadata into comment threads through the Comments API.
+5. The client displays the tracked changes and lets users accept or reject them.
 
 ## Show tracked changes
 
@@ -175,7 +176,7 @@ const result = await fetch(`${apiBaseUrl}/toolkit/execute-tool`, {
 })
 ```
 
-Each non-empty `meta` field in the edit operations becomes a comment thread linked to its tracked change. The justification is stored as the thread's first comment content and as `suggestionReason` in the thread data.
+Each non-empty `meta` field in the edit operations becomes a comment thread linked to its tracked change. The server creates and updates those threads through the Comments API, and stores the justification as the thread's first comment content and as `suggestionReason` in the thread data.
 
 ### Client-side setup
 
@@ -199,7 +200,7 @@ const editor = useEditor({
 })
 ```
 
-Users can review the tracked change and read the AI's justification in the comments sidebar.
+Users can review the tracked change and read the AI's justification in the comments sidebar. The comment thread lifecycle is managed server-side through the Comments API, not through editor event listeners.
 
 ### End result
 


### PR DESCRIPTION
## Summary
Update the Server AI Toolkit tracked changes docs to match the refactored server behavior.

## Changes
- document `operationResults` for server tools
- clarify that tracked-changes comments are created through the Comments API path
- align the guide text with the current server demo behavior
