### PR TITLE
Reorganize Server AI Toolkit custom node docs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -510,7 +510,12 @@ const nextConfig = {
       // Server AI Toolkit redirects
       {
         source: '/content-ai/capabilities/server-ai-toolkit/advanced-guides',
-        destination: '/content-ai/capabilities/server-ai-toolkit/advanced-guides/tiptap-shorthand',
+        destination: '/content-ai/capabilities/server-ai-toolkit/advanced-guides/custom-nodes',
+        permanent: true,
+      },
+      {
+        source: '/content-ai/capabilities/server-ai-toolkit/agents/schema-awareness',
+        destination: '/content-ai/capabilities/server-ai-toolkit/advanced-guides/custom-nodes',
         permanent: true,
       },
       {

--- a/src/content/content-ai/capabilities/server-ai-toolkit/advanced-guides/custom-nodes.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/advanced-guides/custom-nodes.mdx
@@ -1,8 +1,8 @@
 ---
-title: Schema awareness
+title: Custom nodes
 meta:
-  title: Schema awareness | Tiptap Content AI
-  description: Give schema awareness to your AI model so it understands nodes, marks, and attributes in the Server AI Toolkit.
+  title: Custom nodes | Tiptap Content AI
+  description: Configure custom nodes and marks for the Server AI Toolkit so AI models can generate them correctly.
   category: Content AI
 ---
 
@@ -13,22 +13,19 @@ import { Callout } from '@/components/ui/Callout'
   guide](/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot). Read it first.
 </Callout>
 
-A Tiptap [schema](/editor/core-concepts/schema) describes the elements the document can (and cannot) contain. Tiptap's **schema awareness** capabilities allow AI models to understand the document better and generate custom elements.
+If your document includes custom nodes or marks, configure schema awareness so the Server AI
+Toolkit can describe them correctly to your AI model.
 
-<Callout title="Why schema awareness?" variant="default">
-  Without schema awareness, the AI model might generate content that the Tiptap editor does not
-  support. For example, it might generate a table in a document that does not support tables. With
-  schema awareness enabled, the AI model will know that table nodes are not supported and will
-  refuse to generate them.
+<Callout title="Why configure custom nodes?" variant="default">
+  Without schema awareness, the AI model might generate content that your editor does not support,
+  or miss custom elements entirely. Adding custom node metadata gives the model enough context to
+  generate those elements reliably.
 </Callout>
 
-## Guide: give schema awareness to your AI model
+## Get schema awareness data
 
-Integrate the schema awareness feature to an AI agent like the one built in the [AI agent chatbot guide](/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot).
-
-### Step 1: get the schema awareness data
-
-Get the schema awareness data from the Server AI Toolkit package. This data contains information about the document's schema in a format optimized for the AI model.
+Start by generating schema awareness data from your editor. The Server AI Toolkit uses this data to
+describe your document structure to the AI model.
 
 ```ts
 import { Editor } from '@tiptap/core'
@@ -43,19 +40,19 @@ const editor = new Editor({
 const schemaAwarenessData = getSchemaAwarenessData(editor)
 ```
 
-The `getSchemaAwarenessData` function returns schema awareness data that describes the document structure for the Server AI Toolkit API.
-
 <Callout title="Store the schema awareness data" variant="info">
   The schema awareness data returned by `getSchemaAwarenessData` is a JSON-serializable object that
-  you can store in your database. You don't need to generate it every time—only update it when your
-  Editor extensions or schema change.
+  you can store in your database. You don't need to generate it every time. Update it when your
+  editor extensions or schema change.
 </Callout>
 
-### Step 2: configure custom nodes
+## Configure custom nodes
 
-If your document contains [custom Nodes and Marks](/editor/extensions/custom-extensions), add the `addJsonSchemaAwareness` option to the extension configuration. This way, the AI model will be able to generate this custom Node or Mark accurately.
+If your document contains [custom Nodes and Marks](/editor/extensions/custom-extensions), add the
+`addJsonSchemaAwareness` option to the extension configuration. This allows the AI model to
+understand and generate that custom node or mark accurately.
 
-For example, if you have a custom node called `'alert'`, you can allow the AI model to generate it by configuring it like this:
+For example, if you have a custom node called `'alert'`, configure it like this:
 
 ```ts
 import { Node } from '@tiptap/core'
@@ -73,6 +70,7 @@ const CustomExtension = Node.create({
           if (!attributes.type) {
             return {}
           }
+
           return {
             'data-type': attributes.type,
           }
@@ -107,8 +105,6 @@ It can contain inline content like text and formatting marks.`,
   renderHTML({ HTMLAttributes }) {
     return ['div', { ...HTMLAttributes, 'data-alert': '' }, 0]
   },
-
-  // ... Other extension configuration options
 })
 ```
 

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot.mdx
@@ -221,6 +221,12 @@ export async function getSchemaAwarenessPrompt(schemaAwarenessData: unknown): Pr
 }
 ```
 
+<Callout title="Using custom nodes?" variant="info">
+  If your editor includes custom nodes or marks, configure them with
+  `addJsonSchemaAwareness`. See the [custom nodes
+  guide](/content-ai/capabilities/server-ai-toolkit/advanced-guides/custom-nodes).
+</Callout>
+
 #### Execute tool
 
 This function executes a tool via the Server AI Toolkit API. It sends the tool name, input parameters, document ID, and schema awareness data to the API. The server automatically fetches and saves the Tiptap Cloud document using the credentials in the JWT.
@@ -513,6 +519,6 @@ See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
 
 ## Next steps
 
-- Allow your AI to generate custom elements with the [Schema awareness guide](/content-ai/capabilities/server-ai-toolkit/agents/schema-awareness)
+- Allow your AI to generate custom elements with the [custom nodes guide](/content-ai/capabilities/server-ai-toolkit/advanced-guides/custom-nodes)
 - Learn more about the available tools in the [Agents section](/content-ai/capabilities/server-ai-toolkit/agents)
 - Explore the [REST API reference](/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api) for complete endpoint documentation

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/index.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/index.mdx
@@ -28,16 +28,15 @@ With the Server AI Toolkit, you can build agents with server-side document editi
     </div>
   </Link>
   <Link
-    href="/content-ai/capabilities/server-ai-toolkit/agents/schema-awareness"
+    href="/content-ai/capabilities/server-ai-toolkit/advanced-guides/custom-nodes"
     className="flex flex-col p-4 border border-grayAlpha-200 rounded-lg hover:border-grayAlpha-300 transition-colors cursor-pointer no-underline"
   >
     <div className="flex items-center justify-between mb-2">
-      <h4 className="font-semibold text-black">Schema awareness</h4>
+      <h4 className="font-semibold text-black">Custom nodes</h4>
       <span className="text-sm text-blue-600 font-medium whitespace-nowrap ml-4">More →</span>
     </div>
     <div className="text-sm text-grayAlpha-700">
-      Allow your AI model to understand custom nodes, marks, and attributes in your Tiptap
-      documents.
+      Configure schema awareness for custom nodes and marks so your AI can generate them reliably.
     </div>
   </Link>
   <Link

--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/schema-awareness.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/schema-awareness.mdx
@@ -24,7 +24,7 @@ This function collects schema information from extensions and converts it to a f
   Editor extensions or schema change.
 </Callout>
 
-See an example of how to use it in the [schema awareness guide](/content-ai/capabilities/server-ai-toolkit/agents/schema-awareness).
+See an example of how to use it in the [custom nodes guide](/content-ai/capabilities/server-ai-toolkit/advanced-guides/custom-nodes).
 
 ### Parameters
 

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/index.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/index.mdx
@@ -6,8 +6,6 @@ meta:
   category: Content AI
 ---
 
-# Changelog
-
 The Server AI Toolkit consists of the following modules:
 
 - [@tiptap-pro/server-ai-toolkit](/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit) - Server AI Toolkit package

--- a/src/content/content-ai/capabilities/server-ai-toolkit/install.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/install.mdx
@@ -63,6 +63,12 @@ The `getSchemaAwarenessData` function returns schema awareness data that describ
   Editor extensions or schema change.
 </Callout>
 
+<Callout title="Using custom nodes?" variant="info">
+  If your editor includes custom nodes or marks, configure them with
+  `addJsonSchemaAwareness`. See the [custom nodes
+  guide](/content-ai/capabilities/server-ai-toolkit/advanced-guides/custom-nodes).
+</Callout>
+
 For more details, see the [Schema awareness API reference](/content-ai/capabilities/server-ai-toolkit/api-reference/schema-awareness).
 
 ## Set up authorization

--- a/src/content/content-ai/capabilities/server-ai-toolkit/overview.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/overview.mdx
@@ -70,16 +70,15 @@ Build [AI agents](/content-ai/capabilities/server-ai-toolkit/agents) that can pe
     </div>
   </Link>
   <Link
-    href="/content-ai/capabilities/server-ai-toolkit/agents/schema-awareness"
+    href="/content-ai/capabilities/server-ai-toolkit/advanced-guides/custom-nodes"
     className="flex flex-col p-4 border border-grayAlpha-200 rounded-lg hover:border-grayAlpha-300 transition-colors cursor-pointer no-underline"
   >
     <div className="flex items-center justify-between mb-2">
-      <h4 className="font-semibold text-black">Schema awareness</h4>
+      <h4 className="font-semibold text-black">Custom nodes</h4>
       <span className="text-sm text-blue-600 font-medium whitespace-nowrap ml-4">More →</span>
     </div>
     <div className="text-sm text-grayAlpha-700">
-      Allow your AI model to understand custom nodes, marks, and attributes in your Tiptap
-      documents.
+      Configure schema awareness for custom nodes and marks so your AI can generate them reliably.
     </div>
   </Link>
 </div>

--- a/src/content/content-ai/sidebar.ts
+++ b/src/content/content-ai/sidebar.ts
@@ -298,10 +298,6 @@ export const sidebarConfig: SidebarConfig = {
                   href: '/content-ai/capabilities/server-ai-toolkit/agents/review-changes',
                 },
                 {
-                  title: 'Schema awareness',
-                  href: '/content-ai/capabilities/server-ai-toolkit/agents/schema-awareness',
-                },
-                {
                   title: 'Comments',
                   href: '/content-ai/capabilities/server-ai-toolkit/agents/comments',
                 },
@@ -333,6 +329,10 @@ export const sidebarConfig: SidebarConfig = {
               title: 'Advanced guides',
               href: '/content-ai/capabilities/server-ai-toolkit/advanced-guides',
               children: [
+                {
+                  title: 'Custom nodes',
+                  href: '/content-ai/capabilities/server-ai-toolkit/advanced-guides/custom-nodes',
+                },
                 {
                   title: 'Tiptap Shorthand',
                   href: '/content-ai/capabilities/server-ai-toolkit/advanced-guides/tiptap-shorthand',


### PR DESCRIPTION
- move the Server AI Toolkit schema awareness guide from the agents section to advanced guides as custom nodes
- update install, AI agent chatbot, overview, and agents pages to point users to the new custom nodes guide
- add redirects from the old schema awareness path and make the Server AI Toolkit advanced guides landing page resolve to the new guide
- remove the duplicate changelog H1 on the changelog landing page