### PR TITLE
Fix review UI docs when using Server AI toolkit with Tiptap Cloud Documents

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/review-changes.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/review-changes.mdx
@@ -22,43 +22,42 @@ import { Requirements, RequirementItem } from '@/components/Requirements'
 
 After the Server AI Toolkit edits a document on the server, you can display a review UI on the client so users can accept or reject the changes before they are applied.
 
-This guide shows how to use the client-side AI Toolkit's `setSuggestions` method with the `compareDocuments` format to show a diff of the server-side changes.
+This guide shows how to use the client-side AI Toolkit's `setSuggestionsFromDiff` method in review mode to show a diff between the original document and the edited version.
 
 ## How it works
 
-1. The Server AI Toolkit edits the document on the server and returns the updated document.
-2. On the client, you pass the updated document to the AI Toolkit's `setSuggestions` method using the `compareDocuments` format.
-3. The AI Toolkit compares the current editor document with the updated document and displays the differences as suggestions.
-4. Users can accept or reject individual changes, or accept/reject all changes at once.
+1. The developer stores the current document before the AI makes any changes, in the `originalDoc` variable.
+2. The AI modifies the document and returns the updated version.
+3. On the client, the developer calls `setSuggestionsFromDiff` with `originalDoc` as the document to compare with.
+4. The AI Toolkit compares the original document with the current version, and displays the differences as review suggestions.
+5. Users can accept or reject individual changes, or accept/reject all changes at once.
 
 ## Display the diff
 
-After receiving the updated document from the Server AI Toolkit, use `setSuggestions` to show the changes:
+After receiving the updated document from the Server AI Toolkit, use `setSuggestionsFromDiff` in review mode to show the changes:
 
 ```ts
 import { getAiToolkit } from '@tiptap-pro/ai-toolkit'
-import { Node } from '@tiptap/pm/model'
 
 // Get the AI Toolkit instance from the editor
 const toolkit = getAiToolkit(editor)
 
-// `doc` is the updated document returned by the Server AI Toolkit.
-// Convert it to a ProseMirror Node with the editor's schema.
-const otherDoc = Node.fromJSON(editor.state.schema, doc)
+// Store the document before the AI makes changes.
+const originalDoc = editor.state.doc
 
-// Display the diff
+// Wait for the AI to make a tool call and edit the document.
+
+// After the document is edit, show the diff between the old and the new document
 toolkit.setSuggestionsFromDiff({
-  doc: otherDoc,
+  reviewOptions: {
+    // Show suggestions in review mode
+    mode: 'review',
+  },
+  doc: originalDoc,
 })
 ```
 
-<Callout title="Schema compatibility" variant="warning">
-  The document returned by the Server AI Toolkit must be converted to a ProseMirror `Node` using the
-  editor's schema. Use `Node.fromJSON(editor.state.schema, doc)` to ensure both documents share the
-  same schema.
-</Callout>
-
-The editor will now display the differences between the current document and the server-edited version, with deletions highlighted in red and insertions in green.
+The editor will now display the differences between the original document and the server-edited version, with deletions highlighted in red and insertions in green.
 
 ## Style the diff
 


### PR DESCRIPTION
## Summary
- Restore the server AI Toolkit review-changes guide in the docs tree.
- Update the walkthrough so it stores the original document, lets the AI modify it, then calls `setSuggestionsFromDiff` in `review` mode.
- Keep the example aligned with the original document and updated document comparison flow.

## Notes
- The branch was rebased onto the current remote tip before pushing.