### PR TITLE
Fix ToC button icon rendering in dev

### DIFF
--- a/src/components/ToCButton.tsx
+++ b/src/components/ToCButton.tsx
@@ -1,7 +1,7 @@
 'use client'
 
+import { TableOfContentIcon } from './icons/TableOfContentIcon'
 import { Button } from './ui/Button'
-import TableOfContentIcon from '@/assets/icons/TableOfContent.svg'
 import { useToC } from '@/hooks/useToC'
 import { useAppState } from '@/providers/AppState'
 

--- a/src/components/icons/TableOfContentIcon.tsx
+++ b/src/components/icons/TableOfContentIcon.tsx
@@ -1,0 +1,47 @@
+import type { SVGProps } from 'react'
+
+/**
+ * Table of contents icon used in navigation controls.
+ */
+export const TableOfContentIcon = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" {...props}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M8 6C8 5.44772 8.44772 5 9 5H21C21.5523 5 22 5.44772 22 6C22 6.55228 21.5523 7 21 7H9C8.44772 7 8 6.55228 8 6Z"
+        fill="currentColor"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M11 12C11 11.4477 11.4477 11 12 11H21C21.5523 11 22 11.4477 22 12C22 12.5523 21.5523 13 21 13H12C11.4477 13 11 12.5523 11 12Z"
+        fill="currentColor"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M8 18C8 17.4477 8.44772 17 9 17H21C21.5523 17 22 17.4477 22 18C22 18.5523 21.5523 19 21 19H9C8.44772 19 8 18.5523 8 18Z"
+        fill="currentColor"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M3.5 16.5C3.22386 16.5 3 16.7239 3 17V19C3 19.2761 3.22386 19.5 3.5 19.5H5.5C5.77614 19.5 6 19.2761 6 19V17C6 16.7239 5.77614 16.5 5.5 16.5H3.5Z"
+        fill="currentColor"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M6.5 10.5C6.22386 10.5 6 10.7239 6 11V13C6 13.2761 6.22386 13.5 6.5 13.5H8.5C8.77614 13.5 9 13.2761 9 13V11C9 10.7239 8.77614 10.5 8.5 10.5H6.5Z"
+        fill="currentColor"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M3.5 4.5C3.22386 4.5 3 4.72386 3 5V7C3 7.27614 3.22386 7.5 3.5 7.5H5.5C5.77614 7.5 6 7.27614 6 7V5C6 4.72386 5.77614 4.5 5.5 4.5H3.5Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary
- replace the `ToCButton` SVG asset import with a local React icon component
- avoid runtime issues when the SVG import resolves to a non-component object in dev
- keep the icon typed via `SVGProps<SVGSVGElement>` for straightforward reuse

## Testing
- Not run (not requested)