### PR TITLE
Sync AI Toolkit changelogs

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 0.2.2
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.2.2
+
+## 0.2.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.2.1
+
 ## 0.2.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 0.2.2
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.2.2
+
+## 0.2.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.2.1
+
 ## 0.2.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 0.2.2
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.2.2
+
+## 0.2.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.2.1
+
 ## 0.2.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 0.2.2
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.2.2
+
+## 0.2.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.2.1
+
 ## 0.2.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,10 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 0.2.2
+
+## 0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,20 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 0.2.2
+
+### Patch Changes
+
+- daaa0b3: Add support for storing metadata on template fields and expose a helper to read field content plus metadata from Tiptap JSON templates.
+- d531d09: fix(split-view): resolve accept/reject issues and improve UX
+- 2c96594: Allow AI edit operations to insert and replace valid block content inside documents with fixed surrounding schema slots such as required headers and footers.
+
+## 0.2.1
+
+### Patch Changes
+
+- bb69e24: Improve proofreader replacement matching across punctuation boundaries so replacements can target words adjacent to characters like hyphens and slashes.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,6 +8,10 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
+## 0.2.2
+
+## 0.2.1
+
 ## 0.2.0
 
 ## 0.1.4


### PR DESCRIPTION
Updates the AI Toolkit and Server AI Toolkit changelog pages to match the latest releases from tiptap-pro, including the 0.2.2 and 0.2.1 entries across the package-specific changelog pages.\n\nAlso refreshes the AI Toolkit subpackage changelogs so the docs stay aligned with the published package histories.