### PR TITLE
docs: update markdown import REST API logs response example

### DIFF
--- a/src/content/conversion/import/markdown/rest-api.mdx
+++ b/src/content/conversion/import/markdown/rest-api.mdx
@@ -86,7 +86,11 @@ curl -X POST "https://api.tiptap.dev/v2/convert/import/markdown" \
       ]
     }
   },
-  "logs": []
+  "logs": {
+    "info": [],
+    "warn": [],
+    "error": []
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary

Update the Markdown import REST API docs to reflect the current `logs` response shape returned by the endpoint.

## Changes

- replace `"logs": []` with a structured `logs` object
- document the `info`, `warn`, and `error` log buckets shown in the response example
- align the docs example with the actual API behavior

## Context

This change was prompted by a discrepancy between the published docs and the response returned while testing the v2 import endpoint.
Related docs page: https://tiptap.dev/docs/conversion/import/markdown/rest-api#response-200-ok
As discussed in discord: https://discord.com/channels/818568566479257641/1481387531835805919/1481387531835805919