### PR TITLE
Sync AI Toolkit changelogs

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 0.3.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.0
+
+## 0.2.3
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.2.3
+
 ## 0.2.2
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 0.3.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.0
+
+## 0.2.3
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.2.3
+
 ## 0.2.2
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 0.3.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.0
+
+## 0.2.3
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.2.3
+
 ## 0.2.2
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 0.3.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.0
+
+## 0.2.3
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.2.3
+
 ## 0.2.2
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,10 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 0.3.0
+
+## 0.2.3
+
 ## 0.2.2
 
 ## 0.2.1

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,20 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 0.3.0
+
+### Patch Changes
+
+- 6fd2db6: Fix split view spacer alignment by sorting inputs by vertical position
+- 55562f3: Fix table row hashing when AI Toolkit operations parse standalone table HTML such as `<tr>` content.
+- 35e5476: fix(ai-toolkit): compensate for broken CSS margin collapsing in split view spacers
+
+## 0.2.3
+
+### Patch Changes
+
+- a631995: Fix the proofreader workflow so all valid sequential corrections are applied.
+
 ## 0.2.2
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
+## 0.3.0
+
+### Minor Changes
+
+- 7a2f040: Added the ServerAiToolkit extension.
+
+### Patch Changes
+
+- 55562f3: Fix table row hashing when AI Toolkit operations parse standalone table HTML such as `<tr>` content.
+
+## 0.2.3
+
 ## 0.2.2
 
 ## 0.2.1


### PR DESCRIPTION
## Summary
- sync the AI Toolkit changelog pages with the latest package releases from 
- add the missing  and  entries for the AI Toolkit package pages
- add the missing  and  entries for the Server AI Toolkit changelog page

## Testing
- not run (docs-only change)