### PR TITLE
Document the details toggle button renderer

### DIFF
--- a/src/content/editor/extensions/nodes/details.mdx
+++ b/src/content/editor/extensions/nodes/details.mdx
@@ -59,6 +59,25 @@ Details.configure({
 })
 ```
 
+### renderToggleButton
+
+Customize the button that toggles a details node. The callback receives the button `element`, the current `isOpen` state, and the `node` that should be used to derive the label.
+
+This is useful when you want to change the button's accessible label or update the button element directly.
+
+```js
+Details.configure({
+  renderToggleButton: ({ element, isOpen, node }) => {
+    element.setAttribute(
+      'aria-label',
+      isOpen
+        ? `Collapse details: ${node.textContent || 'details'}`
+        : `Expand details: ${node.textContent || 'details'}`,
+    )
+  },
+})
+```
+
 ### HTMLAttributes
 
 Custom HTML attributes that should be added to the rendered HTML tag.


### PR DESCRIPTION
## Summary

This updates the Details extension docs to cover the new `renderToggleButton` option. The option lets you imperatively customize the toggle button element, including its accessible label, based on the current open state and the node being labeled.

Related code change: https://github.com/ueberdosis/tiptap/pull/7656

## Example

```js
Details.configure({
  renderToggleButton: ({ element, isOpen, node }) => {
    element.setAttribute(
      'aria-label',
      isOpen
        ? `Collapse details: ${node.textContent || 'details'}`
        : `Expand details: ${node.textContent || 'details'}`,
    )
  },
})
```
