### PR TITLE
docs: update split view demo URL to ai-toolkit-demos

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/split-view.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/split-view.mdx
@@ -13,7 +13,7 @@ Build a side-by-side comparison that shows the original and AI-modified versions
 <CodeDemo
   isPro
   isLarge
-  src="https://compare-doc-inky.vercel.app/"
+  src="https://ai-toolkit-demos.vercel.app/split-view"
 />
 
 ## How it works
@@ -132,7 +132,7 @@ splitView.on('sync', (entries) => {
 <CodeDemo
   isPro
   isLarge
-  src="https://compare-doc-inky.vercel.app/"
+  src="https://ai-toolkit-demos.vercel.app/split-view"
 />
 
 ## Next steps


### PR DESCRIPTION
Update the split view demo link from the old `compare-doc-inky.vercel.app` URL to the new consolidated `ai-toolkit-demos.vercel.app/split-view` URL. Both demo embeds in the split view guide are updated.