### PR TITLE
Sync AI toolkit changelogs

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,19 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 0.3.2
+
+### Patch Changes
+
+- Updated dependencies [8a7a077]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.3.2
+
+## 0.3.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.1
+
 ## 0.3.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,19 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 0.3.2
+
+### Patch Changes
+
+- Updated dependencies [8a7a077]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.3.2
+
+## 0.3.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.1
+
 ## 0.3.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,19 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 0.3.2
+
+### Patch Changes
+
+- Updated dependencies [8a7a077]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.3.2
+
+## 0.3.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.1
+
 ## 0.3.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,19 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 0.3.2
+
+### Patch Changes
+
+- Updated dependencies [8a7a077]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.3.2
+
+## 0.3.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.1
+
 ## 0.3.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,14 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 0.3.2
+
+### Patch Changes
+
+- 8a7a077: Fix the published CLI so `tool-definitions` and the workflow commands run correctly when invoked as a package binary.
+
+## 0.3.1
+
 ## 0.3.0
 
 ## 0.2.3

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,14 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 0.3.2
+
+## 0.3.1
+
+### Patch Changes
+
+- edd30dc: Add ResizeObserver to split view that recalculates spacer heights when container width changes (e.g. sidebar toggle), with debounce and cooldown to prevent oscillation.
+
 ## 0.3.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,6 +8,10 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
+## 0.3.2
+
+## 0.3.1
+
 ## 0.3.0
 
 ### Minor Changes


### PR DESCRIPTION
## Summary
- add the missing 0.3.1 and 0.3.2 changelog entries for the AI Toolkit package pages
- add the matching 0.3.1 and 0.3.2 changelog entries for the Server AI Toolkit page
- align the docs changelog content with the latest releases from tiptap-pro

## Testing
- not run (docs lint skipped)