### PR TITLE
Replace next lint scripts with eslint and prettier

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,10 +4,18 @@ const require = createRequire(import.meta.url)
 
 const nextConfig = require('eslint-config-next')
 const prettierConfig = require('eslint-config-prettier')
+const mdxPlugin = require('eslint-plugin-mdx')
+const prettierPlugin = require('eslint-plugin-prettier')
 
 const config = [
   ...nextConfig,
+  mdxPlugin.flat,
   prettierConfig,
+  {
+    plugins: {
+      prettier: prettierPlugin,
+    },
+  },
   {
     files: ['**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}'],
     rules: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,24 @@
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+
+const nextConfig = require('eslint-config-next')
+const prettierConfig = require('eslint-config-prettier')
+
+const config = [
+  ...nextConfig,
+  prettierConfig,
+  {
+    files: ['**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}'],
+    rules: {
+      'no-tabs': 'error',
+      'comma-dangle': ['error', 'always-multiline'],
+      'eol-last': ['error', 'always'],
+      'no-unused-vars': 'warn',
+      'prefer-template': 'error',
+      'import/order': 'error',
+    },
+  },
+]
+
+export default config

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "build": "pnpm run build:next",
     "build:next": "next build",
     "start": "next start",
-    "lint": "next lint",
-    "lint:fix": "next lint --fix",
+    "lint": "eslint . && prettier --check .",
+    "lint:fix": "eslint . --fix && prettier --write .",
     "standalone": "pnpm run build && cp -r ./.next/static ./.next/standalone/.next && cp -r public ./.next/standalone && node .next/standalone/server.js",
     "changeset": "changeset",
     "changeset:version": "changeset version"


### PR DESCRIPTION
## Why this change is needed
The project was updated to a newer Next.js version, but the package scripts still called the deprecated next lint command.
In current Next.js versions, next lint is no longer provided as the lint entrypoint, so the existing lint and lint:fix scripts no longer work.

## What changed
- replace the obsolete next lint scripts with direct eslint and prettier commands
- add an eslint.config.mjs bridge so ESLint 9 can run with the repo after the Next.js upgrade
- keep lint and lint:fix as separate ESLint and Prettier steps

## Notes
- the repo already carries the relevant ESLint-related packages, so this change keeps linting on the supported ESLint/Prettier path instead of relying on the removed Next wrapper
- running pnpm lint now executes the new commands and surfaces the current repo lint issues rather than failing because next lint no longer exists
