### PR TITLE
docs: add suggestion reset docs

### DIFF
--- a/src/content/editor/api/utilities/suggestion.mdx
+++ b/src/content/editor/api/utilities/suggestion.mdx
@@ -49,6 +49,31 @@ shouldShow: ({ editor, range, query, text, transaction }) => {
 
 Default: `null`
 
+### shouldResetDismissed
+
+Controls when a dismissed suggestion becomes active again after the user closes it with Escape or `exitSuggestion()`.
+
+By default, the utility keeps the dismissed suggestion closed while the user stays in the same trigger context. With `allowSpaces: true`, that dismissed context can span spaces until the cursor leaves it.
+
+Use `shouldResetDismissed` if you need to decide yourself when that dismissed context should be cleared.
+
+```js
+Suggestion({
+  // ...
+  shouldResetDismissed: ({ transaction, allowSpaces, range, match }) => {
+    if (!allowSpaces) {
+      return false
+    }
+
+    return transaction.doc.textBetween(range.from, match.range.to, '\n').includes('.')
+  },
+})
+```
+
+Return `true` to clear the dismissed state for the current transaction and allow the suggestion to open again.
+
+Default: `null`
+
 
 ### allowSpaces
 

--- a/src/content/editor/api/utilities/suggestion.mdx
+++ b/src/content/editor/api/utilities/suggestion.mdx
@@ -57,6 +57,8 @@ By default, the utility keeps the dismissed suggestion closed while the user sta
 
 Use `shouldResetDismissed` if you need to decide yourself when that dismissed context should be cleared.
 
+The callback is not called for every transaction. It is only evaluated on transactions where the suggestion plugin finds a valid match, the match passes `allow` and `shouldShow`, and there is a dismissed suggestion state to potentially clear.
+
 ```js
 Suggestion({
   // ...
@@ -73,7 +75,6 @@ Suggestion({
 Return `true` to clear the dismissed state for the current transaction and allow the suggestion to open again.
 
 Default: `null`
-
 
 ### allowSpaces
 


### PR DESCRIPTION
## Summary
- document the new `shouldResetDismissed` suggestion option
- explain how dismissed suggestion state behaves by default, including `allowSpaces`
- add a small example showing custom reset logic