### PR TITLE
docs: add styling section to CollaborationCaret extension page

### DIFF
--- a/src/content/editor/extensions/functionality/collaboration-caret.mdx
+++ b/src/content/editor/extensions/functionality/collaboration-caret.mdx
@@ -71,6 +71,41 @@ A render function for the caret, look at [the extension source code](https://git
 
 A render function for the selection, look at [the extension source code](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-collaboration-caret/) for an example.
 
+## Styling
+
+This extension does not include default styles. Without the following CSS, carets will render as unstyled inline elements.
+
+Add the following styles to your project:
+
+```css
+/* Give a remote user a caret */
+.tiptap .collaboration-carets__caret {
+  border-left: 1px solid #0d0d0d;
+  border-right: 1px solid #0d0d0d;
+  margin-left: -1px;
+  margin-right: -1px;
+  pointer-events: none;
+  position: relative;
+  word-break: normal;
+}
+
+/* Render the username above the caret */
+.tiptap .collaboration-carets__label {
+  border-radius: 3px 3px 3px 0;
+  color: #0d0d0d;
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 600;
+  left: -1px;
+  line-height: normal;
+  padding: 0.1rem 0.3rem;
+  position: absolute;
+  top: -1.4em;
+  user-select: none;
+  white-space: nowrap;
+}
+```
+
 ## Commands
 
 ### updateUser()


### PR DESCRIPTION
Adds a new **Styling** section to the CollaborationCaret extension documentation with the required CSS for rendering remote user carets and labels. Without these styles, carets render as unstyled inline elements, which is a common source of confusion for new users.