### PR TITLE
Add missing AI toolkit 0.3.3 changelog entries

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 0.3.3
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.3
+
 ## 0.3.2
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 0.3.3
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.3
+
 ## 0.3.2
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 0.3.3
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.3
+
 ## 0.3.2
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 0.3.3
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.3
+
 ## 0.3.2
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,8 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 0.3.3
+
 ## 0.3.2
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 0.3.3
+
+### Patch Changes
+
+- f09d930: Preserve node hashes across proofreader replacements so sequential corrections continue targeting the same content reliably.
+
 ## 0.3.2
 
 ## 0.3.1

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,6 +8,8 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
+## 0.3.3
+
 ## 0.3.2
 
 ## 0.3.1


### PR DESCRIPTION
## Summary
- add the missing `0.3.3` changelog entry for `@tiptap-pro/ai-toolkit`
- add the matching `0.3.3` dependency changelog entries for the AI toolkit provider packages and tool definitions package
- add the missing `0.3.3` heading for `@tiptap-pro/server-ai-toolkit`

## Source
- synced from the latest `projects/tiptap-pro` `main` branch after updating it to `origin/main`

## Testing
- `pnpm lint` *(fails due to unrelated existing ESLint/MDX issues in the docs repo, including pre-existing errors in `src/components/*`, `src/hooks/*`, `src/content/editor/extensions/*`, and `src/content/pages/sidebar.ts`)*