### PR TITLE
Fix Suggestion Utility isChangeOrigin Usage

### DIFF
--- a/.changeset/fix-is-change-origin-usage-suggestion-utility
+++ b/.changeset/fix-is-change-origin-usage-suggestion-utility
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Fixed isChangeOrigin Usage in Suggestion Utility Docs

--- a/src/content/editor/api/utilities/suggestion.mdx
+++ b/src/content/editor/api/utilities/suggestion.mdx
@@ -43,7 +43,7 @@ A function that returns a boolean to indicate if the suggestion should be active
 
 ```js
 shouldShow: ({ editor, range, query, text, transaction }) => {
-  return isChangeOrigin(transaction)
+  return !isChangeOrigin(transaction)
 }
 ```
 
@@ -179,7 +179,7 @@ Suggestion({
 })
 ```
 
-By returning `isChangeOrigin(props.transaction)`, the suggestion will only be activated if the current user initiated the change.
+By returning `!isChangeOrigin(props.transaction)`, the suggestion will only be activated if the current user initiated the change.
 
 ## Source code
 

--- a/src/content/editor/api/utilities/suggestion.mdx
+++ b/src/content/editor/api/utilities/suggestion.mdx
@@ -174,7 +174,7 @@ import { isChangeOrigin } from '@tiptap/extension-collaboration'
 Suggestion({
   // …
   shouldShow: ({ transaction }) => {
-    return isChangeOrigin(transaction)
+    return !isChangeOrigin(transaction)
   },
 })
 ```


### PR DESCRIPTION
`isChangeOrigin` indicates whether a transaction was created from remote (yjs). We want to disable showing the suggestion popup when this condition is met, so a negation is required.

- No associated issue
- No code changes