### PR TITLE
Floating & Bubble Menu Show/Hide Events

### DIFF
--- a/src/content/editor/extensions/functionality/bubble-menu.mdx
+++ b/src/content/editor/extensions/functionality/bubble-menu.mdx
@@ -257,8 +257,32 @@ new Editor({
 
 ### Force update the position of the bubble menu
 
-If the bubble menu changes size after the initial render, its position will not be adjusted automatically. To fix this, you can force update the position of the bubble menu by emitting an `'updatePosition'` event.
+If the bubble menu changes size after the initial render, its position will not be adjusted automatically. To fix this, you can force update the position by setting a `pluginKey` on the extension and emitting an `'updatePosition'` event with that key.
 
 ```ts
-editor.commands.setMeta('bubbleMenu', 'updatePosition')
+BubbleMenu.configure({
+  pluginKey: 'myBubbleMenu',
+  element: document.querySelector('.menu'),
+})
+
+editor.commands.setMeta('myBubbleMenu', 'updatePosition')
 ```
+
+### Programmatically show or hide the bubble menu
+
+You can programmatically show or hide the bubble menu by setting a `pluginKey` on the extension and dispatching a transaction with the `'show'` or `'hide'` meta value using that key.
+
+```ts
+BubbleMenu.configure({
+  pluginKey: 'myBubbleMenu',
+  element: document.querySelector('.menu'),
+})
+
+// Show the bubble menu
+editor.commands.setMeta('myBubbleMenu', 'show')
+
+// Hide the bubble menu
+editor.commands.setMeta('myBubbleMenu', 'hide')
+```
+
+**Note:** dispatching `'show'` or `'hide'` will override the behavior defined in `shouldShow`.

--- a/src/content/editor/extensions/functionality/floatingmenu.mdx
+++ b/src/content/editor/extensions/functionality/floatingmenu.mdx
@@ -245,14 +245,32 @@ new Editor({
 
 ### Force update the position of the floating menu
 
-If the floating menu changes size after the initial render, its position will not be adjusted automatically. To fix this, you can force update the position of the floating menu using the `updateFloatingMenuPosition` command:
+If the floating menu changes size after the initial render, its position will not be adjusted automatically. To fix this, you can force update the position by setting a `pluginKey` on the extension and emitting an `'updatePosition'` event with that key.
 
 ```ts
-editor.commands.updateFloatingMenuPosition()
+FloatingMenu.configure({
+  pluginKey: 'myFloatingMenu',
+  element: document.querySelector('.menu'),
+})
+
+editor.commands.setMeta('myFloatingMenu', 'updatePosition')
 ```
 
-Alternatively, you can emit an `'updatePosition'` event via transaction metadata:
+### Programmatically show or hide the floating menu
+
+You can programmatically show or hide the floating menu by setting a `pluginKey` on the extension and dispatching a transaction with the `'show'` or `'hide'` meta value using that key.
 
 ```ts
-editor.commands.setMeta('floatingMenu', 'updatePosition')
+FloatingMenu.configure({
+  pluginKey: 'myFloatingMenu',
+  element: document.querySelector('.menu'),
+})
+
+// Show the floating menu
+editor.commands.setMeta('myFloatingMenu', 'show')
+
+// Hide the floating menu
+editor.commands.setMeta('myFloatingMenu', 'hide')
 ```
+
+**Note:** dispatching `'show'` or `'hide'` will override the behavior defined in `shouldShow`.


### PR DESCRIPTION
### Description

Corresponding documentation for https://github.com/ueberdosis/tiptap/pull/7171

* Adds documentation for the `'show'` & `'hide'` "events" for both the bubble & floating menu extensions that can be dispatched as transaction meta.
* Updates the documentation for the existing `'updatePosition'` "event"
* Updated documentation for all three events to require an explicit `pluginKey` parameter, as the default plugin key is unpredictable as of https://github.com/ueberdosis/tiptap/pull/7611