### PR TITLE
docs: add RTL smart quotes documentation to Typography extension

### DIFF
--- a/src/content/editor/extensions/functionality/typography.mdx
+++ b/src/content/editor/extensions/functionality/typography.mdx
@@ -107,3 +107,22 @@ const editor = new Editor({
   ],
 })
 ```
+
+### RTL Smart Quotes
+
+The `openDoubleQuote`, `closeDoubleQuote`, `openSingleQuote`, and `closeSingleQuote` rules support RTL-aware quote characters via the `doubleQuotes` and `singleQuotes` options.
+
+Explicit `rtl` configuration takes precedence over `textDirection`. If no explicit config is provided, the extension falls back to `editor.options.textDirection === 'rtl'`. Otherwise, LTR quotes are used.
+
+> **Note:** Automatic content-based direction detection is intentionally avoided to prevent ambiguity in mixed-direction text.
+
+```js
+new Editor({
+  extensions: [
+    Typography.configure({
+      doubleQuotes: { rtl: { open: '“', close: '”' } },
+      singleQuotes: { rtl: { open: '‘', close: '’' } },
+    }),
+  ],
+})
+```

--- a/src/content/editor/extensions/functionality/typography.mdx
+++ b/src/content/editor/extensions/functionality/typography.mdx
@@ -112,16 +112,19 @@ const editor = new Editor({
 
 The `openDoubleQuote`, `closeDoubleQuote`, `openSingleQuote`, and `closeSingleQuote` rules support RTL-aware quote characters via the `doubleQuotes` and `singleQuotes` options.
 
-Explicit `rtl` configuration takes precedence over `textDirection`. If no explicit config is provided, the extension falls back to `editor.options.textDirection === 'rtl'`. Otherwise, LTR quotes are used.
+Explicit `rtl` configuration takes precedence over `textDirection`. If no explicit config is provided, the extension falls back to `editor.options.textDirection === 'rtl'`. Otherwise, default LTR quotes are used.
 
 > **Note:** Automatic content-based direction detection is intentionally avoided to prevent ambiguity in mixed-direction text.
 
 ```js
-new Editor({
+import { Editor } from '@tiptap/core'
+import Typography from '@tiptap/extension-typography'
+
+const editor = new Editor({
   extensions: [
     Typography.configure({
-      doubleQuotes: { rtl: { open: '“', close: '”' } },
-      singleQuotes: { rtl: { open: '‘', close: '’' } },
+      doubleQuotes: { rtl: { open: '”', close: '“' } },
+      singleQuotes: { rtl: { open: '’', close: '‘' } },
     }),
   ],
 })

--- a/src/content/editor/extensions/functionality/typography.mdx
+++ b/src/content/editor/extensions/functionality/typography.mdx
@@ -108,7 +108,7 @@ const editor = new Editor({
 })
 ```
 
-### RTL Smart Quotes
+### RTL smart quotes
 
 The `openDoubleQuote`, `closeDoubleQuote`, `openSingleQuote`, and `closeSingleQuote` rules support RTL-aware quote characters via the `doubleQuotes` and `singleQuotes` options.
 


### PR DESCRIPTION
## Summary

Adds documentation for RTL smart quotes support in the Typography extension.

## Changes

- Introduced a new **RTL Smart Quotes** section in the Typography docs
- Documented usage of `doubleQuotes.rtl` and `singleQuotes.rtl` configuration
- Explained behavior and precedence:
  - Explicit `rtl` configuration takes precedence
  - Falls back to `editor.options.textDirection === 'rtl'`
  - Defaults to LTR quotes otherwise
- Added example demonstrating RTL quote configuration

## Notes

- Automatic content based direction detection is intentionally not supported to avoid ambiguity in mixed direction text

## Related

- Core implementation: https://github.com/ueberdosis/tiptap/pull/7463