### PR TITLE
docs: clarify menu updatePosition pluginKey usage

### DIFF
--- a/src/content/editor/extensions/functionality/bubble-menu.mdx
+++ b/src/content/editor/extensions/functionality/bubble-menu.mdx
@@ -262,3 +262,11 @@ If the bubble menu changes size after the initial render, its position will not 
 ```ts
 editor.commands.setMeta('bubbleMenu', 'updatePosition')
 ```
+
+To target a specific bubble menu, pass that menu's `pluginKey` instead.
+
+```ts
+editor.commands.setMeta('bubbleMenuOne', 'updatePosition')
+```
+
+If you use the React or Vue `BubbleMenu` component and want to trigger `updatePosition` externally, pass an explicit `pluginKey` prop to the component first. If you omit `pluginKey`, the component creates its own ProseMirror `PluginKey`, which external code cannot reliably reference later.

--- a/src/content/editor/extensions/functionality/floatingmenu.mdx
+++ b/src/content/editor/extensions/functionality/floatingmenu.mdx
@@ -251,8 +251,16 @@ If the floating menu changes size after the initial render, its position will no
 editor.commands.updateFloatingMenuPosition()
 ```
 
-Alternatively, you can emit an `'updatePosition'` event via transaction metadata:
+To target a specific floating menu, emit an `'updatePosition'` event via transaction metadata and use that menu's `pluginKey`:
 
 ```ts
 editor.commands.setMeta('floatingMenu', 'updatePosition')
 ```
+
+For example, if you have multiple floating menus:
+
+```ts
+editor.commands.setMeta('floatingMenuOne', 'updatePosition')
+```
+
+If you use the React or Vue `FloatingMenu` component and want to trigger `updatePosition` externally, pass an explicit `pluginKey` prop to the component first. If you omit `pluginKey`, the component creates its own ProseMirror `PluginKey`, which external code cannot reliably reference later.


### PR DESCRIPTION
## Summary
- clarify that `updatePosition` targets the menu's `pluginKey`
- add examples for targeting a specific bubble or floating menu instance
- document that React/Vue users must pass an explicit `pluginKey` for external `updatePosition` calls