### PR TITLE
fix: make pro demos use latest deployment

### DIFF
--- a/src/content/conversion/export/doc/editor-export.mdx
+++ b/src/content/conversion/export/doc/editor-export.mdx
@@ -27,7 +27,7 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
     </RequirementItem>
 </Requirements>
 
-<CodeDemo src="https://feature-beta-conversion-extensions--tiptap-pro.netlify.app/preview/Extensions/ExportDoc" />
+<CodeDemo isPro path="/Extensions/ExportDoc" />
 
 <Callout title="Consider using DOCX instead" variant="info">
     The DOC format is a legacy format from Microsoft Word 97-2003. For modern use, we recommend exporting to [DOCX](/conversion/export/docx/editor-export) instead. Use DOC only when compatibility with older systems requires it.

--- a/src/content/conversion/export/docx/custom-node-conversion.mdx
+++ b/src/content/conversion/export/docx/custom-node-conversion.mdx
@@ -33,7 +33,7 @@ This allows you to preserve application-specific content in the exported Word fi
 
 ## Export custom nodes to .docx
 
-<CodeDemo src="https://feature-beta-conversion-extensions--tiptap-pro.netlify.app/preview/Extensions/ExportDocxCustomNode" />
+<CodeDemo isPro path="/Extensions/ExportDocxCustomNode" />
 
 When calling `editor.exportDocx()`, you can pass an array of custom node definitions in the `ExportDocxOptions` argument. Each definition specifies the node type and a render function.
 

--- a/src/content/conversion/export/docx/custom-page-layout.mdx
+++ b/src/content/conversion/export/docx/custom-page-layout.mdx
@@ -29,7 +29,7 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
 The DOCX Export extension now supports custom page sizes and margins, allowing you to create documents with precise layouts that match your requirements. Whether you need A5 pages, custom paper sizes, or specific margin configurations, you can configure these settings directly in the extension.
 
-<CodeDemo src="https://feature-beta-conversion-extensions--tiptap-pro.netlify.app/preview/Extensions/ExportDocxCustomPageSize" />
+<CodeDemo isPro path="/Extensions/ExportDocxCustomPageSize" />
 
 ## Page size configuration
 

--- a/src/content/conversion/export/docx/editor-export.mdx
+++ b/src/content/conversion/export/docx/editor-export.mdx
@@ -26,7 +26,7 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
     </RequirementItem>
 </Requirements>
 
-<CodeDemo src="https://feature-beta-conversion-extensions--tiptap-pro.netlify.app/preview/Extensions/ExportDocx" />
+<CodeDemo isPro path="/Extensions/ExportDocx" />
 
 Use Tiptap’s `@tiptap-pro/extension-export-docx` to export the editor's content as a `.docx` file. This extension integrates `DOCX` export functionality into your editor.
 

--- a/src/content/conversion/export/docx/headers-footers.mdx
+++ b/src/content/conversion/export/docx/headers-footers.mdx
@@ -29,7 +29,7 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
 The `@tiptap-pro/extension-export-docx` extension includes built-in support for customizing the headers and footers of the exported document.
 
-<CodeDemo src="https://feature-beta-conversion-extensions--tiptap-pro.netlify.app/preview/Extensions/ExportDocxCustomHeaderFooter" />
+<CodeDemo isPro path="/Extensions/ExportDocxCustomHeaderFooter" />
 
 When adding this extension it will allow you to configure your `ExportDocx` with some additional properties:
 

--- a/src/content/conversion/export/epub/editor-export.mdx
+++ b/src/content/conversion/export/epub/editor-export.mdx
@@ -26,7 +26,7 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
     </RequirementItem>
 </Requirements>
 
-<CodeDemo src="https://feature-beta-conversion-extensions--tiptap-pro.netlify.app/preview/Extensions/ExportEpub" />
+<CodeDemo isPro path="/Extensions/ExportEpub" />
 
 Use Tiptap's `@tiptap-pro/extension-export-epub` to export your editor's content as an `.epub` file. This extension integrates EPUB export functionality into your editor by sending the document to the Tiptap convert service for conversion.
 

--- a/src/content/conversion/export/markdown/editor-export.mdx
+++ b/src/content/conversion/export/markdown/editor-export.mdx
@@ -27,7 +27,7 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
     </RequirementItem>
 </Requirements>
 
-<CodeDemo src="https://feature-beta-conversion-extensions--tiptap-pro.netlify.app/preview/Extensions/ExportMarkdown" />
+<CodeDemo isPro path="/Extensions/ExportMarkdown" />
 
 Use Tiptap's `@tiptap-pro/extension-export-markdown` to export your editor's content as a `.md` file. This extension converts your editor content to Markdown locally using the `@tiptap/markdown` extension — no API calls or credentials are required.
 

--- a/src/content/conversion/export/odt/editor-export.mdx
+++ b/src/content/conversion/export/odt/editor-export.mdx
@@ -26,7 +26,7 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
     </RequirementItem>
 </Requirements>
 
-<CodeDemo src="https://feature-beta-conversion-extensions--tiptap-pro.netlify.app/preview/Extensions/ExportOdt" />
+<CodeDemo isPro path="/Extensions/ExportOdt" />
 
 Use Tiptap's `@tiptap-pro/extension-export-odt` to export your editor's content as an `.odt` file. This extension integrates ODT export functionality into your editor by sending the document to the Tiptap convert service for conversion.
 

--- a/src/content/conversion/export/pdf/editor-export.mdx
+++ b/src/content/conversion/export/pdf/editor-export.mdx
@@ -27,7 +27,7 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
     </RequirementItem>
 </Requirements>
 
-<CodeDemo src="https://feature-beta-conversion-extensions--tiptap-pro.netlify.app/preview/Extensions/ExportPdf" />
+<CodeDemo isPro path="/Extensions/ExportPdf" />
 
 Use Tiptap's `@tiptap-pro/extension-export-pdf` to export your editor's content as a `.pdf` file. This extension integrates PDF export functionality into your editor by sending the document to the Tiptap convert service for conversion.
 

--- a/src/content/conversion/getting-started/overview.mdx
+++ b/src/content/conversion/getting-started/overview.mdx
@@ -28,7 +28,7 @@ The Tiptap Conversion Service makes it easy to import and export content between
 </Callout>
 
 
-<CodeDemo src="https://feature-beta-conversion-extensions--tiptap-pro.netlify.app/preview/Extensions/ExportImportDocx" />
+<CodeDemo isPro path="/Extensions/ExportImportDocx" />
 
 <Callout title="Conversion service">
     We are continuously improving the Conversion Service. Page break **import** is now supported via the [PageBreak extension](/pages/core-concepts/page-break-node). Page break export and other complex features are in active development.

--- a/src/content/conversion/import/docx/custom-node-conversion.mdx
+++ b/src/content/conversion/import/docx/custom-node-conversion.mdx
@@ -31,7 +31,7 @@ The `@tiptap-pro/extension-import-docx` extension allows you to define how custo
 
 ## Import custom nodes from .docx
 
-<CodeDemo src="https://feature-beta-conversion-extensions--tiptap-pro.netlify.app/preview/Extensions/ImportDocxCustomNode" />
+<CodeDemo isPro path="/Extensions/ImportDocxCustomNode" />
 
 When importing a DOCX file, you can define how custom nodes should be converted back to Tiptap nodes. This is done by passing an array of custom node definitions to the `import` command.
 

--- a/src/content/conversion/import/docx/editor-import.mdx
+++ b/src/content/conversion/import/docx/editor-import.mdx
@@ -27,7 +27,7 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
     </RequirementItem>
 </Requirements>
 
-<CodeDemo src="https://feature-beta-conversion-extensions--tiptap-pro.netlify.app/preview/Extensions/ImportDocx" />
+<CodeDemo isPro path="/Extensions/ImportDocx" />
 
 Converting `.docx` files to Tiptap JSON is simple with the `@tiptap-pro/extension-import-docx` editor extension,
 which integrates directly into your Tiptap Editor.

--- a/src/content/pages/core-concepts/page-format.mdx
+++ b/src/content/pages/core-concepts/page-format.mdx
@@ -13,10 +13,7 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 The `pageFormat` option controls the size and margins of each page in your document. This helps your content look consistent and professional, especially when printing or exporting.
 
-<CodeDemo
-  isPro
-  src="https://feat-pages-and-docx--tiptap-pro.netlify.app/preview/extensions/pagespageformat"
-/>
+<CodeDemo isPro path="/Extensions/PagesPageFormat" />
 
 ## Built-in formats
 
@@ -63,10 +60,7 @@ Use whichever approach you prefer.
 
 ## Custom page formats
 
-<CodeDemo
-  isPro
-  src="https://feat-pages-and-docx--tiptap-pro.netlify.app/preview/extensions/pagescustompageformat"
-/>
+<CodeDemo isPro path="/Extensions/PagesCustomPageFormat" />
 
 You can define custom page formats by providing a page format object with your desired dimensions and margins:
 

--- a/src/content/pages/core-concepts/page-gap.mdx
+++ b/src/content/pages/core-concepts/page-gap.mdx
@@ -21,10 +21,7 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 The `pageGapBackground` and `pageGap` options lets you change the background color of the area between pages and the spacing between pages. This can help visually separate pages or match your app's background color design.
 
-<CodeDemo
-  isPro
-  src="https://feat-pages-and-docx--tiptap-pro.netlify.app/preview/extensions/pagescustompagebreak"
-/>
+<CodeDemo isPro path="/Extensions/PagesCustomPageGap" />
 
 ## How to set the page gap background
 

--- a/src/content/pages/core-concepts/page-header-footer.mdx
+++ b/src/content/pages/core-concepts/page-header-footer.mdx
@@ -17,10 +17,7 @@ Headers and footers allow you to display consistent content at the top and botto
   Headers and footers are always editable via double-click. This behavior cannot be disabled.
 </Callout>
 
-<CodeDemo
-  isPro
-  src="https://feat-pages-and-docx--tiptap-pro.netlify.app/preview/extensions/pagesheaderfooter"
-/>
+<CodeDemo isPro path="/Extensions/PagesHeaderFooter" />
 
 ## Content types
 

--- a/src/content/pages/getting-started/overview.mdx
+++ b/src/content/pages/getting-started/overview.mdx
@@ -15,10 +15,7 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 Tiptap Pages is a powerful extension that transforms your editing experience from a traditional single-block editor into a sophisticated page-based interface.
 
-<CodeDemo
-  isPro
-  src="https://feat-pages-and-docx--tiptap-pro.netlify.app/preview/extensions/pages"
-/>
+<CodeDemo isPro path="/Extensions/Pages" />
 
 With Pages, you can create documents that feel more like real pages, complete with proper margins, page breaks, and layout controls. This makes it perfect for creating documents that need to maintain a professional, page-based structure – whether you're working on reports, articles, or any other content that benefits from a traditional document format.
 

--- a/src/content/pages/guides/collaboration-with-pages.mdx
+++ b/src/content/pages/guides/collaboration-with-pages.mdx
@@ -15,10 +15,7 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 You can enable real-time collaboration in your paginated editor by combining the Pages extension with a collaborative provider, such as TiptapCollabProvider.
 
-<CodeDemo
-  isPro
-  src="https://feat-pages-and-docx--tiptap-pro.netlify.app/preview/extensions/pagescollaboration"
-/>
+<CodeDemo isPro path="/Extensions/PagesCollaboration" />
 
 ---
 

--- a/src/content/pages/guides/pagekit-usage.mdx
+++ b/src/content/pages/guides/pagekit-usage.mdx
@@ -15,10 +15,7 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 PageKit is a convenience extension that bundles the Pages, Table, and PageBreak extensions together. It lets you configure all three at once for a paginated, table-ready editor with page break support.
 
-<CodeDemo
-  isPro
-  src="https://feat-pages-and-docx--tiptap-pro.netlify.app/preview/extensions/pagespagekit"
-/>
+<CodeDemo isPro path="/Extensions/PagesPageKit" />
 
 ---
 

--- a/src/content/pages/guides/table-with-pages.mdx
+++ b/src/content/pages/guides/table-with-pages.mdx
@@ -15,10 +15,7 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 To add tables to your paginated editor, you should use the TableKit extension from the `@tiptap-pro/extension-pages-tablekit` package. This ensures full compatibility with pagination as in order to properly split tables across the pages we needed to heavily modify the behavior and layout of tables.
 
-<CodeDemo
-  isPro
-  src="https://feat-pages-and-docx--tiptap-pro.netlify.app/preview/extensions/pagestables"
-/>
+<CodeDemo isPro path="/Extensions/PagesTables" />
 
 ---
 

--- a/src/content/pages/guides/zero-to-print-ready.mdx
+++ b/src/content/pages/guides/zero-to-print-ready.mdx
@@ -15,10 +15,7 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 This guide will walk you through setting up a Tiptap editor from scratch, adding the Pages extension for pagination and print-like layout, and enabling DOCX export and import for a professional, print-ready workflow.
 
-<CodeDemo
-  isPro
-  src="https://feat-pages-and-docx--tiptap-pro.netlify.app/preview/extensions/pagesimportexportdocx"
-/>
+<CodeDemo isPro path="/Extensions/PagesImportExportDocx" />
 
 ---
 


### PR DESCRIPTION
This pull request updates all code demo components in the documentation to use a new, simplified format. Instead of linking to external preview URLs, the demos now use a local `path` property, making the code more maintainable and consistent. All affected demos retain the `isPro` flag where appropriate.

The most important changes are:

**Documentation demo updates:**

* All `<CodeDemo>` components in the documentation now use the `path` property (e.g., `path="/Extensions/ExportDocx"`) instead of the previous `src` property with external URLs. This change standardizes how code demos are referenced and improves maintainability. [[1]](diffhunk://#diff-60a493aa289bbf407beae0323d4a5aad2cf88e72a4f48f5c177d4645f3dc6c12L30-R30) [[2]](diffhunk://#diff-974694a34e497ca082766602bdf0b86e211b08d1cfd90d9f2013a185773fb510L29-R29) [[3]](diffhunk://#diff-60994387ff30f7dd7d6cfcd1d1298299fdfe3866ebe20f5edf9f40114fb2c2fcL32-R32) [[4]](diffhunk://#diff-fa899acb7011c08ea7a71d02ec40454d5859dd9218a8c5a26c14b49e3126640aL32-R32) [[5]](diffhunk://#diff-ef304cc484cf87c007379c4ab707a4031cd191c498643efbd5e4f27aa8fb91a9L29-R29) [[6]](diffhunk://#diff-510de7bf7fa413ca35780212e50d69d9d8314ff4caa2dc4e398aa4cc03526558L30-R30) [[7]](diffhunk://#diff-3df01bdc43e1e31f2e2abc0a861fd280f140a51f14162dcfebeaa6530c57f06cL29-R29) [[8]](diffhunk://#diff-ddf26dd02fa6268093f0f66b1fd3dbd41727c4eaa81e251d3d790603785c0b5eL30-R30) [[9]](diffhunk://#diff-e4557d1fcd0ab9ba6972219e2fdd6c58284acd67a38feea1c109c35cee671df2L31-R31) [[10]](diffhunk://#diff-cbafb2b4381dcf75d34935676abd1848756bb44de40f59e6f57dde641f56b4ecL34-R34) [[11]](diffhunk://#diff-6dea1b4d73becac27b1337c9bba7144b85897009e372b1acedd891a3f2691287L30-R30) [[12]](diffhunk://#diff-4fb50350a11b7d1925b0ef4689d0af83d0d000865489e469b68a91a606d22d9cL16-R16) [[13]](diffhunk://#diff-4fb50350a11b7d1925b0ef4689d0af83d0d000865489e469b68a91a606d22d9cL66-R63) [[14]](diffhunk://#diff-b032120dc2c16edef1bbdf050c734bd4e914130aa73de2cc7488e9399c1d729bL24-R24) [[15]](diffhunk://#diff-16b7384fd455252d2aea308f912791827e088c60aed3c9141a6d733fc8718c18L20-R20) [[16]](diffhunk://#diff-c5fe9181a0ceb4f4eaf2ae5f58a7b55b8370d69378d2fb887a3ddb3cd174522dL18-R18) [[17]](diffhunk://#diff-6005daa63530d82e041f144df988fe977028003802d654b353facb2af70695afL18-R18) [[18]](diffhunk://#diff-38deefc5c7730a90b1a02b9c46e6fccfec4ab594a970e915b6d7395a5a19e0cbL18-R18) [[19]](diffhunk://#diff-b35c35366c0e099459ae698fb595af81331d16012e9e57dab11c52ae5ca73addL18-R18) [[20]](diffhunk://#diff-515c66b9df2d53cbb1c6ead1b86e6a7e84f3a74b2064e3352ae00329e6a4f734L18-R18)

**Consistency and code quality:**

* All demos consistently retain the `isPro` flag, ensuring the correct feature gating in documentation. (All references above)
* The new format improves clarity for both contributors and users by making demo references easier to follow and update. (All references above)