### PR TITLE
feat: pages zoom docs

### DIFF
--- a/src/content/pages/core-concepts/options.mdx
+++ b/src/content/pages/core-concepts/options.mdx
@@ -60,6 +60,18 @@ interface PagesOptions {
    * @default () => {}
    */
   onPageFormatChange?: (pageFormat: PageFormat) => void
+
+  /**
+   * Initial zoom level for visual scaling. Clamped to [0.25, 4].
+   * @default 1
+   */
+  zoom?: number
+
+  /**
+   * Callback function called when the zoom level changes.
+   * Receives the new zoom level as an argument.
+   */
+  onZoomChange?: (zoom: number) => void
 }
 
 interface PageFormat {
@@ -85,6 +97,8 @@ interface PageFormat {
 | `footer`              | `string \| fn`               | `'{page}'`| Footer content; string (supports `{page}`/`{total}`) or (pageNumber, totalPages) => string |
 | `pageGapBackground` | `string` (CSS color)         | `undefined` | Background color for page gaps                                                          |
 | `onPageFormatChange`  | `fn`                         | `() => {}` | Callback when page format changes; receives new PageFormat                               |
+| `zoom`                | `number`                     | `1`        | Initial zoom level (0.25–4). See [Zoom](/pages/core-concepts/zoom)                      |
+| `onZoomChange`        | `fn`                         | `undefined`| Callback when zoom changes; receives new zoom level                                      |
 
 ## Example usage
 
@@ -101,7 +115,7 @@ const editor = new Editor({
       footerHeight: 40,
       pageGap: 40,
       header: 'My Project',
-      footer: (page, total) => `Page ${page} of ${total}`,
+      footer: 'Page {page} of {total}',
       pageGapBackground: '#f8f8f8',
     }),
   ],
@@ -145,6 +159,7 @@ The Pages extension provides the following commands:
 | Command          | Parameters               | Description                                    |
 |------------------|--------------------------|------------------------------------------------|
 | `setPageFormat`  | `pageFormat: PageFormat` | Changes the page format programmatically      |
+| `setZoom`        | `zoom: number`           | Sets the zoom level (clamped to 0.25–4). See [Zoom](/pages/core-concepts/zoom) |
 
 ### Command usage
 

--- a/src/content/pages/core-concepts/zoom.mdx
+++ b/src/content/pages/core-concepts/zoom.mdx
@@ -1,0 +1,168 @@
+---
+title: Zoom
+meta:
+  title: Zoom | Tiptap Pages Docs
+  description: Learn how to zoom in and out of your Tiptap Pages editor to make content larger or smaller, just like in Google Docs or Microsoft Word.
+  category: Pages
+sidebars:
+  hideSecondary: true
+---
+
+import { Callout } from '@/components/ui/Callout'
+import { CodeDemo } from '@/components/CodeDemo'
+
+Zoom lets your users make the editor content **bigger** or **smaller** without changing the actual document. Think of it like pinching to zoom on your phone, or using the zoom slider in Google Docs.
+
+- **Zoom in** to see details up close (great for precise formatting)
+- **Zoom out** to see more of the document at once (great for getting an overview)
+- The document itself doesn't change — zoom is purely visual
+
+<CodeDemo isPro path="/Extensions/PagesZoom" />
+
+## Quick start
+
+Set an initial zoom level when configuring the extension:
+
+```js
+import { Pages } from '@tiptap-pro/extension-pages'
+
+Pages.configure({
+  zoom: 0.75, // 75% — makes everything smaller
+})
+```
+
+Change the zoom level at any time with a command:
+
+```js
+// Zoom to 150%
+editor.commands.setZoom(1.5)
+
+// Zoom to 50%
+editor.commands.setZoom(0.5)
+
+// Back to normal (100%)
+editor.commands.setZoom(1)
+```
+
+That's it. Two lines of code and you have zoom.
+
+## Zoom range
+
+Zoom accepts any value between **0.25** (25%) and **4** (400%). Values outside this range are automatically clamped.
+
+| Value  | Zoom level | Use case |
+|--------|-----------|----------|
+| `0.25` | 25%       | Maximum zoom out — see entire document layout |
+| `0.5`  | 50%       | Overview mode — good for long documents |
+| `0.75` | 75%       | Slightly smaller — fits more on screen |
+| `1`    | 100%      | Default — normal size |
+| `1.25` | 125%      | Slightly larger — easier to read |
+| `1.5`  | 150%      | Comfortable reading zoom |
+| `2`    | 200%      | Large — good for accessibility |
+| `4`    | 400%      | Maximum zoom in — pixel-level detail |
+
+```js
+// These all work
+editor.commands.setZoom(0.25)  // minimum
+editor.commands.setZoom(1.5)   // 150%
+editor.commands.setZoom(4)     // maximum
+
+// These get clamped automatically
+editor.commands.setZoom(0.1)   // becomes 0.25
+editor.commands.setZoom(10)    // becomes 4
+```
+
+## Reading the current zoom level
+
+You can read the current zoom level from storage at any time:
+
+```js
+// Read the current zoom level directly
+const zoom = editor.storage.pages.zoom
+console.log(`Current zoom: ${zoom * 100}%`) // e.g. "Current zoom: 125%"
+
+// Or use the getter function
+const zoom = editor.storage.pages.getZoom?.()
+```
+
+## Reacting to zoom changes
+
+Use the `onZoomChange` callback to keep your UI in sync when the zoom level changes. This is useful for building zoom controls like dropdowns or sliders.
+
+```js
+Pages.configure({
+  zoom: 1,
+  onZoomChange: (zoom) => {
+    // Update your UI, e.g. a dropdown or label
+    console.log(`Zoom changed to ${zoom * 100}%`)
+  },
+})
+```
+
+### React example with a zoom dropdown
+
+```jsx
+import { Pages } from '@tiptap-pro/extension-pages'
+import { useState } from 'react'
+
+function MyEditor() {
+  const [zoom, setZoom] = useState(1)
+
+  const editor = useEditor({
+    extensions: [
+      Pages.configure({
+        pageFormat: 'A4',
+        onZoomChange: setZoom, // keeps dropdown in sync
+      }),
+    ],
+  })
+
+  return (
+    <>
+      <select
+        value={zoom}
+        onChange={(e) => {
+          const value = parseFloat(e.target.value)
+          editor.commands.setZoom(value)
+        }}
+      >
+        <option value={0.5}>50%</option>
+        <option value={0.75}>75%</option>
+        <option value={1}>100%</option>
+        <option value={1.25}>125%</option>
+        <option value={1.5}>150%</option>
+        <option value={2}>200%</option>
+      </select>
+      <EditorContent editor={editor} />
+    </>
+  )
+}
+```
+
+## Configuration reference
+
+### Option
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `zoom` | `number` | `1` | Initial zoom level. Clamped to `[0.25, 4]`. |
+| `onZoomChange` | `(zoom: number) => void` | `undefined` | Callback fired when zoom changes via `setZoom`. |
+
+### Command
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setZoom` | `zoom: number` | Set the zoom level. Value is clamped to `[0.25, 4]`. |
+
+### Storage
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `zoom` | `number` | Current zoom level. |
+| `getZoom` | `() => number` | Returns the current zoom level. |
+
+## Good to know
+
+- **Zoom is visual only.** It does not change the document structure, content, or formatting. When you export to DOCX or print, the output is always at 100%.
+- **Headers and footers follow zoom.** They scale with the rest of the page. If you open a header or footer editor, the overlay matches the current zoom level — even if you change zoom while editing.
+- **Pagination stays accurate.** Page breaks, page count, and all pagination calculations remain correct at every zoom level. Zooming does not add or remove pages.

--- a/src/content/pages/sidebar.ts
+++ b/src/content/pages/sidebar.ts
@@ -42,6 +42,11 @@ export const sidebarConfig: SidebarConfig = {
           href: '/pages/core-concepts/page-gap',
         },
         {
+          title: 'Zoom',
+          href: '/pages/core-concepts/zoom',
+          tags: ['New'],
+        },
+        {
           title: 'PageBreak node',
           href: '/pages/core-concepts/page-break-node',
           tags: ['New'],


### PR DESCRIPTION
This pull request adds comprehensive documentation and configuration options for the new zoom feature in the Tiptap Pages extension. The changes introduce support for setting and reacting to zoom levels, update the options and commands reference, and provide a dedicated "Zoom" documentation page. The sidebar is also updated to include the new page.

**Zoom feature documentation and configuration:**

* Added `zoom` (initial zoom level, clamped between 0.25 and 4) and `onZoomChange` (callback for zoom changes) options to the `PagesOptions` interface and documented them in the options table. [[1]](diffhunk://#diff-77a3815d1bd0033256ee2002db3ab22714f0c0e224fe37377db6ed83c238246cR63-R74) [[2]](diffhunk://#diff-77a3815d1bd0033256ee2002db3ab22714f0c0e224fe37377db6ed83c238246cR100-R101)
* Added a new command `setZoom` to programmatically set the zoom level, with documentation and usage examples.
* Created a detailed `zoom.mdx` page explaining how zoom works, usage examples, configuration, commands, storage, and best practices.
* Updated the sidebar to include the new "Zoom" documentation page, tagged as "New".

**Minor improvements:**

* Updated the example usage in the options documentation to use a string footer instead of a function for consistency.