### PR TITLE
Sync AI toolkit changelogs

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 0.3.9
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.9
+
+## 0.3.8
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.8
+
 ## 0.3.5
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -20,6 +20,20 @@ meta:
 
 - @tiptap-pro/ai-toolkit-tool-definitions@0.3.8
 
+## 0.3.7
+
+### Patch Changes
+
+- 0608c46: Minor bugfixes & improvements
+- Updated dependencies [0608c46]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.3.7
+
+## 0.3.6
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.6
+
 ## 0.3.5
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 0.3.9
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.9
+
+## 0.3.8
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.8
+
 ## 0.3.5
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -20,6 +20,20 @@ meta:
 
 - @tiptap-pro/ai-toolkit-tool-definitions@0.3.8
 
+## 0.3.7
+
+### Patch Changes
+
+- 0608c46: Minor bugfixes & improvements
+- Updated dependencies [0608c46]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.3.7
+
+## 0.3.6
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.6
+
 ## 0.3.5
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 0.3.9
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.9
+
+## 0.3.8
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.8
+
 ## 0.3.5
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -20,6 +20,20 @@ meta:
 
 - @tiptap-pro/ai-toolkit-tool-definitions@0.3.8
 
+## 0.3.7
+
+### Patch Changes
+
+- 0608c46: Minor bugfixes & improvements
+- Updated dependencies [0608c46]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.3.7
+
+## 0.3.6
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.6
+
 ## 0.3.5
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 0.3.9
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.9
+
+## 0.3.8
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.8
+
 ## 0.3.5
 
 ### Patch Changes
@@ -167,7 +179,6 @@ meta:
 - Upgrade to OpenAI SDK v6.
 
 ## 3.0.0-alpha.16
-
 
 ### Minor Changes
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -20,6 +20,20 @@ meta:
 
 - @tiptap-pro/ai-toolkit-tool-definitions@0.3.8
 
+## 0.3.7
+
+### Patch Changes
+
+- 0608c46: Minor bugfixes & improvements
+- Updated dependencies [0608c46]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.3.7
+
+## 0.3.6
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.6
+
 ## 0.3.5
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,10 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 0.3.9
+
+## 0.3.8
+
 ## 0.3.5
 
 ## 0.3.4
@@ -45,7 +49,6 @@ meta:
   Add streaming support when using the AI Toolkit with Tracked Changes. When streaming content with tracked changes, streaming support does not show a "typing effect". Instead, it streams content on a per-operation basis.
 
   **Breaking changes:**
-
   - The `tiptapEdit` tool output now includes the `operationResults` property instead of `successful` and `failed`.
   - `tiptapEditWorkflow` now returns `operationResults` instead of `successful` and `failed`.
   - `proofreaderWorkflow` now returns `operationResults` instead of `operations`.

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -12,6 +12,14 @@ meta:
 
 ## 0.3.8
 
+## 0.3.7
+
+### Patch Changes
+
+- 0608c46: Minor bugfixes & improvements
+
+## 0.3.6
+
 ## 0.3.5
 
 ## 0.3.4

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 0.3.9
+
+### Patch Changes
+
+- 19c0fb9: Stop assigning `_hash` values during editor load and document updates. The hash extensions now only define the `_hash` attribute.
+
+## 0.3.8
+
+### Patch Changes
+
+- 99d0172: Ensure `tiptapReadChunks` repairs missing document hashes before returning chunked content.
+
 ## 0.3.5
 
 ### Patch Changes
@@ -77,7 +89,6 @@ meta:
   Add streaming support when using the AI Toolkit with Tracked Changes. When streaming content with tracked changes, streaming support does not show a "typing effect". Instead, it streams content on a per-operation basis.
 
   **Breaking changes:**
-
   - The `tiptapEdit` tool output now includes the `operationResults` property instead of `successful` and `failed`.
   - `tiptapEditWorkflow` now returns `operationResults` instead of `successful` and `failed`.
   - `proofreaderWorkflow` now returns `operationResults` instead of `operations`.

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -20,6 +20,18 @@ meta:
 
 - 99d0172: Ensure `tiptapReadChunks` repairs missing document hashes before returning chunked content.
 
+## 0.3.7
+
+### Patch Changes
+
+- 0608c46: Minor bugfixes & improvements
+
+## 0.3.6
+
+### Patch Changes
+
+- 3ec3fe2: Preserve inline whitespace in parsed HTML without turning formatting whitespace around block nodes into standalone AI edit blocks.
+
 ## 0.3.5
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -16,6 +16,14 @@ meta:
 
 ## 0.3.8
 
+## 0.3.7
+
+### Patch Changes
+
+- 0608c46: Minor bugfixes & improvements
+
+## 0.3.6
+
 ## 0.3.5
 
 ## 0.3.4

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,6 +8,14 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
+## 0.3.9
+
+### Patch Changes
+
+- 19c0fb9: Stop assigning `_hash` values during editor load and document updates. The hash extensions now only define the `_hash` attribute.
+
+## 0.3.8
+
 ## 0.3.5
 
 ## 0.3.4


### PR DESCRIPTION
Updates the mirrored AI toolkit and server AI toolkit changelog pages in tiptap-docs to include the latest 0.3.9 and 0.3.8 package releases from Tiptap Pro.

This keeps the documentation aligned with the current package changelogs after the latest main branch sync.