### PR TITLE
Update AI toolkit changelogs

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 0.3.10
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.10
+
 ## 0.3.9
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 0.3.10
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.10
+
 ## 0.3.9
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 0.3.10
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.10
+
 ## 0.3.9
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 0.3.10
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.3.10
+
 ## 0.3.9
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,8 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 0.3.10
+
 ## 0.3.9
 
 ## 0.3.8

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 0.3.10
+
+### Patch Changes
+
+- 61cfeb6: Avoid rebuilding suggestion tracking state on streamed AI Toolkit updates that immediately replace suggestions.
+- fb9430c: Performance optimization: skip unnecessary computations during streaming when no operation in the batch will be applied. This makes the proofreader workflow more performant while streaming.
+
 ## 0.3.9
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,6 +8,8 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
+## 0.3.10
+
 ## 0.3.9
 
 ### Patch Changes


### PR DESCRIPTION
Updates the AI Toolkit and Server AI Toolkit changelog pages in Tiptap Docs to match the latest package releases from tiptap-pro.

Changes include the new 0.3.10 entries for the core AI Toolkit packages and the server AI toolkit changelog page.