### PR TITLE
Remove experimental callout from tracked changes overview

### DIFF
--- a/src/content/tracked-changes/getting-started/overview.mdx
+++ b/src/content/tracked-changes/getting-started/overview.mdx
@@ -11,13 +11,8 @@ meta:
 ---
 
 import { CodeDemo } from '@/components/CodeDemo'
-import { Callout } from '@/components/ui/Callout'
 
 The Tracked Changes extension enables suggestion mode for collaborative editing workflows. When enabled, all edits appear as proposals that can be accepted or rejected, similar to change tracking in word processors.
-
-<Callout title="Experimental" variant="warning">
-  This extension is under active development. The API may change in future releases. All versions below 1.0.0 are expected to be unstable, use them at your own risk.
-</Callout>
 
 <CodeDemo isPro path="/Experiments/TrackedChanges" />
 


### PR DESCRIPTION
## Summary
- remove the experimental warning callout from the tracked changes getting started overview
- remove the now-unused `Callout` import from the page

## Testing
- Not run (not requested)