### PR TITLE
Document the Server AI Toolkit session mechanism

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot.mdx
@@ -26,6 +26,11 @@ import { Requirements, RequirementItem } from '@/components/Requirements'
 
 Build a simple AI agent chatbot that can read and edit Tiptap documents.
 
+<Callout title="Persist the session across chat turns" variant="info">
+  Store the latest `sessionId` in the conversation history and reuse it on later tool calls. This
+  lets the server reject stale edits instead of overwriting newer user changes.
+</Callout>
+
 <CodeDemo
   isLarge
   path=""
@@ -50,8 +55,8 @@ npx create-next-app@latest server-ai-agent-chatbot
 ```
 
 <Callout title="Pro packages" variant="hint">
-  The Server AI Toolkit and Collaboration are pro packages. Before installation, you'll need to set up [access to Tiptap's private NPM
-  registry](/guides/pro-extensions).
+  The Server AI Toolkit and Collaboration are pro packages. Before installation, you'll need to set
+  up [access to Tiptap's private NPM registry](/guides/pro-extensions).
 </Callout>
 
 Install the core Tiptap packages, collaboration extensions, and the [Vercel AI SDK](https://ai-sdk.dev/) for OpenAI:
@@ -126,7 +131,8 @@ export function getTiptapCloudAiJwtToken(): string {
   const payload = {
     // Document Server credentials for automatic document fetching/saving
     experimental_document_server_id: process.env.TIPTAP_CLOUD_DOCUMENT_SERVER_ID,
-    experimental_document_server_management_api_secret: process.env.TIPTAP_CLOUD_DOCUMENT_SERVER_MANAGEMENT_API_SECRET,
+    experimental_document_server_management_api_secret:
+      process.env.TIPTAP_CLOUD_DOCUMENT_SERVER_MANAGEMENT_API_SECRET,
   }
 
   return jwt.sign(payload, secret, { expiresIn: '1h' })
@@ -222,9 +228,8 @@ export async function getSchemaAwarenessPrompt(schemaAwarenessData: unknown): Pr
 ```
 
 <Callout title="Using custom nodes?" variant="info">
-  If your editor includes custom nodes or marks, configure them with
-  `addJsonSchemaAwareness`. See the [custom nodes
-  guide](/content-ai/capabilities/server-ai-toolkit/advanced-guides/custom-nodes).
+  If your editor includes custom nodes or marks, configure them with `addJsonSchemaAwareness`. See
+  the [custom nodes guide](/content-ai/capabilities/server-ai-toolkit/advanced-guides/custom-nodes).
 </Callout>
 
 #### Execute tool
@@ -243,7 +248,8 @@ export async function executeTool(
   input: unknown,
   documentId: string,
   schemaAwarenessData: unknown,
-): Promise<{ output: unknown; docChanged: boolean }> {
+  options: { sessionId?: string } = {},
+): Promise<{ output: unknown; docChanged: boolean; sessionId: string }> {
   const apiBaseUrl = process.env.TIPTAP_CLOUD_AI_API_URL || 'https://api.tiptap.dev/v3/ai'
   const appId = process.env.TIPTAP_CLOUD_AI_APP_ID
 
@@ -261,6 +267,7 @@ export async function executeTool(
     body: JSON.stringify({
       toolName,
       input,
+      sessionId: options.sessionId,
       experimental_documentOptions: { documentId },
       schemaAwarenessData,
     }),
@@ -274,16 +281,41 @@ export async function executeTool(
 }
 ```
 
+```ts
+// lib/server-ai-toolkit/session-id.ts
+import type { UIMessage } from 'ai'
+
+type ServerAiToolkitMessage = UIMessage<{ sessionId?: string }>
+
+export function getSessionIdFromConversationHistory(
+  messages: ServerAiToolkitMessage[],
+): string | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const sessionId = messages[index]?.metadata?.sessionId
+
+    if (typeof sessionId === 'string' && sessionId.length > 0) {
+      return sessionId
+    }
+  }
+
+  return undefined
+}
+```
+
 Now create the main API route:
 
 ```ts
 // app/api/server-ai-agent-chatbot/route.ts
 import { openai } from '@ai-sdk/openai'
-import { createAgentUIStreamResponse, ToolLoopAgent, tool, type UIMessage } from 'ai'
+import { createAgentUIStreamResponse, ToolLoopAgent, tool } from 'ai'
 import z from 'zod'
 import { executeTool } from '@/lib/server-ai-toolkit/execute-tool'
 import { getSchemaAwarenessPrompt } from '@/lib/server-ai-toolkit/get-schema-awareness-prompt'
 import { getToolDefinitions } from '@/lib/server-ai-toolkit/get-tool-definitions'
+import {
+  getSessionIdFromConversationHistory,
+  type ServerAiToolkitMessage,
+} from '@/lib/server-ai-toolkit/session-id'
 
 export async function POST(req: Request) {
   const {
@@ -291,10 +323,11 @@ export async function POST(req: Request) {
     schemaAwarenessData,
     documentId,
   }: {
-    messages: UIMessage[]
+    messages: ServerAiToolkitMessage[]
     schemaAwarenessData: unknown
     documentId: string
   } = await req.json()
+  let sessionId = getSessionIdFromConversationHistory(messages)
 
   // Get tool definitions from the Server AI Toolkit API
   const toolDefinitions = await getToolDefinitions(schemaAwarenessData)
@@ -311,7 +344,10 @@ export async function POST(req: Request) {
         inputSchema: z.fromJSONSchema(toolDef.inputSchema),
         execute: async (input) => {
           try {
-            const result = await executeTool(toolDef.name, input, documentId, schemaAwarenessData)
+            const result = await executeTool(toolDef.name, input, documentId, schemaAwarenessData, {
+              sessionId,
+            })
+            sessionId = result.sessionId
             return result.output
           } catch (error) {
             console.error(`Failed to execute tool ${toolDef.name}:`, error)
@@ -343,6 +379,8 @@ ${schemaAwarenessPrompt}`,
 
   return createAgentUIStreamResponse({
     agent,
+    messageMetadata: ({ part }) =>
+      part.type === 'finish' && sessionId ? { sessionId } : undefined,
     uiMessages: messages,
   })
 }
@@ -503,17 +541,22 @@ export default function Page() {
 
 <Callout title="Alternative: provide the document directly" variant="info">
   Instead of using Tiptap Cloud documents, you can provide and manage the document yourself by
-  passing a `document` field (instead of `experimental_documentOptions`) in the execute-tool
-  request body. With this approach, you need to fetch the document before each tool execution
-  and save the updated document when `result.docChanged` is `true`.
-  See the [REST API reference](/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api).
+  passing a `document` field (instead of `experimental_documentOptions`) in the execute-tool request
+  body. With this approach, you need to fetch the document before each tool execution and save the
+  updated document when `result.docChanged` is `true`. See the [REST API
+  reference](/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api).
 </Callout>
 
 ## End result
 
 With additional CSS styles, the result is a simple but polished AI chatbot application that uses the Server AI Toolkit to edit documents:
 
-<CodeDemo isLarge path="" isScrollable src="https://ai-toolkit-demos.vercel.app/server-ai-agent-chatbot" />
+<CodeDemo
+  isLarge
+  path=""
+  isScrollable
+  src="https://ai-toolkit-demos.vercel.app/server-ai-agent-chatbot"
+/>
 
 See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
 

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot.mdx
@@ -281,26 +281,8 @@ export async function executeTool(
 }
 ```
 
-```ts
-// lib/server-ai-toolkit/session-id.ts
-import type { UIMessage } from 'ai'
-
-type ServerAiToolkitMessage = UIMessage<{ sessionId?: string }>
-
-export function getSessionIdFromConversationHistory(
-  messages: ServerAiToolkitMessage[],
-): string | undefined {
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const sessionId = messages[index]?.metadata?.sessionId
-
-    if (typeof sessionId === 'string' && sessionId.length > 0) {
-      return sessionId
-    }
-  }
-
-  return undefined
-}
-```
+Use a small helper such as [`lib/server-ai-toolkit/session-id.ts`](https://github.com/ueberdosis/ai-toolkit-demos/blob/main/src/lib/server-ai-toolkit/session-id.ts)
+to read the latest `sessionId` from the conversation history.
 
 Now create the main API route:
 

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/comments.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/comments.mdx
@@ -26,12 +26,6 @@ See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
   guide](/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot). Read it first.
 </Callout>
 
-<Callout title="Reuse the same chat session" variant="info">
-  Keep reusing the `sessionId` from the chatbot guide when your agent calls comment tools. This
-  keeps the same stale-read protection when the agent reads document content before creating or
-  updating comments.
-</Callout>
-
 ## Enable comment tools
 
 To enable comment tools, pass the `getThreads` and `editThreads` options when fetching tool definitions from the Server AI Toolkit API.

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/comments.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/comments.mdx
@@ -26,6 +26,12 @@ See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
   guide](/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot). Read it first.
 </Callout>
 
+<Callout title="Reuse the same chat session" variant="info">
+  Keep reusing the `sessionId` from the chatbot guide when your agent calls comment tools. This
+  keeps the same stale-read protection when the agent reads document content before creating or
+  updating comments.
+</Callout>
+
 ## Enable comment tools
 
 To enable comment tools, pass the `getThreads` and `editThreads` options when fetching tool definitions from the Server AI Toolkit API.
@@ -101,6 +107,7 @@ const result = await fetch(`${apiBaseUrl}/toolkit/execute-tool`, {
     toolName: 'editThreads',
     input: {},
     schemaAwarenessData,
+    sessionId,
     // Reference the Tiptap Cloud document
     experimental_documentOptions: {
       documentId: '123',

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/selection-awareness.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/selection-awareness.mdx
@@ -27,11 +27,6 @@ See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
   authentication setup from that guide.
 </Callout>
 
-<Callout title="Reuse the same chat session" variant="info">
-  Store the returned `sessionId` in the chat history and reuse it for both selection reads and tool
-  execution. This keeps the selection context and follow-up edits protected against stale reads.
-</Callout>
-
 ## 1. Track the active selection
 
 Add the `Selection` extension and store the current range whenever the selection changes.

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/selection-awareness.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/selection-awareness.mdx
@@ -27,6 +27,11 @@ See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
   authentication setup from that guide.
 </Callout>
 
+<Callout title="Reuse the same chat session" variant="info">
+  Store the returned `sessionId` in the chat history and reuse it for both selection reads and tool
+  execution. This keeps the selection context and follow-up edits protected against stale reads.
+</Callout>
+
 ## 1. Track the active selection
 
 Add the `Selection` extension and store the current range whenever the selection changes.
@@ -93,6 +98,7 @@ const response = await fetch(`${apiBaseUrl}/toolkit/read/read-selection`, {
   body: JSON.stringify({
     schemaAwarenessData,
     range: selectionRange,
+    sessionId,
     reviewOptions: {
       mode: 'disabled',
     },

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
@@ -23,6 +23,12 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 Display server-side AI edits as tracked changes, so your users can review and accept or reject them individually. This integrates the Server AI Toolkit with the [Tracked Changes](/tracked-changes/getting-started/overview) extension.
 
+<Callout title="Reuse the same chat session" variant="info">
+  Keep reusing the `sessionId` from the chatbot guide when the agent calls `tiptapRead` and
+  `tiptapEdit`. This lets the server reject tracked-change edits that were generated from stale
+  document content.
+</Callout>
+
 <CodeDemo
   isLarge
   path=""
@@ -59,6 +65,7 @@ const result = await fetch(`${apiBaseUrl}/toolkit/execute-tool`, {
     toolName: 'tiptapEdit',
     input: toolCallInput,
     schemaAwarenessData,
+    sessionId,
     experimental_documentOptions: {
       documentId: 'your-document-id',
       userId: 'ai-assistant',
@@ -168,6 +175,7 @@ const result = await fetch(`${apiBaseUrl}/toolkit/execute-tool`, {
     toolName: 'tiptapEdit',
     input: toolCallInput,
     schemaAwarenessData,
+    sessionId,
     experimental_documentOptions: {
       documentId: 'your-document-id',
       userId: 'ai-assistant',

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
@@ -23,12 +23,6 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 Display server-side AI edits as tracked changes, so your users can review and accept or reject them individually. This integrates the Server AI Toolkit with the [Tracked Changes](/tracked-changes/getting-started/overview) extension.
 
-<Callout title="Reuse the same chat session" variant="info">
-  Keep reusing the `sessionId` from the chatbot guide when the agent calls `tiptapRead` and
-  `tiptapEdit`. This lets the server reject tracked-change edits that were generated from stale
-  document content.
-</Callout>
-
 <CodeDemo
   isLarge
   path=""

--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
@@ -97,6 +97,12 @@ Example with an inline document:
   Thread and comment endpoints always require `experimental_documentOptions.documentId`.
 </Callout>
 
+## Session mechanism
+
+Read endpoints return a `sessionId` that records the node hashes and content hashes the AI saw.
+Reuse that same `sessionId` on follow-up edit requests so the server can reject stale edits instead
+of overwriting newer user changes.
+
 ## Formats
 
 Most endpoints accept a `format` field:
@@ -144,6 +150,7 @@ Request body:
 - `toolName` (`string`, required)
 - `input` (`unknown`, required)
 - `schemaAwarenessData` (`SchemaAwarenessData`, required)
+- `sessionId?` (`string | null`, optional): Reuse the session from a previous read or tool execution to enable stale-read protection.
 - `format?` (`'json' | 'shorthand'`, optional)
 - `chunkSize?` (`number`, optional)
 - `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/server-ai-toolkit/api-reference/review-options), optional)
@@ -154,6 +161,7 @@ Request body:
 
 Response:
 
+- `sessionId` (`string`)
 - `output` (`unknown`)
 - `docChanged` (`boolean`)
 - `document` (`object | null`)
@@ -189,6 +197,8 @@ curl --location 'BASE_URL/v3/ai/toolkit/workflows/edit' \
     "format": "shorthand"
   }'
 ```
+
+Keep the returned `sessionId` and send it with the matching workflow execute request.
 
 ### Read document content for a workflow
 
@@ -239,6 +249,8 @@ curl --location 'BASE_URL/v3/ai/toolkit/read/read-document' \
     }
   }'
 ```
+
+Keep the returned `sessionId` and send it with the matching insert-content execute request.
 
 ### Read the current selection
 

--- a/src/content/content-ai/capabilities/server-ai-toolkit/workflows/comments.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/workflows/comments.mdx
@@ -25,6 +25,11 @@ See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
   use `experimental_documentOptions.documentId`.
 </Callout>
 
+<Callout title="Reuse the document read session for thread edits" variant="info">
+  `read-document` returns a `sessionId`. Send that same `sessionId` with the execute request so the
+  server can reject thread operations that target content the AI read before a user changed it.
+</Callout>
+
 ## 1. Read the document and existing threads from the AI Server
 
 The comments workflow needs both the current document content and the existing thread list. Call:
@@ -43,6 +48,7 @@ const documentResponse = await fetch(`${apiBaseUrl}/toolkit/read/read-document`,
   body: JSON.stringify({
     schemaAwarenessData,
     format: 'shorthand',
+    sessionId,
     reviewOptions: {
       mode: 'disabled',
     },
@@ -140,6 +146,7 @@ const executeResponse = await fetch(`${apiBaseUrl}/toolkit/execute-workflow/thre
     schemaAwarenessData,
     format: 'shorthand',
     input: output,
+    sessionId: documentReadResult.sessionId,
     experimental_documentOptions: {
       documentId,
       userId: 'ai-assistant',
@@ -169,8 +176,12 @@ const response = await fetch('/api/server-comments-workflow', {
     documentId,
     schemaAwarenessData: getSchemaAwarenessData(editor),
     task,
+    sessionId,
   }),
 })
+
+const result: { sessionId: string } = await response.json()
+setSessionId(result.sessionId)
 ```
 
 ## End result

--- a/src/content/content-ai/capabilities/server-ai-toolkit/workflows/insert-content.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/workflows/insert-content.mdx
@@ -24,6 +24,11 @@ See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
   the [AI agent chatbot guide](/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot).
 </Callout>
 
+<Callout title="Reuse the same session across read and execute" variant="info">
+  The selection read step returns a `sessionId`. Send that same `sessionId` with the execute request
+  so the server can reject stale edits when the selected content changed after the AI read it.
+</Callout>
+
 ## 1. Read the current selection from the AI Server
 
 The insert-content workflow starts by reading the selected content from a collaborative document.

--- a/src/content/content-ai/capabilities/server-ai-toolkit/workflows/proofreader.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/workflows/proofreader.mdx
@@ -24,6 +24,11 @@ See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
   The Server AI Toolkit proofreader workflow currently uses `format: 'shorthand'`.
 </Callout>
 
+<Callout title="Reuse the same session across read and execute" variant="info">
+  The read step returns a `sessionId`. Send that same `sessionId` with the execute request so the
+  server can reject stale edits when the document changed after the AI read it.
+</Callout>
+
 ## 1. Read the document content from the AI Server
 
 Start by reading the document in shorthand format. Call:

--- a/src/content/content-ai/capabilities/server-ai-toolkit/workflows/tiptap-edit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/workflows/tiptap-edit.mdx
@@ -21,6 +21,11 @@ See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
   rewriting paragraphs, inserting new blocks near a target node, or transforming an entire document.
 </Callout>
 
+<Callout title="Reuse the same session across read and execute" variant="info">
+  The read step returns a `sessionId`. Send that same `sessionId` with the execute request so the
+  server can reject stale edits when the document changed after the AI read it.
+</Callout>
+
 ## 1. Read the document from the AI Server
 
 Read the part of the document you want the model to work on. Call:
@@ -133,7 +138,7 @@ const executeResult = await executeResponse.json()
 
 ## 4. Trigger the workflow from the editor UI
 
-The client only needs to send the document ID, the schema awareness data, and the task.
+The client should keep the latest `sessionId` and send it with the next request.
 
 ```tsx
 const response = await fetch('/api/server-edit-workflow', {


### PR DESCRIPTION
## Summary
- explain the Server AI Toolkit session mechanism in the REST API reference and in every server-side workflow or agent guide where sessionId should be reused
- update the guide snippets to show sessionId flowing through read and execute requests, plus AI SDK message metadata for chat-based demos
- keep the documentation concise and focused on the stale-read protection behavior

## Validation
- pnpm exec eslint src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx src/content/content-ai/capabilities/server-ai-toolkit/workflows/tiptap-edit.mdx src/content/content-ai/capabilities/server-ai-toolkit/workflows/proofreader.mdx src/content/content-ai/capabilities/server-ai-toolkit/workflows/insert-content.mdx src/content/content-ai/capabilities/server-ai-toolkit/workflows/comments.mdx src/content/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot.mdx src/content/content-ai/capabilities/server-ai-toolkit/agents/comments.mdx src/content/content-ai/capabilities/server-ai-toolkit/agents/selection-awareness.mdx src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
- pnpm exec prettier --check src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx src/content/content-ai/capabilities/server-ai-toolkit/workflows/tiptap-edit.mdx src/content/content-ai/capabilities/server-ai-toolkit/workflows/proofreader.mdx src/content/content-ai/capabilities/server-ai-toolkit/workflows/insert-content.mdx src/content/content-ai/capabilities/server-ai-toolkit/workflows/comments.mdx src/content/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot.mdx src/content/content-ai/capabilities/server-ai-toolkit/agents/comments.mdx src/content/content-ai/capabilities/server-ai-toolkit/agents/selection-awareness.mdx src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
- pnpm build

## Notes
- the repository-wide pnpm lint command currently reports unrelated existing issues outside these files