### PR TITLE
Add streaming coming soon page to Server AI Toolkit agents

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/streaming.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/streaming.mdx
@@ -1,0 +1,21 @@
+---
+title: Streaming
+meta:
+  title: Streaming | Tiptap Server AI Toolkit
+  description: Streaming support is coming soon to the Server AI Toolkit.
+  category: Content AI
+---
+
+import { Callout } from '@/components/ui/Callout'
+
+<Callout title="Coming soon" variant="info">
+  Streaming is not yet available in the Server AI Toolkit. In the meantime, you can use the [AI
+  Toolkit](/content-ai/capabilities/ai-toolkit/agents/streaming) to stream AI-generated content in
+  real-time on the client side.
+</Callout>
+
+Streaming support for the Server AI Toolkit is under active development. Once available, it will allow AI-generated document edits to appear in real-time as the model produces them, directly from the server side.
+
+## Use the AI Toolkit for streaming
+
+Until server-side streaming is available, you can use the [AI Toolkit's streaming feature](/content-ai/capabilities/ai-toolkit/agents/streaming) to achieve real-time updates. The AI Toolkit runs on the client side and supports streaming today via the `streamTool` method.

--- a/src/content/content-ai/sidebar.ts
+++ b/src/content/content-ai/sidebar.ts
@@ -314,6 +314,10 @@ export const sidebarConfig: SidebarConfig = {
                   href: '/content-ai/capabilities/server-ai-toolkit/agents/selection-awareness',
                 },
                 {
+                  title: 'Streaming',
+                  href: '/content-ai/capabilities/server-ai-toolkit/agents/streaming',
+                },
+                {
                   title: 'Tool definitions',
                   href: '/content-ai/capabilities/server-ai-toolkit/agents/tools',
                 },


### PR DESCRIPTION
## Summary

- Adds a new **Streaming** page under Server AI Toolkit > Agents that communicates streaming is not yet available and directs users to the AI Toolkit streaming feature in the meantime.
- Adds the new page to the sidebar under the Server AI Toolkit agents section.

The Server AI Toolkit does not yet support streaming. This page sets the right expectation and links users to the equivalent AI Toolkit streaming guide as a workaround.

## Test plan

- [ ] Verify the new Streaming page appears in the sidebar under Server AI Toolkit > Agents.
- [ ] Verify the page renders correctly and the callout and links work.
- [ ] Verify the AI Toolkit streaming page is unaffected.