### PR TITLE
fix: document required initialization order for UniqueID with Collaboration

### DIFF
--- a/src/content/editor/extensions/functionality/collaboration.mdx
+++ b/src/content/editor/extensions/functionality/collaboration.mdx
@@ -110,6 +110,10 @@ editor.commands.redo()
 | undo()  | <kbd>Control</kbd> + <kbd>Z</kbd>                                                         | <kbd>Cmd</kbd> + <kbd>Z</kbd>                                                     |
 | redo()  | <kbd>Shift</kbd> + <kbd>Control</kbd> + <kbd>Z</kbd> or <kbd>Control</kbd> + <kbd>Y</kbd> | <kbd>Shift</kbd> + <kbd>Cmd</kbd> + <kbd>Z</kbd> or <kbd>Cmd</kbd> + <kbd>Y</kbd> |
 
+## Usage with UniqueID
+
+If you are using the [UniqueID extension](/editor/extensions/functionality/uniqueid) together with Collaboration, make sure to mount the editor only after the collaboration provider has synced. Incorrect initialization order can cause persistent empty paragraphs in the document. See [UniqueID: Usage with Collaboration](/editor/extensions/functionality/uniqueid#usage-with-collaboration) for details.
+
 ## Source code
 
 [packages/extension-collaboration/](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-collaboration/)

--- a/src/content/editor/extensions/functionality/uniqueid.mdx
+++ b/src/content/editor/extensions/functionality/uniqueid.mdx
@@ -22,6 +22,7 @@ meta:
 ---
 
 import { CodeDemo } from '@/components/CodeDemo'
+import { Callout } from '@/components/ui/Callout'
 
 The `UniqueID` extension adds unique IDs to the node types you configure.
 The extension keeps track of your nodes, even if you split them, merge them, undo/redo changes, crop content, paste content … It just works.
@@ -106,6 +107,121 @@ UniqueID.configure({
   updateDocument: false,
 })
 ```
+
+## Usage with Collaboration
+
+<Callout title="Important" variant="warning">
+When using the UniqueID extension together with the [Collaboration extension](/editor/extensions/functionality/collaboration), ensure that the editor is only mounted **after** the collaboration provider has synced. Mounting the editor on an unsynced `Y.Doc` can lead to unintended document state (e.g., persistent empty paragraphs), which the UniqueID extension will then preserve.
+</Callout>
+
+### Incorrect setup
+
+In this example, the editor is mounted immediately with the Collaboration extension before the provider has synced. This causes the editor to initialize against an empty `Y.Doc`, which leads to unintended document mutations.
+
+```tsx
+import Collaboration from '@tiptap/extension-collaboration'
+import { isChangeOrigin } from '@tiptap/extension-collaboration'
+import { EditorContent, useEditor } from '@tiptap/react'
+import { TiptapCollabProvider } from '@tiptap-pro/provider'
+import { useEffect } from 'react'
+import * as Y from 'yjs'
+
+const doc = new Y.Doc()
+
+export default () => {
+  // ❌ Editor is mounted before the provider has synced
+  const editor = useEditor({
+    extensions: [
+      // ...other extensions
+      UniqueID.configure({
+        types: ['paragraph', 'heading'],
+        filterTransaction: (transaction) => !isChangeOrigin(transaction),
+      }),
+      Collaboration.configure({
+        document: doc,
+      }),
+    ],
+    content: '<p>Initial content</p>', // This will be duplicated on every sync
+  })
+
+  useEffect(() => {
+    // Provider connects and syncs after the editor is already mounted
+    const provider = new TiptapCollabProvider({
+      name: 'your-document-name',
+      appId: 'YOUR_APP_ID',
+      token: 'YOUR_JWT',
+      document: doc,
+    })
+  }, [])
+
+  return <EditorContent editor={editor} />
+}
+```
+
+### Correct setup
+
+To avoid this issue, follow this initialization order:
+
+1. Initialize the `Y.Doc`
+2. Start the collaboration provider
+3. Wait for the `synced` event
+4. Check if the collaborative document is empty
+5. Mount the editor with the correct content
+
+```tsx
+import Collaboration from '@tiptap/extension-collaboration'
+import { isChangeOrigin } from '@tiptap/extension-collaboration'
+import { EditorContent, useEditor } from '@tiptap/react'
+import { TiptapCollabProvider } from '@tiptap-pro/provider'
+import { useEffect } from 'react'
+import * as Y from 'yjs'
+
+const doc = new Y.Doc()
+
+export default () => {
+  const editor = useEditor({
+    extensions: [
+      // ...other extensions
+      UniqueID.configure({
+        types: ['paragraph', 'heading'],
+        filterTransaction: (transaction) => !isChangeOrigin(transaction),
+      }),
+      Collaboration.configure({
+        document: doc,
+      }),
+    ],
+    // Do not set content here — wait for sync
+  })
+
+  useEffect(() => {
+    const provider = new TiptapCollabProvider({
+      name: 'your-document-name',
+      appId: 'YOUR_APP_ID',
+      token: 'YOUR_JWT',
+      document: doc,
+
+      onSynced() {
+        // Only seed content if the collaborative document is empty
+        const isEmpty = doc.getXmlFragment('default').length === 0
+
+        if (isEmpty && editor) {
+          editor.commands.setContent(yourInitialContent)
+        }
+      },
+    })
+  }, [])
+
+  return <EditorContent editor={editor} />
+}
+```
+
+### Key points
+
+- **Do not initialize editor content before sync.** Do not rely on default editor state when using collaboration.
+- **Use `filterTransaction`** to ignore mutations from collaboration. See the [filterTransaction setting](#filtertransaction).
+- **Avoid reusing corrupted document names during development.** If a bad state has already been persisted, use a new document name to start clean.
+
+For the full collaboration setup guide, refer to the [Install Collaboration](/collaboration/getting-started/install) documentation.
 
 ## Server side Unique ID utility
 


### PR DESCRIPTION
## Summary

- Adds a "Usage with Collaboration" section to the UniqueID extension docs with incorrect vs correct setup examples, explaining how mounting the editor before the collaboration provider syncs can cause persistent empty paragraphs
- Adds a cross-link from the Collaboration extension docs to the new UniqueID section

## Test plan

- [ ] Verify the UniqueID docs page renders correctly with the new Callout, code examples, and key points section
- [ ] Verify the Collaboration docs page renders the new "Usage with UniqueID" cross-link correctly
- [ ] Confirm all internal links resolve properly