### PR TITLE
feat: experimental css export-import style mapping docs

### DIFF
--- a/src/content/conversion/export/docx/css-to-docx.mdx
+++ b/src/content/conversion/export/docx/css-to-docx.mdx
@@ -1,0 +1,162 @@
+---
+title: Export editor CSS as DOCX styles
+tags:
+  - type: start
+  - type: experiment
+  - type: version
+    label: v0.16.0
+meta:
+    title: CSS to DOCX | Tiptap Conversion
+    description: Compile CSS rules from your editor into DOCX style definitions on export. Experimental feature — API may change.
+    category: Conversion
+---
+
+import { Callout } from '@/components/ui/Callout'
+import { CodeDemo } from '@/components/CodeDemo'
+import { Requirements, RequirementItem } from '@/components/Requirements'
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="docx" renderMode="sidebar" disableWaitlist />
+
+<Callout variant="warning" title="Experimental feature">
+  The APIs and property mapping documented on this page may change without
+  notice. Pin exact package versions if you depend on this feature. Read the
+  **What won't work** section before you adopt it.
+</Callout>
+
+<Requirements>
+  <RequirementItem label="1. Activate trial or subscribe">
+    Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start plan](https://cloud.tiptap.dev/v2/billing) in your account.
+  </RequirementItem>
+  <RequirementItem label="2. Install from private registry">
+    Authenticate to Tiptap's private npm registry by following the [setup guide](/guides/pro-extensions).
+  </RequirementItem>
+</Requirements>
+
+<CodeDemo isPro path="/Extensions/ExportDocxCssStyles" />
+
+## What this does
+
+Exporting from Tiptap to DOCX normally takes your document's **node and mark attributes** and writes them inline onto every paragraph, run, and cell. The result is a DOCX file where every element carries its own copy of `fontSize`, `color`, and spacing — verbose, redundant, and visually identical but structurally poor.
+
+This feature lets you keep your editor's **stylesheet** as the source of truth. You provide CSS rules (either explicitly or by letting us extract them from the browser), and on export we compile those rules into DOCX **style definitions** — the named entries Word uses as its own source of truth. The exported DOCX has a proper style catalog that Word users can edit once to change the look of every paragraph that uses the style.
+
+Paired with [CSS injection on import](/conversion/import/docx/css-injection), you get a round-trip path for the *style layer* of your document — separate from the *content layer*.
+
+A second demo shows the browser-extraction variant:
+
+<CodeDemo isPro path="/Extensions/ExportDocxCssStylesExtract" />
+
+## Install
+
+```bash
+npm i @tiptap-pro/extension-export-docx@^0.16.0
+```
+
+## How it works
+
+Three steps:
+
+1. **Collect the CSS.** The exporter reads your styles from two possible sources (you can use either or both):
+   - an explicit `styles` object you pass to `configure()`
+   - the browser's live stylesheets (if `extractFromDocument: true`), scoped to your editor root
+2. **Compile each selector.** The compiler looks up each selector in a fixed map (the same 16 selectors as the import side), converts each CSS property to its DOCX equivalent, and drops properties it can't map.
+3. **Merge into the styles catalog.** The compiled DOCX style fragments are merged into the export options' styles catalog, then handed to the DOCX writer.
+
+```ts
+import { ExportDocx } from '@tiptap-pro/extension-export-docx'
+
+ExportDocx.configure({
+  cssStyles: {
+    styles: {
+      h1: { fontSize: '32px', fontWeight: 'bold', color: '#1a1a1a' },
+      p:  { fontSize: '16px', lineHeight: 1.5, marginTop: '0pt', marginBottom: '8pt' },
+      blockquote: { fontStyle: 'italic', color: '#555' },
+    },
+    // Optional: also pick up rules from the live browser stylesheets
+    extractFromDocument: true,
+    // Optional: base for rem/em resolution
+    baseFontSize: 16,
+  },
+})
+```
+
+When `extractFromDocument: true`, the exporter walks `document.styleSheets`, picks rules whose selectors match the 16-selector map scoped under your editor root, and merges them with any explicit `styles`. **Explicit styles win per-property.**
+
+## What works
+
+**Selectors (16):** same as the import side.
+
+`p`, `h1`–`h6`, `blockquote`, `ul li`, `ol li`, `strong`, `em`, `u`, `s`, `a`, `code`
+
+**CSS properties.** Each selector can carry any subset of the following. Unlisted properties are skipped with a `console.warn` during export.
+
+- `fontSize` — converted to half-points (DOCX `w:sz`)
+- `color` — mapped to DOCX `w:color` (hex)
+- `fontFamily` — mapped to DOCX `w:rFonts`
+- `fontWeight` — `bold` toggles `w:b`
+- `fontStyle` — `italic` toggles `w:i`
+- `textDecoration` — `underline` → `w:u`, `line-through` → `w:strike`
+- `backgroundColor` — mapped to DOCX `w:shd` fill
+- `letterSpacing` — supported on export (not extracted on import)
+- `textAlign` — mapped to DOCX `w:jc` (`justify` → DOCX `both`)
+- `marginTop` / `marginBottom` — mapped to `w:spacing` `before` / `after` (in twips)
+- `lineHeight` — unitless → auto line rule (proportional); `Npt` → exact; `Npx` → converted
+
+**Unit conversion.** The compiler accepts `px`, `pt`, `rem`, `em`. `rem` and `em` are resolved against `baseFontSize` (default `16`). Other units (`%`, `vh`, `ch`, etc.) are not recognised and the property is skipped.
+
+**List merging.** Both `ul li` and `ol li` map to the DOCX `ListParagraph` style. If both are defined, their properties are merged; per-property, the later entry wins.
+
+## What won't work
+
+<Callout variant="warning" title="These are intentional limits">
+These are not bugs. They are explicit, documented boundaries of the feature. If your workflow depends on any of the items below, this feature is not the right tool.
+</Callout>
+
+- **Cross-origin stylesheets.** Browser security blocks `.cssRules` access on any stylesheet served from a different origin. `extractFromDocument` silently skips those sheets. If your theme lives on a CDN, pass the rules explicitly via `styles` instead.
+- **Pseudo-classes, pseudo-elements, media queries.** `a:hover`, `p::first-line`, `@media (min-width: …)` — none of these map to DOCX. They're dropped.
+- **CSS variables and `calc()`.** The compiler reads declared values, not computed values — `var(--brand)` or `calc(100% - 2rem)` are not resolved. Resolve them before passing the styles in.
+- **Arbitrary selectors.** The 16-selector map is the whole menu. Descendants like `.prose p` or `article h1` resolve only if they match the map exactly *after scope stripping* — otherwise dropped.
+- **Cascade and specificity.** The compiler flattens each selector to a single property set. If you have conflicting rules for the same selector at different specificities, only the compiled result lands in DOCX — the cascade is not preserved.
+- **Computed-style inheritance.** The browser extractor reads `document.styleSheets` directly. It does not walk the DOM or compute inherited values. If a property is inherited in the browser but not declared on the target selector, it will not be exported.
+
+## What to expect
+
+- A DOCX file with a proper `styles.xml` that a Word user can edit centrally.
+- Exactly one DOCX style entry per matched selector with exactly the properties that mapped cleanly. Everything else is either merged from an explicit `styles` override or skipped with a `console.warn`.
+- Deterministic behaviour: given the same inputs (`styles` object and DOM stylesheets), exports are byte-comparable.
+- Safe server-side usage: if `document` is undefined (Node, SSR), `extractFromDocument` is a no-op — no errors thrown, nothing injected.
+
+## What not to expect
+
+- **Round-trip identity with the import side.** Some CSS → DOCX conversions are lossy (for example: `line-height: 1.5` → auto line rule, but re-importing that DOCX will emit the line-height back as a unitless multiplier, which may not equal `1.5` exactly if Word normalised the stored value).
+- **Media-query-aware exports.** DOCX has no media queries. If your responsive CSS differs between mobile and desktop, you get whatever rule matched when you called `configure()` (usually desktop).
+- **Visual fidelity against the browser render.** DOCX's rendering engine (Word, LibreOffice, Google Docs) interprets styles differently from a browser. Expect small differences in line spacing, kerning, and paragraph spacing.
+- **Automatic theme translation.** Colours, fonts, and sizes map 1:1. Word "themes" (accent colours, font pairings) do not — if you want a Word theme, you have to set one up on the export options directly.
+
+## Configuration reference
+
+```ts
+ExportDocx.configure({
+  cssStyles: {
+    // Either: explicit object of selectors → CSS declarations
+    styles?: {
+      p?: { fontSize?: string; color?: string; /* … */ },
+      h1?: { /* … */ },
+      // …any of the 16 selectors
+    },
+
+    // Or: extract from the browser's live stylesheets
+    extractFromDocument?: boolean,  // default: false
+
+    // Base size for resolving rem / em
+    baseFontSize?: number,  // default: 16
+  },
+})
+```
+
+## Related
+
+- [CSS injection (import)](/conversion/import/docx/css-injection) — the reverse direction.
+- [Export styles](/conversion/export/docx/export-styles) — the original DOCX export styles guide (manual style definitions, not CSS-based).
+- [REST API](/conversion/export/docx/rest-api) — the DOCX export endpoint.

--- a/src/content/conversion/import/docx/convertkit.mdx
+++ b/src/content/conversion/import/docx/convertkit.mdx
@@ -1,0 +1,199 @@
+---
+title: ConvertKit — DOCX-aware editor extensions
+tags:
+  - type: start
+  - type: experiment
+  - type: version
+    label: v0.1.0
+meta:
+    title: ConvertKit | Tiptap Conversion
+    description: A bundled Tiptap extension that configures the editor for DOCX-imported content. Experimental feature — API may change.
+    category: Conversion
+---
+
+import { Callout } from '@/components/ui/Callout'
+import { CodeDemo } from '@/components/CodeDemo'
+import { Requirements, RequirementItem } from '@/components/Requirements'
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="docx" renderMode="sidebar" disableWaitlist />
+
+<Callout variant="warning" title="Experimental feature">
+  The APIs, attribute names, and bundled extensions documented on this page may
+  change without notice. Pin exact package versions if you depend on ConvertKit.
+  Read the **What won't work** section before you adopt it.
+</Callout>
+
+<Requirements>
+  <RequirementItem label="1. Activate trial or subscribe">
+    Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start plan](https://cloud.tiptap.dev/v2/billing) in your account.
+  </RequirementItem>
+  <RequirementItem label="2. Install from private registry">
+    Authenticate to Tiptap's private npm registry by following the [setup guide](/guides/pro-extensions).
+  </RequirementItem>
+</Requirements>
+
+<CodeDemo isPro path="/Extensions/ImportDocxCssStyles" />
+
+## What this does
+
+A DOCX file carries formatting metadata that the stock Tiptap extensions do not know about — paragraph spacing in twips, table-row height rules, image crop percentages, vertical cell alignment, per-side border widths. If you render DOCX content with vanilla Tiptap, that information is lost or mis-rendered.
+
+**ConvertKit is a single extension that configures your editor for DOCX-imported content.** Drop it in and you get:
+
+- 27 bundled extensions wired up to handle everything the Convert API produces.
+- Custom Paragraph, Heading, Image, Table, TableRow, TableCell, and TableHeader extensions that accept the DOCX-specific attributes.
+- A small CSS reset injected at editor creation that normalises browser defaults so DOCX spacing values render accurately.
+- Every bundled extension is individually configurable or disableable.
+
+## Install
+
+```bash
+npm i @tiptap-pro/extension-convert-kit@^0.1.0
+```
+
+## How it works
+
+Three parts:
+
+1. **Extension bundle.** ConvertKit is a Tiptap `Extension` that adds child extensions via `addExtensions()`. Each child is either a base Tiptap extension (Bold, Italic, BulletList, …) or a custom override (Paragraph with spacing, Table with width, …). You can pass `false` for any slot to exclude that child.
+2. **Custom attributes.** The custom extensions extend their base counterparts (e.g. `Paragraph.extend(…)`) and declare additional attributes in `addAttributes()`. Parsing happens from HTML / JSON on editor init; rendering happens via `renderHTML()` onto inline `style` or `data-*` attributes.
+3. **CSS resets.** On `onCreate`, ConvertKit appends a `<style id="tiptap-convert-kit-css-resets">` to `document.head`. On `onDestroy`, it removes it. The reset normalises paragraph margins, table line-heights, cell vertical-alignment, and the `.cell-content` wrapper behaviour for exact-height rows.
+
+```ts
+import { Editor } from '@tiptap/core'
+import { ConvertKit } from '@tiptap-pro/extension-convert-kit'
+
+const editor = new Editor({
+  extensions: [ConvertKit],
+})
+```
+
+Customise or disable specific children:
+
+```ts
+new Editor({
+  extensions: [
+    ConvertKit.configure({
+      heading: { levels: [1, 2, 3] }, // only allow H1–H3
+      codeBlock: false,               // drop the code-block node entirely
+      table: false,                   // swap for a different table stack
+    }),
+  ],
+})
+```
+
+## What works
+
+### Bundled extensions
+
+ConvertKit ships **27** extensions:
+
+| Category | Extensions |
+|----------|------------|
+| Core | `Document`, `Text`, `Paragraph`*, `Heading`* |
+| Marks | `Bold`, `Italic`, `Underline`, `Strike`, `Code`, `Link` |
+| Blocks | `Blockquote`, `HorizontalRule`, `HardBreak`, `CodeBlock`, `PageBreak` |
+| Lists | `BulletList`, `OrderedList`, `ListItem`, `ListKeymap` |
+| Media | `Image`* |
+| Styling | `TextStyleKit` (Color, FontFamily, FontSize), `TextAlign`, `Highlight` (multicolor), `Superscript`, `Subscript` |
+| UI helpers | `Dropcursor`, `Gapcursor` |
+| Tables | `ConvertTableKit` (Table*, TableRow*, TableCell*, TableHeader*) |
+
+Extensions marked with `*` are custom, DOCX-aware overrides of the Tiptap base — see the next section for what they add.
+
+### DOCX attributes added on top of Tiptap base extensions
+
+| Extension | Added attributes | Source |
+|-----------|------------------|--------|
+| `Paragraph` | `spacingBefore`, `spacingAfter`, `lineHeight`, `fontSize`, `indent`, `hangingIndent`, `contextualSpacing` | DOCX `w:pPr` + `w:rPr` on paragraph mark |
+| `Heading` | same as `Paragraph` | DOCX `w:pPr` + `w:rPr` on paragraph mark |
+| `Image` | `cropTop`, `cropBottom`, `cropLeft`, `cropRight` | DOCX `a:srcRect` on drawings |
+| `Table` | `width`, `indent` (+ `cellMinWidth: 1` default, vs Tiptap's `25`) | DOCX `w:tblW`, `w:tblInd`, `w:tblGrid` |
+| `TableRow` | `height`, `heightRule` (`exact` / `atLeast`) | DOCX `w:trHeight` + `w:hRule` |
+| `TableCell` / `TableHeader` | `background`, `verticalAlign`, per-side border (`width` / `style` / `color` on top/bottom/left/right) | DOCX `w:tcPr` |
+
+### CSS resets injected at editor creation
+
+- All `*` descendants of `.tiptap`: `box-sizing: border-box`, zero top/bottom margin.
+- `table`: `border-collapse: collapse`, inherited border colour.
+- `table tr`: `line-height: 1`, zero top/bottom margin + padding.
+- `table td`, `table th`: `line-height: 1`, `vertical-align: top`, zero margin + padding.
+- `table tr[data-height-rule="exact"] td > .cell-content`: `overflow: hidden; height: var(--tr-height)` — this is what makes exact-height rows actually clip content. A CSS `height` on a `<td>` doesn't do what you'd expect for a `display: table-cell` element; the `.cell-content` wrapper is the block-level element that carries the clamp.
+- `table td p`, `table th p`: `white-space: normal` to counter any upstream `white-space: pre-line` inheritance.
+- `.ProseMirror-trailingBreak`: zero margins + padding (so the trailing break doesn't introduce phantom spacing).
+- `.tiptap p`: `line-height: 1`, zero margin + padding.
+
+### Small-but-important defaults
+
+- `cellMinWidth: 1` on Table. Tiptap defaults to `25`, which inflates DOCX spacer columns (1–15 px narrow columns used for layout) into visible gaps. ConvertKit caps the minimum at `1` px.
+- `textAlign` configured with `types: ['paragraph', 'heading']` so DOCX paragraph justification flows through both blocks.
+- `highlight` configured with `multicolor: true` so DOCX `w:highlight` colours come through as-is.
+
+## What won't work
+
+<Callout variant="warning" title="These are intentional limits">
+These are not bugs. They are explicit, documented boundaries of the feature. If your workflow depends on any of the items below, this feature is not the right tool.
+</Callout>
+
+- **Floating tables.** DOCX `w:tblpPr` (tables positioned relative to an anchor with text wrapping) render as plain stacked inline tables. The positioning metadata is dropped by the converter. Intended — float layout fidelity is out of scope.
+- **Negative table indents.** `w:tblInd` values below zero are preserved in `attrs.indent` but clamped to `0` at render time. Word renders negative indents into the paper gutter; browsers have no gutter, so rendering them would push the table past the page edge.
+- **Exact-height row overflow.** Rows with `heightRule: "exact"` clip overflowing content via the `.cell-content` wrapper's `overflow: hidden`. Content taller than the declared height is not visible.
+- **Over-wide table widths.** Tables whose declared `width` exceeds the container render with `max-width: 100%` — the declared width is preserved in `attrs.width` but visually clamped.
+- **Multi-page layout.** ConvertKit does not paginate. If you need tables that span pages, an actual page container, headers/footers, or page breaks to be respected visually, pair ConvertKit with the [Pages extension](/pages/getting-started/overview) and use [PagesTableKit](/pages/guides/pages-tablekit) for the table extensions.
+- **Footnotes, endnotes, comments.** Not rendered. The converter emits them as paragraphs or drops them; ConvertKit does not add any footnote/comment UI.
+
+## What to expect
+
+- One `<style id="tiptap-convert-kit-css-resets">` element added to `document.head` on editor creation, removed on editor destroy. Multiple ConvertKit-powered editors share the same element by ID (inserted once).
+- A consistent render of DOCX-imported content across your app. Images with non-zero DOCX crops actually render cropped; rows with `heightRule: "atLeast"` grow vertically when their columns shrink; cells with `verticalAlign: "center"` center their content.
+- Full compatibility with the rest of the Tiptap Pro extension ecosystem. `@tiptap-pro/extension-import-docx` and `@tiptap-pro/extension-export-docx` are the natural siblings; `@tiptap-pro/extension-pages-tablekit` stacks on top if you need pagination.
+
+## What not to expect
+
+- **A drop-in StarterKit replacement.** The CSS resets assume DOCX-origin content (zeroed paragraph margins, tight line-height). Using ConvertKit as your everyday editor kit for non-DOCX content will give you a visually compressed default style — you'll have to add your own typography rules back on top.
+- **DOCX fidelity beyond the node-attr level.** ConvertKit wires up the attributes the Convert API produces. If the converter doesn't parse a given DOCX feature, ConvertKit can't render it.
+- **Automatic resize handles on tables.** ConvertKit's Table extension inherits from `@tiptap/extension-table` and supports the standard resize behaviour — but the default `cellMinWidth: 1` means handles can drag columns down to 1 px wide, which is usually not what you want for hand-editing. Override `table.cellMinWidth` when mixing DOCX imports with hand authoring.
+
+## Configuration reference
+
+Every key is optional. Pass `false` to exclude an extension. Pass a partial options object to forward to the underlying extension's `configure()`. Defaults for each key are `{}`.
+
+```ts
+ConvertKit.configure({
+  document:       Record<string, never> | false,
+  text:           Record<string, never> | false,
+  paragraph:      Partial<ParagraphOptions>      | false,
+  heading:        Partial<HeadingOptions>        | false,
+  blockquote:     Partial<BlockquoteOptions>     | false,
+  bold:           Partial<BoldOptions>           | false,
+  italic:         Partial<ItalicOptions>         | false,
+  underline:      Partial<UnderlineOptions>      | false,
+  strike:         Partial<StrikeOptions>         | false,
+  code:           Partial<CodeOptions>           | false,
+  link:           Partial<LinkOptions>           | false,
+  bulletList:     Partial<BulletListOptions>     | false,
+  orderedList:    Partial<OrderedListOptions>    | false,
+  listItem:       Partial<ListItemOptions>       | false,
+  listKeymap:     Partial<ListKeymapOptions>     | false,
+  hardBreak:      Partial<HardBreakOptions>      | false,
+  horizontalRule: Partial<HorizontalRuleOptions> | false,
+  dropcursor:     Partial<DropcursorOptions>     | false,
+  gapcursor:      Record<string, never>          | false,
+  codeBlock:      Partial<CodeBlockOptions>      | false,
+  image:          Partial<ImageOptions>          | false,
+  textStyleKit:   Partial<TextStyleKitOptions>   | false,
+  textAlign:      Partial<TextAlignOptions>      | false, // default: { types: ['paragraph', 'heading'] }
+  highlight:      Partial<HighlightOptions>      | false, // default: { multicolor: true }
+  superscript:    Partial<SuperscriptExtensionOptions> | false,
+  subscript:      Partial<SubscriptExtensionOptions>   | false,
+  pageBreak:      Partial<PageBreakOptions>      | false,
+  table:          Partial<ConvertTableKitOptions> | false,
+})
+```
+
+## Related
+
+- [PagesTableKit](/pages/guides/pages-tablekit) — companion package that wraps ConvertKit's Table extensions in a CSS-Grid NodeView compatible with the Pages extension's pagination.
+- [CSS injection (import)](/conversion/import/docx/css-injection) — pair ConvertKit with CSS injection to get typographic fidelity from the DOCX style catalog.
+- [Editor extension (import DOCX)](/conversion/import/docx/editor-import) — how the `ImportDocx` extension calls into the Convert API.

--- a/src/content/conversion/import/docx/css-injection.mdx
+++ b/src/content/conversion/import/docx/css-injection.mdx
@@ -1,0 +1,180 @@
+---
+title: Inject DOCX default styles as CSS
+tags:
+  - type: start
+  - type: experiment
+  - type: version
+    label: v0.10.0
+meta:
+    title: CSS Injection (Import DOCX) | Tiptap Conversion
+    description: Extract the default styles from a DOCX file as CSS and inject them into your Tiptap editor on import. Experimental feature — API may change.
+    category: Conversion
+---
+
+import { Callout } from '@/components/ui/Callout'
+import { CodeDemo } from '@/components/CodeDemo'
+import { Requirements, RequirementItem } from '@/components/Requirements'
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="docx" renderMode="sidebar" disableWaitlist />
+
+<Callout variant="warning" title="Experimental feature">
+  The APIs, attribute names, and behaviour documented on this page may change
+  without notice. Pin exact package versions if you depend on this feature. Read
+  the **What won't work** section before you adopt it.
+</Callout>
+
+<Requirements>
+  <RequirementItem label="1. Activate trial or subscribe">
+    Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start plan](https://cloud.tiptap.dev/v2/billing) in your account.
+  </RequirementItem>
+  <RequirementItem label="2. Install from private registry">
+    Authenticate to Tiptap's private npm registry by following the [setup guide](/guides/pro-extensions).
+  </RequirementItem>
+</Requirements>
+
+<CodeDemo isPro path="/Extensions/ImportDocxCssStyles" />
+
+## What this does
+
+DOCX files carry a style catalog — the named definitions (`Heading1`, `Normal`, `Quote`, etc.) that tell Word how body text, headings, hyperlinks, and lists should look. Every paragraph or run in a DOCX either inherits from one of these named styles or overrides individual properties inline.
+
+Without this feature, the Tiptap Convert API flattens those styles into per-node attributes — you see fontSize, color, and spacing applied inline on each paragraph, but the reusable named styles that Word used as a source of truth are discarded.
+
+This feature extracts the named-style catalog as a **CSS object** (keyed by CSS selector) and can either return it to you directly or inject it as a scoped `<style>` tag into your page. The result: the document's baseline typography renders through CSS rules that cascade — not through inline attributes on every node — so your editor visually matches the original DOCX without bloating the document model.
+
+## Install
+
+```bash
+npm i @tiptap-pro/extension-import-docx@^0.10.0
+```
+
+## How it works
+
+A four-step pipeline:
+
+1. **Opt in on the import request.** The extension asks the Convert API to include the style catalog when `cssStyles.enabled` is `true`.
+2. **Convert service extracts.** The converter reads the DOCX style definitions, resolves inheritance chains (`basedOn`), translates OOXML properties to CSS equivalents, and returns a `cssStyles` object on the import response.
+3. **Extension builds CSS rules.** The `cssStyles` object is compiled to a CSS string, scoped by the selector you configure (default `.tiptap`).
+4. **Auto-inject or hand-off.** If `autoInject: true`, the extension appends a scoped `<style>` element to `document.head`. If `autoInject: false`, you receive the raw `cssStyles` object on the `onImport` callback and decide what to do with it.
+
+```ts
+import { Import } from '@tiptap-pro/extension-import-docx'
+
+Import.configure({
+  appId: 'your-app-id',
+  token: 'your-jwt',
+  cssStyles: {
+    enabled: true,      // extract styles on every import
+    autoInject: true,   // automatically inject as a scoped <style> tag
+    selector: '.tiptap', // scope the rules under this selector
+  },
+})
+```
+
+Or control it per-call:
+
+```ts
+editor
+  .chain()
+  .importDocx({
+    file,
+    cssStyles: { enabled: true, autoInject: false },
+    onImport(context) {
+      // `context.cssStyles` is the raw object — apply it however you like
+      console.log(context.cssStyles)
+    },
+  })
+  .run()
+```
+
+## What works
+
+**Selectors (16):** the feature extracts named styles mapped to these CSS selectors only.
+
+| Kind | Selectors |
+|------|-----------|
+| Block-level | `p`, `h1`–`h6`, `blockquote`, `ul li`, `ol li` |
+| Inline / marks | `strong`, `em`, `u`, `s`, `a`, `code` |
+
+**CSS properties (11):** each selector above can receive any subset of these, depending on what the DOCX style defined.
+
+| Property | DOCX source | Notes |
+|----------|-------------|-------|
+| `fontSize` | `w:sz` (half-points) | Converted to `Npx` (`halfPoints / 2`) |
+| `color` | `w:color` | Hex; `"auto"` is skipped |
+| `fontFamily` | `w:rFonts` | Prefers `@w:ascii`, falls back to `hAnsi`, then `cs` |
+| `fontWeight` | `w:b` | `"bold"` or `"normal"` |
+| `fontStyle` | `w:i` | `"italic"` or `"normal"` |
+| `textDecoration` | `w:u` + `w:strike` | Combined (e.g. `"underline line-through"`) |
+| `backgroundColor` | `w:shd[@fill]` | Hex; `"auto"` is skipped |
+| `textAlign` | `w:jc` | `left` / `center` / `right` / `justify` (DOCX `both` → `justify`) |
+| `marginTop` | `w:spacing[@before]` | Twips → `Npt` |
+| `marginBottom` | `w:spacing[@after]` | Twips → `Npt` |
+| `lineHeight` | `w:spacing[@line]` + `[@lineRule]` | `auto` → unitless multiplier; `exact`/`atLeast` → `Npt` |
+
+**Other behaviours:**
+- **Inheritance chains.** `basedOn` references resolve iteratively with cycle detection — a child style includes everything it inherits from its parent.
+- **Localized documents.** DOCX files authored in non-English Word builds (e.g. Spanish `Título1`, German `Überschrift1`) are mapped back to their canonical names (`heading 1`) so the selector assignment still works.
+- **Failure is invisible.** If extraction throws for any reason (malformed styles.xml, unexpected attributes), it returns `{}` and the import continues normally — the feature never blocks a working import.
+
+## What won't work
+
+<Callout variant="warning" title="These are intentional limits">
+These are not bugs. They are explicit, documented boundaries of the feature. If your workflow depends on any of the items below, this feature is not the right tool.
+</Callout>
+
+- **Pseudo-classes.** `:hover`, `:focus`, `:first-child`, etc. The DOCX style model has no equivalent; none are extracted.
+- **Arbitrary selectors.** The 16 selectors in the table above are the entire map. Any DOCX style whose purpose falls outside that map (`TableGrid`, `TOC1`, `FootnoteText`, custom user styles) is dropped.
+- **Letter spacing.** Supported by the export-side compiler, but **not** extracted on import.
+- **Specificity beyond the selector itself.** The injected rules are scoped under your selector (e.g. `.tiptap h1 { … }`). They do not account for cascade ordering against your own stylesheet — you must make sure your CSS doesn't accidentally override them or vice versa.
+- **Inline overrides.** If a specific paragraph or run overrides its style inline in Word (e.g. one `<w:r>` sets `w:color` directly), those overrides continue to render via node attributes on the Tiptap node, not via the injected stylesheet. You cannot "un-override" inline formatting by editing the injected CSS.
+- **Non-text styles.** Table styles (`w:tblStyle`), numbering styles (`w:numId`), character styles like page numbers — not part of the map.
+
+## What to expect
+
+- A single scoped `<style>` element attached to `document.head` after each successful import with `autoInject: true`. Subsequent imports replace the previous element — you will only ever have one active at a time.
+- The raw `cssStyles` object on your `onImport` callback's context, regardless of the `autoInject` setting. You can ignore auto-inject entirely and apply the styles yourself — write them to a file, send them to a theming system, whatever makes sense for your app.
+- Styles scoped to your editor — default `.tiptap`, configurable via `cssStyles.selector`. Leaking into other parts of your page only happens if you set the selector to something global (e.g. `body`).
+- Silent failure modes. If the DOCX carries no style catalog, or every named style falls outside the 16-selector map, `cssStyles` comes back empty and no style tag is injected.
+
+## What not to expect
+
+- **Pixel-perfect Word fidelity.** Word uses an intrinsic layout engine with paragraph-spacing semantics that differ from CSS (e.g. collapsed margins, before/after contextual spacing). The extracted CSS is a faithful translation of the DOCX *style definitions*, not a reproduction of Word's layout output.
+- **Dynamic updates on live editing.** The styles are injected once per import. If the user edits the document in Tiptap afterwards, the injected styles do not re-compute — they describe the imported document's baseline, not the current editor state.
+- **Cross-document merging.** Each import replaces the previous `<style>` tag. Importing two DOCX files in a row gives you the second document's styles only. If you need to merge, read both `cssStyles` objects from `onImport` and merge them yourself.
+- **Round-trip guarantees.** The extract-then-export cycle is not lossless; see the [CSS to DOCX](/conversion/export/docx/css-to-docx) export page for the reverse direction and its own caveats.
+
+## Configuration reference
+
+```ts
+Import.configure({
+  cssStyles: {
+    enabled?: boolean,     // default: false. Turn extraction on.
+    autoInject?: boolean,  // default: false. Append <style> tag to document.head.
+    selector?: string,     // default: '.tiptap'. Scope for injected rules.
+  },
+})
+```
+
+Per-call override:
+
+```ts
+editor.chain().importDocx({
+  file,
+  cssStyles: { enabled, autoInject, selector }, // any subset
+  onImport(context) { /* context.cssStyles is available here */ },
+})
+```
+
+REST API query parameter (if you're calling `/import/docx` directly):
+
+```
+POST /import/docx?extractCssStyles=true
+```
+
+## Related
+
+- [CSS to DOCX (export)](/conversion/export/docx/css-to-docx) — the reverse direction: compile your editor's CSS back into DOCX style definitions.
+- [ConvertKit](/conversion/import/docx/convertkit) — the companion extension bundle that adds DOCX-aware attributes to Paragraph, Heading, Table, and more.
+- [REST API — CSS style extraction](/conversion/import/docx/rest-api#css-style-extraction-experimental) — the raw `extractCssStyles` parameter and full response shape.

--- a/src/content/conversion/import/docx/rest-api.mdx
+++ b/src/content/conversion/import/docx/rest-api.mdx
@@ -71,6 +71,7 @@ curl -X POST "https://api.tiptap.dev/v2/convert/import/docx" \
 | `prosemirrorNodes`       | `Object string` | Custom node mapping for the conversion, [see more info](/conversion/import/docx/custom-node-conversion).       |
 | `prosemirrorMarks`       | `Object string` | Custom mark mapping for the conversion, [see more info](/conversion/import/docx/custom-mark-conversion)        |
 | `verbose` | `string \| number` | A configuration property to help you control the level of diagnostic output during the import process. This is especially useful for debugging or for getting more insight into what happens during conversion. See more at [Verbose output](#import-verbose-output) |
+| `extractCssStyles` | `"true" \| "false"` | **Experimental.** When `"true"`, the response includes a `cssStyles` field with the DOCX style catalog translated to CSS-compatible key/value pairs. Defaults to `"false"`. See [CSS style extraction](#css-style-extraction-experimental) for the output shape and caveats. |
 
 ### Import verbose output
 
@@ -263,6 +264,94 @@ Inline references in the document body are represented as `footnoteReference` an
   }
 }
 ```
+
+## CSS style extraction (experimental)
+
+<Callout title="Experimental feature" variant="warning">
+  `extractCssStyles` is opt-in and experimental. The shape of the response may
+  change without notice. Pin exact client versions if you depend on it, and
+  read the [CSS injection documentation](/conversion/import/docx/css-injection)
+  for the full list of supported selectors, CSS properties, and known
+  limitations.
+</Callout>
+
+Pass `extractCssStyles=true` on the request to have the response include a `cssStyles` field. The field contains the DOCX default-style catalog translated to CSS-compatible key/value pairs, keyed by CSS selector.
+
+### Request
+
+```bash
+curl -X POST "https://api.tiptap.dev/v2/convert/import/docx" \
+    -H "Authorization: Bearer YOUR_TOKEN" \
+    -H "X-App-Id: YOUR_APP_ID" \
+    -F "file=@/path/to/your/file.docx" \
+    -F "extractCssStyles=true"
+```
+
+### Response field
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cssStyles` | `Object \| null` | An object keyed by CSS selector, where each value is an object of CSS properties. `null` or empty (`{}`) when the document has no extractable default styles or when the feature was not requested. |
+
+### Supported selectors
+
+The extractor maps DOCX named styles to this fixed set of CSS selectors. Styles that don't match the map are dropped silently.
+
+`p`, `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `blockquote`, `ul li`, `ol li`, `strong`, `em`, `u`, `s`, `a`, `code`
+
+### Supported CSS properties
+
+Each selector above can carry any subset of the following, depending on what the DOCX style defined.
+
+`color`, `fontSize`, `fontFamily`, `fontWeight`, `fontStyle`, `textDecoration`, `backgroundColor`, `textAlign`, `marginTop`, `marginBottom`, `lineHeight`
+
+### Example response
+
+```json
+{
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "paragraph",
+          "content": [{ "type": "text", "text": "Document body..." }]
+        }
+      ]
+    },
+    "cssStyles": {
+      "p": {
+        "fontSize": "16px",
+        "fontFamily": "Calibri",
+        "lineHeight": 1.15,
+        "marginBottom": "8pt"
+      },
+      "h1": {
+        "fontSize": "28px",
+        "fontWeight": "bold",
+        "color": "#1F3864",
+        "marginTop": "24pt",
+        "marginBottom": "6pt"
+      },
+      "a": {
+        "color": "#0563C1",
+        "textDecoration": "underline"
+      },
+      "blockquote": {
+        "fontStyle": "italic",
+        "color": "#595959"
+      }
+    }
+  }
+}
+```
+
+Notes on the output:
+
+- **Values are strings or numbers.** Pixel-based properties (`fontSize`) are emitted as `"Npx"` strings; point-based spacing (`marginTop`, `marginBottom`) is emitted as `"Npt"`; unitless multipliers (`lineHeight` under the `auto` line rule) are emitted as plain numbers.
+- **Style inheritance is resolved.** Child DOCX styles include everything they inherit from their parents (via `basedOn`) — the output is flattened, you do not have to walk a chain.
+- **Localized documents are supported.** Named styles in non-English Word builds are mapped back to their canonical selector before emission.
+- **Missing fields mean "not defined".** A selector only appears when at least one property could be extracted. If the DOCX has no style catalog at all, `cssStyles` is `null`.
 
 ### Custom node and mark mapping
 

--- a/src/content/conversion/sidebar.ts
+++ b/src/content/conversion/sidebar.ts
@@ -53,6 +53,16 @@ export const sidebarConfig: SidebarConfig = {
               tags: ['New'],
             },
             {
+              title: 'ConvertKit',
+              href: '/conversion/import/docx/convertkit',
+              tags: ['Experimental'],
+            },
+            {
+              title: 'CSS injection',
+              href: '/conversion/import/docx/css-injection',
+              tags: ['Experimental'],
+            },
+            {
               title: 'REST API',
               href: '/conversion/import/docx/rest-api',
             },
@@ -106,6 +116,11 @@ export const sidebarConfig: SidebarConfig = {
             {
               title: 'Export styles',
               href: '/conversion/export/docx/export-styles',
+            },
+            {
+              title: 'CSS to DOCX',
+              href: '/conversion/export/docx/css-to-docx',
+              tags: ['Experimental'],
             },
             {
               title: 'REST API',

--- a/src/content/pages/guides/pages-tablekit.mdx
+++ b/src/content/pages/guides/pages-tablekit.mdx
@@ -1,0 +1,209 @@
+---
+title: PagesTableKit — tables for the Pages extension
+tags:
+  - type: start
+  - type: experiment
+  - type: version
+    label: v0.2.0
+meta:
+    title: PagesTableKit | Tiptap Pages
+    description: Table extensions tailored for the Pages pagination extension. Works for any Pages setup; pairs with DOCX import for faithful Word-document rendering. Experimental feature — API may change.
+    category: Pages
+---
+
+import { Callout } from '@/components/ui/Callout'
+import { CodeDemo } from '@/components/CodeDemo'
+import { Requirements, RequirementItem } from '@/components/Requirements'
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="docx" renderMode="sidebar" disableWaitlist />
+
+<Callout variant="warning" title="Experimental feature">
+  PagesTableKit is built specifically for the Pages extension. APIs and
+  rendering behaviour may change without notice. Pin exact package versions if
+  you depend on it. Read the **What won't work** section before adopting it.
+</Callout>
+
+<Requirements>
+  <RequirementItem label="1. Activate trial or subscribe">
+    Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start plan](https://cloud.tiptap.dev/v2/billing) in your account.
+  </RequirementItem>
+  <RequirementItem label="2. Install from private registry">
+    Authenticate to Tiptap's private npm registry by following the [setup guide](/guides/pro-extensions).
+  </RequirementItem>
+</Requirements>
+
+## Which setup applies to me?
+
+<Callout title="Two audiences, one extension" variant="info">
+  PagesTableKit is useful in two distinct scenarios. Pick the one that matches
+  your workflow — the rest of this page is organised around the split.
+</Callout>
+
+- **Pages-only workflow** — you are building a paginated editor (print-ready layouts, letter-style documents, reports) and you need tables that paginate correctly. You are **not** importing DOCX files.
+- **Pages + DOCX import workflow** — you are importing `.docx` files and rendering them in a paginated editor. You need tables that paginate **and** faithfully reflect the authored DOCX formatting (declared widths, row heights, indentation).
+
+The installation is the same. The setup and expected behaviour differ; each section below flags which scenario it applies to.
+
+<CodeDemo isPro path="/Extensions/ImportDocxCssStylesPages" />
+
+## Install
+
+```bash
+npm i @tiptap-pro/extension-pages-tablekit@^0.2.0
+```
+
+## How to set it up
+
+PagesTableKit ships a single `TableKit` extension that bundles the Table, TableRow, TableCell, and TableHeader extensions. Register it once instead of wiring up the four extensions individually.
+
+### Scenario A: Pages-only (no DOCX import)
+
+You only need Pages + PagesTableKit. Register `TableKit` alongside whatever editor kit you already use.
+
+```ts
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import { Pages } from '@tiptap-pro/extension-pages'
+import { TableKit } from '@tiptap-pro/extension-pages-tablekit'
+
+const editor = new Editor({
+  extensions: [
+    StarterKit,
+    TableKit,
+    Pages.configure({ /* page format, margins, etc. */ }),
+  ],
+})
+```
+
+### Scenario B: Pages + DOCX import
+
+Pair PagesTableKit with [ConvertKit](/conversion/import/docx/convertkit) (the DOCX-aware editor kit) and the [ImportDocx extension](/conversion/import/docx/editor-import). Disable ConvertKit's own table stack so PagesTableKit's `TableKit` can take over:
+
+```ts
+import { Editor } from '@tiptap/core'
+import { ConvertKit } from '@tiptap-pro/extension-convert-kit'
+import { Import as ImportDocx } from '@tiptap-pro/extension-import-docx'
+import { Pages } from '@tiptap-pro/extension-pages'
+import { TableKit } from '@tiptap-pro/extension-pages-tablekit'
+
+const editor = new Editor({
+  extensions: [
+    ConvertKit.configure({ table: false }), // disable ConvertKit's table stack
+    TableKit,
+    ImportDocx.configure({ /* appId, token, … */ }),
+    Pages.configure({ /* page format, margins, etc. */ }),
+  ],
+})
+```
+
+## What works
+
+### Universal behaviour (both scenarios)
+
+- **Pagination-safe table rendering.** Tables sit inside the page content area and never horizontally overflow it.
+- **Column proportions preserved.** When every cell carries a `colwidth`, columns shrink proportionally to fit the page — a 10 % / 40 % / 50 % column split renders as 10 / 40 / 50 at any page width.
+- **Row height behaviour.**
+  - `heightRule: "exact"` — the row renders at the declared height and clips overflowing content.
+  - `heightRule: "atLeast"` (or unset) — the row grows vertically when content or narrower columns would otherwise force clipping.
+- **Live updates.** Edits that add, remove, or reorder cells re-lay the row out immediately.
+
+### DOCX-specific behaviour (Scenario B)
+
+These extras activate automatically when your document content was produced by the DOCX importer. You don't configure them separately — if the converter emitted the attribute, PagesTableKit honours it.
+
+- **Declared DOCX widths respected.** A DOCX table authored wider than the page shrinks proportionally into the content area instead of overflowing.
+- **DOCX row heights.** `w:trHeight` with `w:hRule="exact"` clips; `w:hRule="atLeast"` (or missing) grows.
+- **Narrow spacer columns preserved.** DOCX spacer columns (1–15 px) don't get inflated to a visible width.
+- **Negative DOCX indents.** Negative `w:tblInd` values (which Word renders into the paper gutter) are preserved in `attrs.indent` but clamped to 0 visually so tables don't push past the page edge.
+- **Cell background, vertical alignment, per-side borders.** Flow through from the DOCX import without extra work.
+
+## What won't work
+
+<Callout variant="warning" title="These are intentional limits">
+These are not bugs. They are explicit, documented boundaries of the feature. If your workflow depends on any of the items below, this feature is not the right tool.
+</Callout>
+
+### Universal limits (both scenarios)
+
+- **Editors without the Pages extension.** PagesTableKit is designed for Pages' paginated layout — it relies on Pages to constrain rows within the page. In a standard editor rows won't render correctly and over-wide tables will overflow horizontally. Use a regular table extension instead.
+- **Hand-authored rows with mixed `colwidth` / no `colwidth`.** The proportional-shrink behaviour kicks in when **every** cell carries a column width. In rows where some cells do and some don't, columns may render with different proportions than you'd expect.
+- **Column resize handles.** Drag-to-resize from `@tiptap/extension-table` is supported, but the final rendered widths may be proportional rather than the exact pixel values you dragged to — especially when every cell already carries a column width.
+
+### DOCX-specific limits (Scenario B)
+
+- **Floating tables.** DOCX `w:tblpPr` (tables positioned relative to an anchor with text wrap) is not converted by the importer — floats render as regular stacked tables.
+- **Pixel-perfect parity with Microsoft Word's table layout.** Word uses a proprietary layout algorithm that blends fixed and proportional sizing with content measurement. Expect small differences on tables authored with Word's "AutoFit to contents" setting.
+
+## Known issues
+
+### Rows must fit on a single page
+
+When a table row does not fit on the current page, Pages moves the **entire row** to the next page as an atomic unit. This differs from Microsoft Word, which visually splits a tall row across pages — PagesTableKit does not currently support mid-row page splits.
+
+If a row is taller than the page content area, moving it to the next page doesn't help: it won't fit there either, and the editor will keep trying to move it forward indefinitely. The result is an infinite pagination loop and a broken editor.
+
+**How to avoid it.** Keep row heights below the page content area. Be especially careful with:
+
+- `heightRule: "atLeast"` rows whose content can grow unbounded.
+- DOCX imports that carry very tall exact-height rows authored for larger paper than your target page format.
+- Nested tables inside cells, which can force the outer row taller than the page.
+
+Mid-row page splitting is on the roadmap. ETA: TBD.
+
+## What to expect
+
+### Universal (both scenarios)
+
+- Tables sit inside the page content area; exact-height rows clip, `atLeast` rows grow.
+- Updates land on every transaction — adding or removing cells re-lays the row immediately.
+- Very large tables (thousands of rows) may have a noticeable layout cost on edits. If you hit this, consider paginating large tables manually or splitting them across multiple documents.
+
+### DOCX-specific (Scenario B)
+
+- DOCX tables retain their declared widths, row heights, indentation, background colours, and per-side borders on import.
+- Over-wide DOCX tables (common in templates drawn full-width in Word) visually shrink to fit the page instead of overflowing.
+- You do not need to post-process imported DOCX JSON before rendering — the extensions read the attributes the importer produces.
+
+## What not to expect
+
+### Universal (both scenarios)
+
+- **A replacement for Pages.** PagesTableKit only handles tables. Pagination, page containers, headers, and footers are Pages' responsibility.
+- **Column-width mutation from your own DOM code.** Column widths flow from the ProseMirror document. Change them via `@tiptap/extension-table`'s commands (or your own transactions), not by writing directly to `dom.style`.
+
+### DOCX-specific (Scenario B)
+
+- **Round-trip identity.** Importing then exporting a DOCX through the Convert pipeline is not guaranteed to be byte-identical. Unsupported DOCX features (floats, certain table styles) are dropped on import.
+
+## Configuration reference
+
+PagesTableKit exports a single `TableKit` extension that bundles Table, TableRow, TableCell, and TableHeader.
+
+```ts
+import { TableKit } from '@tiptap-pro/extension-pages-tablekit'
+
+// Use defaults
+TableKit,
+```
+
+Each bundled extension can be configured (or disabled with `false`) through `TableKit.configure()`:
+
+```ts
+TableKit.configure({
+  table:       { cellMinWidth: 1 }, // Table options from @tiptap/extension-table
+  tableRow:    { /* TableRow options */ },
+  tableCell:   { /* TableCell options */ },
+  tableHeader: false, // disable the header extension entirely
+})
+```
+
+There are no configuration options unique to PagesTableKit — each key forwards to the underlying extension's standard options.
+
+## Related
+
+- [Pages overview](/pages/getting-started/overview) — the pagination extension PagesTableKit requires.
+- [Pages with tables](/pages/guides/table-with-pages) — general guide for authoring tables inside Pages.
+- [ConvertKit](/conversion/import/docx/convertkit) — DOCX-aware editor kit; use it for Scenario B.
+- [Editor extension (import DOCX)](/conversion/import/docx/editor-import) — how the `ImportDocx` extension pulls Word content into your editor.
+- [CSS injection (import)](/conversion/import/docx/css-injection) — extract the DOCX style catalog as CSS for consistent typography across paginated content.

--- a/src/content/pages/sidebar.ts
+++ b/src/content/pages/sidebar.ts
@@ -90,6 +90,11 @@ export const sidebarConfig: SidebarConfig = {
           href: '/pages/guides/table-with-pages',
         },
         {
+          title: 'PagesTableKit',
+          href: '/pages/guides/pages-tablekit',
+          tags: ['Experimental'],
+        },
+        {
           title: 'PageKit',
           href: '/pages/guides/pagekit-usage',
         },


### PR DESCRIPTION
This pull request adds two new documentation pages that introduce experimental features for DOCX conversion in Tiptap. The first page describes how to export editor CSS as DOCX styles, allowing for more maintainable and editable style definitions in exported Word documents. The second page documents the ConvertKit extension, which configures Tiptap to accurately render DOCX-imported content by handling DOCX-specific attributes and normalizing browser rendering. Both features are marked as experimental and are available via Tiptap Pro.

**New DOCX Export Feature:**

* Added `src/content/conversion/export/docx/css-to-docx.mdx` documenting how to export editor CSS as DOCX style definitions, including supported selectors, properties, unit conversion, and limitations. This feature enables round-trip style fidelity between Tiptap and Word, and supports both explicit CSS and extraction from live browser stylesheets.

**New DOCX Import Feature:**

* Added `src/content/conversion/import/docx/convertkit.mdx` documenting the ConvertKit extension, which bundles 27 extensions (including DOCX-aware overrides) to render DOCX-imported content accurately. The page details supported attributes, injected CSS resets, configuration options, and intentional feature boundaries.