### PR TITLE
docs: document field parameter for collaborative documents

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
@@ -71,6 +71,12 @@ Most tool and workflow endpoints accept exactly one document source:
 - `document`: Inline Tiptap JSON
 - `experimental_documentOptions`: A Tiptap Cloud document reference
 
+`experimental_documentOptions` has the following shape:
+
+- `documentId` (`string`, required): The Tiptap Cloud document identifier.
+- `userId?` (`string | null`, optional): Identifier attributed to edits the AI performs.
+- `field?` (`string | null`, optional): Targets a specific collaborative field (Y.js XML fragment) inside the document. Defaults to `"default"` when omitted or `null`. Use this when your document stores multiple editable fields — for example a separate title and body — under the same `documentId`.
+
 Example with a Tiptap Cloud document:
 
 ```json
@@ -78,6 +84,18 @@ Example with a Tiptap Cloud document:
   "experimental_documentOptions": {
     "documentId": "your-document-id",
     "userId": "ai-assistant"
+  }
+}
+```
+
+Example targeting a non-default collaborative field:
+
+```json
+{
+  "experimental_documentOptions": {
+    "documentId": "your-document-id",
+    "userId": "ai-assistant",
+    "field": "title"
   }
 }
 ```
@@ -316,7 +334,7 @@ Request body:
 
 - `schemaAwarenessData` (`SchemaAwarenessData`, required)
 - `format` (`'json' | 'shorthand'`, required)
-- `experimental_documentOptions` (`{ documentId: string, userId?: string }`, required)
+- `experimental_documentOptions` (`{ documentId: string, userId?: string, field?: string | null }`, required)
 
 Response:
 
@@ -512,7 +530,7 @@ Request body:
 - `input` (`object`, required): Thread operations
 - `schemaAwarenessData` (`SchemaAwarenessData`, required)
 - `format` (`'json' | 'shorthand'`, required)
-- `experimental_documentOptions` (`{ documentId: string, userId?: string }`, required)
+- `experimental_documentOptions` (`{ documentId: string, userId?: string, field?: string | null }`, required)
 - `experimental_commentsOptions?` (`{ threadData?: Record<string, unknown>, commentData?: Record<string, unknown> }`, optional): Metadata attached to new threads and comments created by the workflow.
 
 Response:


### PR DESCRIPTION
## Summary
Documents the new `field` parameter in `experimental_documentOptions` for the Server AI Toolkit REST API, allowing users to target specific collaborative fields (Y.js XML fragments) within a Tiptap Cloud document.

## Changes
- Adds a dedicated description of the `experimental_documentOptions` shape, including the new optional `field` parameter
- Adds an example payload showing how to target a non-default collaborative field (e.g. `title`)
- Updates type signatures for thread and workflow endpoints to reflect `field?: string | null`