### PR TITLE
Add gpt-5.4-mini and gpt-5.4-nano to supported AI models

### DIFF
--- a/src/content/content-ai/capabilities/generation/text-generation/built-in-commands.mdx
+++ b/src/content/content-ai/capabilities/generation/text-generation/built-in-commands.mdx
@@ -113,6 +113,8 @@ We currently support the following OpenAI chat models:
 - `gpt-5-nano-2025-08-07`
 - `gpt-5-chat`
 - `gpt-5-chat-2025-08-07`
+- `gpt-5.4-mini`
+- `gpt-5.4-nano`
 - `gpt-4.1`
 - `gpt-4.1-2025-04-14`
 - `gpt-4.1-mini`


### PR DESCRIPTION
## Summary

- Adds `gpt-5.4-mini` and `gpt-5.4-nano` to the list of supported text models in the AI Generation extension documentation (`built-in-commands.mdx`).

## Test plan

- [x] Verify the new models appear in the [Supported text models](https://tiptap.dev/docs/content-ai/capabilities/generation/text-generation/built-in-commands#supported-text-models) section
- [x] Confirm the page renders correctly with no formatting issues