### PR TITLE
docs: document AI Caret events API

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/ai-caret.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/advanced-guides/ai-caret.mdx
@@ -94,3 +94,27 @@ AiCaret.configure({
   },
 })
 ```
+
+## Events
+
+The `AiCaret` extension emits events through the Tiptap events API. You can subscribe to them to react to the caret's movement — for example, to follow the AI's writing position with custom UI behavior.
+
+### Available events
+
+| Event                      | Description                                                                                    | Payload                |
+| -------------------------- | ---------------------------------------------------------------------------------------------- | ---------------------- |
+| `aiCaret:positionChanged`  | Fired whenever the AI caret position is updated during a streaming or edit operation.          | `{ position: number }` |
+
+The `position` value is a ProseMirror document position pointing to where the AI caret is currently placed.
+
+### Subscribing to events
+
+Use `editor.on` to listen for the event, and `editor.off` to unsubscribe when no longer needed.
+
+```tsx
+editor.on('aiCaret:positionChanged', ({ position }) => {
+  console.log('AI caret moved to position', position)
+})
+```
+
+The `aiCaret:positionChanged` event can fire frequently during streaming — once per streamed chunk. If your handler performs expensive work, consider throttling it with `requestAnimationFrame` or a utility like `lodash.throttle`.


### PR DESCRIPTION
## Summary

Adds an Events section to the AI Caret advanced guide documenting the `aiCaret:positionChanged` event, its payload, and how to subscribe via `editor.on` / `editor.off`. Includes a note about throttling handlers since the event fires frequently during streaming.

## Test plan

- [ ] Verify the new Events section renders correctly in the docs site