### PR TITLE
Remove incorrect suggestions guide reference from tracked changes section

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/tiptap-edit.mdx
@@ -278,9 +278,6 @@ toolkit.tiptapEditWorkflow({
   },
 })
 ```
-
-See the [Suggestions](/content-ai/capabilities/ai-toolkit/advanced-guides/suggestions) guide to learn more about suggestions.
-
 ## Related guides
 
 - [API reference](/content-ai/capabilities/ai-toolkit/api-reference/read-the-document#tiptapread) of the `tiptapRead` method


### PR DESCRIPTION
## Summary

The "Review changes as tracked changes" section of the Tiptap Edit workflow page contained a sentence linking to the Suggestions guide:

> See the Suggestions guide to learn more about suggestions.

This reference is incorrect in this context — tracked changes and suggestions are different concepts. The Suggestions guide link already exists in the "Related guides" section below, so removing this sentence avoids confusion without losing discoverability.