### PR TITLE
Update AI Toolkit changelog docs to v0.4.0

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 0.4.0
+
+### Patch Changes
+
+- Updated dependencies [a8ac0a0]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.4.0
+
 ## 0.3.10
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 0.4.0
+
+### Patch Changes
+
+- Updated dependencies [a8ac0a0]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.4.0
+
 ## 0.3.10
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 0.4.0
+
+### Patch Changes
+
+- Updated dependencies [a8ac0a0]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.4.0
+
 ## 0.3.10
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 0.4.0
+
+### Patch Changes
+
+- Updated dependencies [a8ac0a0]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.4.0
+
 ## 0.3.10
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 0.4.0
+
+### Patch Changes
+
+- a8ac0a0: Improve the tiptapReadSelection tool so that it uses less tokens and it does not cause the AI to mistake the selected content with the content of the nodes where the selection is located.
+
 ## 0.3.10
 
 ## 0.3.9

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 0.4.0
+
+### Minor Changes
+
+- b41d288: Add a new `aiCaret:positionChanged` event to the AI Caret extension. The event fires whenever the AI caret's position is updated during streaming or edit operations, with a payload of `{ position: number }` — a ProseMirror document position. Subscribe via `editor.on('aiCaret:positionChanged', handler)` to react to the AI's writing position, for example to implement auto-scrolling.
+
+### Patch Changes
+
+- a8ac0a0: Improve the tiptapReadSelection tool so that it uses less tokens and it does not cause the AI to mistake the selected content with the content of the nodes where the selection is located.
+- fd30961: When the AI wants to replace the entire document, prevent it from overwriting user's edits by comparing the current state of the document with the document state when the AI last read it.
+- 99f0fde: The hash function used to check that AI does not overwrite user changes is more efficient.
+
 ## 0.3.10
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,6 +8,8 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
+## 0.4.0
+
 ## 0.3.10
 
 ## 0.3.9


### PR DESCRIPTION
## Summary

- Added v0.4.0 changelog entries for 7 AI Toolkit packages: `ai-toolkit`, `ai-toolkit-ai-sdk`, `ai-toolkit-anthropic`, `ai-toolkit-openai`, `ai-toolkit-langchain`, `ai-toolkit-tool-definitions`, and `server-ai-toolkit`.
- Key changes documented include the new `aiCaret:positionChanged` event, improved `tiptapReadSelection` tool, document overwrite prevention, and a more efficient hash function.
- Provider packages (`ai-sdk`, `anthropic`, `openai`, `langchain`) updated their dependency on `ai-toolkit-tool-definitions@0.4.0`.

## Notes

A related PR updating the AI Toolkit package versions in `ai-toolkit-demos` will be linked once available.