### PR TITLE
fix: correct editorInstance typo in useEditorState selector example

### DIFF
--- a/.changeset/legal-llamas-ask.md
+++ b/.changeset/legal-llamas-ask.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Fixed editorInstance typo in useEditorState selector example

--- a/src/content/guides/performance.mdx
+++ b/src/content/guides/performance.mdx
@@ -107,8 +107,8 @@ function Component() {
     // This function will be called every time the editor state changes
     selector: ({ editor }: { editor: Editor }) => ({
       // It will only re-render if the bold or italic state changes
-      isBold: editorInstance.isActive('bold'),
-      isItalic: editorInstance.isActive('italic'),
+      isBold: editor.isActive('bold'),
+      isItalic: editor.isActive('italic'),
     }),
   })
 


### PR DESCRIPTION
Fixed a typo in the useEditorState selector example. The selector was referencing editorInstance which is undefined the correct variable is editor from the destructured parameter. This would throw a ReferenceError if copied directly from the docs.