### PR TITLE
feat: export pdf headers footers update

### DIFF
--- a/src/content/conversion/export/pdf/editor-export.mdx
+++ b/src/content/conversion/export/pdf/editor-export.mdx
@@ -90,25 +90,47 @@ const editor = new Editor({
 | `customFonts`    | `CustomFont[]`           | Custom font files to provision for PDF export (on-premises only) | `undefined`             |
 | `onCompleteExport` | `(result: Blob) => void` | Callback that receives the exported file as a Blob | Throws error if not provided |
 
+### Header and footer slot values
+
+Every header and footer slot (`default`, `first`, `even`) accepts any of five shapes — pick whichever matches your data. The first three work with `@tiptap-pro/extension-export-pdf` alone; the last two require `@tiptap-pro/extension-export-docx` to also be installed (they take the DOCX-first export path, which is lazy-loaded so PDF-only consumers aren't affected).
+
+| Shape                                       | Example                                     | Notes                                                                                          |
+| ------------------------------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Plain text                                  | `'Company name, 2026'`                      | Unstyled header/footer.                                                                        |
+| Stringified Tiptap JSONContent              | `JSON.stringify(myHeaderDoc)`               | Pre-serialized Tiptap node. Rich formatting preserved.                                         |
+| Tiptap JSONContent object                   | `{ type: 'doc', content: [/* … */] }`       | Rich Tiptap node passed directly — no stringification needed.                                  |
+| `docx` `Header` / `Footer` instance         | `new Docx.Header({ children: [/* … */] })`  | Full DOCX-level control. Requires the DOCX extension.                                          |
+| Async factory returning `Header` / `Footer` | `() => convertHeader({ node })`             | Built on demand at export time. Typical use: `convertHeader` / `convertFooter`. Requires the DOCX extension. |
+
+In TypeScript these shapes collapse to two aliases:
+
+```ts
+import type { JSONContent } from '@tiptap/core'
+import type { Footer, Header } from 'docx'
+
+type HeaderSlotValue = string | JSONContent | Header | (() => Promise<Header>)
+type FooterSlotValue = string | JSONContent | Footer | (() => Promise<Footer>)
+```
+
 ### HeaderConfig
 
-| Property            | Type      | Description                                                                                          |
-| ------------------- | --------- | ---------------------------------------------------------------------------------------------------- |
-| `evenAndOddHeaders` | `boolean` | Whether to use different headers for odd and even pages                                              |
-| `differentFirstPage` | `boolean` | Whether to use a different header on the first page. When `true`, the `first` value is used on page one instead of `default`. |
-| `default`           | `string`  | The standard default header on every page, or header on odd pages when `evenAndOddHeaders` is active. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
-| `first`             | `string`  | The header on the first page. Only used when `differentFirstPage` is set to `true`. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
-| `even`              | `string`  | The header on even pages when the `evenAndOddHeaders` option is activated. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
+| Property             | Type              | Description                                                                                          |
+| -------------------- | ----------------- | ---------------------------------------------------------------------------------------------------- |
+| `evenAndOddHeaders`  | `boolean`         | Whether to use different headers for odd and even pages.                                             |
+| `differentFirstPage` | `boolean`         | Whether to use a different header on the first page. When `true`, the `first` value is used on page one instead of `default`. |
+| `default`            | `HeaderSlotValue` | The standard default header on every page, or the header on odd pages when `evenAndOddHeaders` is active. |
+| `first`              | `HeaderSlotValue` | The header on the first page. Only used when `differentFirstPage` is `true`.                         |
+| `even`               | `HeaderSlotValue` | The header on even pages. Only used when `evenAndOddHeaders` is `true`.                              |
 
 ### FooterConfig
 
-| Property            | Type      | Description                                                                                          |
-| ------------------- | --------- | ---------------------------------------------------------------------------------------------------- |
-| `evenAndOddFooters` | `boolean` | Whether to use different footers for odd and even pages                                              |
-| `differentFirstPage` | `boolean` | Whether to use a different footer on the first page. When `true`, the `first` value is used on page one instead of `default`. |
-| `default`           | `string`  | The standard default footer on every page, or footer on odd pages when `evenAndOddFooters` is active. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
-| `first`             | `string`  | The footer on the first page. Only used when `differentFirstPage` is set to `true`. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
-| `even`              | `string`  | The footer on even pages when the `evenAndOddFooters` option is activated. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
+| Property             | Type              | Description                                                                                          |
+| -------------------- | ----------------- | ---------------------------------------------------------------------------------------------------- |
+| `evenAndOddFooters`  | `boolean`         | Whether to use different footers for odd and even pages.                                             |
+| `differentFirstPage` | `boolean`         | Whether to use a different footer on the first page. When `true`, the `first` value is used on page one instead of `default`. |
+| `default`            | `FooterSlotValue` | The standard default footer on every page, or the footer on odd pages when `evenAndOddFooters` is active. |
+| `first`              | `FooterSlotValue` | The footer on the first page. Only used when `differentFirstPage` is `true`.                         |
+| `even`               | `FooterSlotValue` | The footer on even pages. Only used when `evenAndOddFooters` is `true`.                              |
 
 ### PageSize
 

--- a/src/content/conversion/export/pdf/editor-export.mdx
+++ b/src/content/conversion/export/pdf/editor-export.mdx
@@ -89,6 +89,7 @@ const editor = new Editor({
 | `customNodes`    | `CustomNodeDefinition[]` | Custom node definitions for DOCX-based conversion (requires `@tiptap-pro/extension-export-docx`) | `undefined` |
 | `customFonts`    | `CustomFont[]`           | Custom font files to provision for PDF export (on-premises only) | `undefined`             |
 | `onCompleteExport` | `(result: Blob) => void` | Callback that receives the exported file as a Blob | Throws error if not provided |
+| `onExportError`  | `(error: Error) => void` | Optional callback invoked when the export pipeline rejects (failed dynamic import, failed DOCX conversion, network error, non-OK response). When omitted, errors are logged via `console.error`. | `undefined`          |
 
 ### Header and footer slot values
 
@@ -102,14 +103,18 @@ Every header and footer slot (`default`, `first`, `even`) accepts any of five sh
 | `docx` `Header` / `Footer` instance         | `new Docx.Header({ children: [/* … */] })`  | Full DOCX-level control. Requires the DOCX extension.                                          |
 | Async factory returning `Header` / `Footer` | `() => convertHeader({ node })`             | Built on demand at export time. Typical use: `convertHeader` / `convertFooter`. Requires the DOCX extension. |
 
-In TypeScript these shapes collapse to two aliases:
+Tiptap JSONContent objects **must** include a `type` field — that's the runtime discriminator the extension uses to tell a Tiptap node apart from a `docx` instance. Objects without `type` that aren't `Header` / `Footer` instances are dropped with a `console.warn` pointing at the offending value, not forwarded to the DOCX serializer.
+
+In TypeScript these shapes collapse to two aliases (the `type` requirement is encoded in `TiptapNodeContent`):
 
 ```ts
 import type { JSONContent } from '@tiptap/core'
 import type { Footer, Header } from 'docx'
 
-type HeaderSlotValue = string | JSONContent | Header | (() => Promise<Header>)
-type FooterSlotValue = string | JSONContent | Footer | (() => Promise<Footer>)
+type TiptapNodeContent = JSONContent & { type: string }
+
+type HeaderSlotValue = string | TiptapNodeContent | Header | (() => Promise<Header>)
+type FooterSlotValue = string | TiptapNodeContent | Footer | (() => Promise<Footer>)
 ```
 
 ### HeaderConfig
@@ -188,6 +193,7 @@ The `ExportPdfCommandOptions` interface extends `ExportPdfOptions`, so every con
 | `customNodes`      | `CustomNodeDefinition[]`  | Override custom node definitions for this specific export                               |
 | `customFonts`      | `CustomFont[]`            | Override custom fonts for this specific export (on-premises only)                      |
 | `onCompleteExport` | `(result: Blob) => void`  | Override the callback for this specific export                                         |
+| `onExportError`    | `(error: Error) => void`  | Override the error handler for this specific export                                    |
 
 ```js
 import { ExportPdf } from '@tiptap-pro/extension-export-pdf'

--- a/src/content/conversion/export/pdf/headers-footers.mdx
+++ b/src/content/conversion/export/pdf/headers-footers.mdx
@@ -39,14 +39,18 @@ Each header and footer slot (`default`, `first`, `even`) accepts one of the shap
 | `docx` `Header` / `Footer`       | `new Docx.Header({ children: [/* … */] })`       | Full DOCX-level control over paragraphs and runs. Requires `@tiptap-pro/extension-export-docx`.           |
 | Async factory returning `Header` / `Footer` | `() => convertHeader({ node })`       | Built on demand when the export runs. Typical use: `convertHeader` / `convertFooter` from the DOCX extension. |
 
-In TypeScript these collapse to two type aliases:
+Tiptap JSONContent objects **must** include a `type` field — the extension uses it at runtime to distinguish a Tiptap node from a `docx` instance. Objects without `type` that aren't `Header` / `Footer` instances are dropped with a `console.warn` naming the offending value; they're never forwarded to the DOCX serializer.
+
+In TypeScript these collapse to two aliases (the `type` requirement is encoded in `TiptapNodeContent`):
 
 ```ts
 import type { JSONContent } from '@tiptap/core'
 import type { Footer, Header } from 'docx'
 
-type HeaderSlotValue = string | JSONContent | Header | (() => Promise<Header>)
-type FooterSlotValue = string | JSONContent | Footer | (() => Promise<Footer>)
+type TiptapNodeContent = JSONContent & { type: string }
+
+type HeaderSlotValue = string | TiptapNodeContent | Header | (() => Promise<Header>)
+type FooterSlotValue = string | TiptapNodeContent | Footer | (() => Promise<Footer>)
 ```
 
 The first three shapes work on their own with `@tiptap-pro/extension-export-pdf`. The `Header` / `Footer` instance and async-factory shapes require `@tiptap-pro/extension-export-docx` to be installed — they take the DOCX-first export path, which is loaded on demand so PDF-only consumers aren't affected.

--- a/src/content/conversion/export/pdf/headers-footers.mdx
+++ b/src/content/conversion/export/pdf/headers-footers.mdx
@@ -27,33 +27,53 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
 The `@tiptap-pro/extension-export-pdf` extension includes built-in support for customizing the headers and footers of the exported document. You can configure different headers and footers for the first page, odd pages, and even pages.
 
+## Header and footer slot values
+
+Each header and footer slot (`default`, `first`, `even`) accepts one of the shapes below. Mix and match freely across slots — pick whichever matches your data.
+
+| Shape                            | Example                                          | Notes                                                                                                     |
+| -------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| Plain text                       | `'Company name, 2026'`                           | Rendered as an unstyled header/footer.                                                                    |
+| Stringified Tiptap JSONContent   | `JSON.stringify(myHeaderDoc)`                    | Pre-serialized Tiptap node. Rich formatting (bold, italic, links, etc.) is preserved on render.           |
+| Tiptap JSONContent object        | `{ type: 'doc', content: [/* … */] }`            | A Tiptap node passed directly. Same fidelity as stringified JSONContent, but no `JSON.stringify` step.    |
+| `docx` `Header` / `Footer`       | `new Docx.Header({ children: [/* … */] })`       | Full DOCX-level control over paragraphs and runs. Requires `@tiptap-pro/extension-export-docx`.           |
+| Async factory returning `Header` / `Footer` | `() => convertHeader({ node })`       | Built on demand when the export runs. Typical use: `convertHeader` / `convertFooter` from the DOCX extension. |
+
+In TypeScript these collapse to two type aliases:
+
+```ts
+import type { JSONContent } from '@tiptap/core'
+import type { Footer, Header } from 'docx'
+
+type HeaderSlotValue = string | JSONContent | Header | (() => Promise<Header>)
+type FooterSlotValue = string | JSONContent | Footer | (() => Promise<Footer>)
+```
+
+The first three shapes work on their own with `@tiptap-pro/extension-export-pdf`. The `Header` / `Footer` instance and async-factory shapes require `@tiptap-pro/extension-export-docx` to be installed — they take the DOCX-first export path, which is loaded on demand so PDF-only consumers aren't affected.
+
 ## Headers Configuration
 
-The `headers` object allows you to customize the headers of your exported PDF document:
+The `headers` object configures the running header. Each slot accepts a [header slot value](#header-and-footer-slot-values).
 
-| Property            | Type      | Description                                                                                          |
-| ------------------- | --------- | ---------------------------------------------------------------------------------------------------- |
-| `evenAndOddHeaders` | `boolean` | Whether to use different headers for odd and even pages                                              |
-| `differentFirstPage` | `boolean` | Whether to use a different header on the first page. When `true`, the `first` value is used on page one instead of `default`. |
-| `default`           | `string`  | The standard default header on every page, or header on odd pages when `evenAndOddHeaders` is active. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
-| `first`             | `string`  | The header on the first page. Only used when `differentFirstPage` is set to `true`. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
-| `even`              | `string`  | The header on even pages when the `evenAndOddHeaders` option is activated. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
-
-When using plain text, a simple unstyled header is produced. When using stringified Tiptap JSONContent (via `JSON.stringify()`), rich formatting such as bold, italic, and links is preserved.
+| Property             | Type              | Description                                                                                          |
+| -------------------- | ----------------- | ---------------------------------------------------------------------------------------------------- |
+| `evenAndOddHeaders`  | `boolean`         | Whether to use different headers for odd and even pages.                                             |
+| `differentFirstPage` | `boolean`         | Whether to use a different header on the first page. When `true`, the `first` value is used on page one instead of `default`. |
+| `default`            | `HeaderSlotValue` | The standard default header on every page, or the header on odd pages when `evenAndOddHeaders` is active. |
+| `first`              | `HeaderSlotValue` | The header on the first page. Only used when `differentFirstPage` is `true`.                         |
+| `even`               | `HeaderSlotValue` | The header on even pages. Only used when `evenAndOddHeaders` is `true`.                              |
 
 ## Footers Configuration
 
-The `footers` object allows you to customize the footers of your exported PDF document:
+The `footers` object mirrors `headers`. Each slot accepts a [footer slot value](#header-and-footer-slot-values).
 
-| Property            | Type      | Description                                                                                          |
-| ------------------- | --------- | ---------------------------------------------------------------------------------------------------- |
-| `evenAndOddFooters` | `boolean` | Whether to use different footers for odd and even pages                                              |
-| `differentFirstPage` | `boolean` | Whether to use a different footer on the first page. When `true`, the `first` value is used on page one instead of `default`. |
-| `default`           | `string`  | The standard default footer on every page, or footer on odd pages when `evenAndOddFooters` is active. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
-| `first`             | `string`  | The footer on the first page. Only used when `differentFirstPage` is set to `true`. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
-| `even`              | `string`  | The footer on even pages when the `evenAndOddFooters` option is activated. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
-
-When using plain text, a simple unstyled footer is produced. When using stringified Tiptap JSONContent (via `JSON.stringify()`), rich formatting such as bold, italic, and links is preserved.
+| Property             | Type              | Description                                                                                          |
+| -------------------- | ----------------- | ---------------------------------------------------------------------------------------------------- |
+| `evenAndOddFooters`  | `boolean`         | Whether to use different footers for odd and even pages.                                             |
+| `differentFirstPage` | `boolean`         | Whether to use a different footer on the first page. When `true`, the `first` value is used on page one instead of `default`. |
+| `default`            | `FooterSlotValue` | The standard default footer on every page, or the footer on odd pages when `evenAndOddFooters` is active. |
+| `first`              | `FooterSlotValue` | The footer on the first page. Only used when `differentFirstPage` is `true`.                         |
+| `even`               | `FooterSlotValue` | The footer on even pages. Only used when `evenAndOddFooters` is `true`.                              |
 
 ## Complete example
 
@@ -114,6 +134,64 @@ ExportPdf.configure({
   },
   footers: {
     default: 'Page Footer - Company Name',
+  },
+})
+```
+
+## Rich headers via Tiptap JSONContent
+
+Pass a Tiptap JSONContent node directly on any slot — useful when you already have the node in memory and don't want to build a `Docx.Header` by hand:
+
+```js
+ExportPdf.configure({
+  token: 'YOUR_TOKEN',
+  appId: 'YOUR_APP_ID',
+  headers: {
+    default: {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', marks: [{ type: 'bold' }], text: 'My Document' },
+            { type: 'text', text: ' — Confidential' },
+          ],
+        },
+      ],
+    },
+  },
+})
+```
+
+## Docx Header / Footer instances
+
+For full control over paragraph properties, alignment, and run styles you can pass a `docx` `Header` / `Footer` instance (or an async factory that returns one). This requires `@tiptap-pro/extension-export-docx` to be installed alongside the PDF extension:
+
+```ts
+import { Docx, convertHeader } from '@tiptap-pro/extension-export-docx'
+
+ExportPdf.configure({
+  token: 'YOUR_TOKEN',
+  appId: 'YOUR_APP_ID',
+  headers: {
+    // Direct Docx.Header instance
+    default: new Docx.Header({
+      children: [
+        new Docx.Paragraph({
+          children: [new Docx.TextRun({ text: 'My Document' })],
+        }),
+      ],
+    }),
+    // Async factory — convert a Tiptap node to a Docx.Header on demand
+    first: () =>
+      convertHeader({
+        node: {
+          type: 'doc',
+          content: [
+            { type: 'paragraph', content: [{ type: 'text', text: 'Welcome' }] },
+          ],
+        },
+      }),
   },
 })
 ```

--- a/src/content/conversion/export/pdf/rest-api.mdx
+++ b/src/content/conversion/export/pdf/rest-api.mdx
@@ -98,35 +98,62 @@ The `pageMargins` object allows you to customize the margins of your exported PD
 
 #### Headers Configuration
 
-The `headers` object allows you to customize the headers of your exported PDF document:
+The `headers` object allows you to customize the headers of your exported PDF document. Each slot (`default`, `first`, `even`) accepts any of: a plain text string, a stringified Tiptap JSONContent, or a Tiptap JSONContent object sent directly in the JSON body.
 
-| Property            | Type      | Description                                                                                                          |
-| ------------------- | --------- | -------------------------------------------------------------------------------------------------------------------- |
-| `evenAndOddHeaders` | `boolean` | Whether to use different headers for odd and even pages                                                              |
-| `differentFirstPage` | `boolean` | Whether to use a different header on the first page. When `true`, the `first` value is used on page one instead of `default`. |
-| `default`           | `string`  | The standard default header on every page, or header on odd pages when `evenAndOddHeaders` is activated. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
-| `first`             | `string`  | The header on the first page. Only used when `differentFirstPage` is set to `true`. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
-| `even`              | `string`  | The header on even pages when the `evenAndOddHeaders` option is activated. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
+| Property            | Type                  | Description                                                                                                          |
+| ------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `evenAndOddHeaders` | `boolean`             | Whether to use different headers for odd and even pages                                                              |
+| `differentFirstPage` | `boolean`             | Whether to use a different header on the first page. When `true`, the `first` value is used on page one instead of `default`. |
+| `default`           | `string \| Object`    | The standard default header on every page, or header on odd pages when `evenAndOddHeaders` is activated. Accepts plain text, stringified Tiptap JSONContent, or a Tiptap JSONContent object. |
+| `first`             | `string \| Object`    | The header on the first page. Only used when `differentFirstPage` is set to `true`. Accepts plain text, stringified Tiptap JSONContent, or a Tiptap JSONContent object. |
+| `even`              | `string \| Object`    | The header on even pages when the `evenAndOddHeaders` option is activated. Accepts plain text, stringified Tiptap JSONContent, or a Tiptap JSONContent object. |
 
-<Callout title="Plain text vs. Tiptap JSONContent">
-    Each header value can be either a **plain text string** (produces a simple unstyled header) or a **stringified Tiptap JSONContent** object (enables rich formatting such as bold, italic, links, etc.). When passing JSONContent, stringify the object with `JSON.stringify()` before sending it in the request body.
+<Callout title="Accepted slot values">
+    Each header value may be one of three shapes:
+    - A **plain text string** — produces a simple unstyled header.
+    - A **stringified Tiptap JSONContent** — enables rich formatting (bold, italic, links, etc.). Produce it with `JSON.stringify(yourHeaderDoc)`.
+    - A **Tiptap JSONContent object** — the same rich content, sent as a nested JSON object inside the request body (no stringification needed).
+
+    Objects are validated at the slot level and must include a `type` field. Invalid shapes return `400 Bad Request`.
 </Callout>
 
 #### Footers Configuration
 
-The `footers` object allows you to customize the footers of your exported PDF document:
+The `footers` object allows you to customize the footers of your exported PDF document. Slots accept the same three shapes as headers.
 
-| Property            | Type      | Description                                                                                                          |
-| ------------------- | --------- | -------------------------------------------------------------------------------------------------------------------- |
-| `evenAndOddFooters` | `boolean` | Whether to use different footers for odd and even pages                                                              |
-| `differentFirstPage` | `boolean` | Whether to use a different footer on the first page. When `true`, the `first` value is used on page one instead of `default`. |
-| `default`           | `string`  | The standard default footer on every page, or footer on odd pages when `evenAndOddFooters` is activated. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
-| `first`             | `string`  | The footer on the first page. Only used when `differentFirstPage` is set to `true`. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
-| `even`              | `string`  | The footer on even pages when the `evenAndOddFooters` option is activated. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
+| Property            | Type                  | Description                                                                                                          |
+| ------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `evenAndOddFooters` | `boolean`             | Whether to use different footers for odd and even pages                                                              |
+| `differentFirstPage` | `boolean`             | Whether to use a different footer on the first page. When `true`, the `first` value is used on page one instead of `default`. |
+| `default`           | `string \| Object`    | The standard default footer on every page, or footer on odd pages when `evenAndOddFooters` is activated. Accepts plain text, stringified Tiptap JSONContent, or a Tiptap JSONContent object. |
+| `first`             | `string \| Object`    | The footer on the first page. Only used when `differentFirstPage` is set to `true`. Accepts plain text, stringified Tiptap JSONContent, or a Tiptap JSONContent object. |
+| `even`              | `string \| Object`    | The footer on even pages when the `evenAndOddFooters` option is activated. Accepts plain text, stringified Tiptap JSONContent, or a Tiptap JSONContent object. |
 
-<Callout title="Plain text vs. Tiptap JSONContent">
-    Each footer value can be either a **plain text string** (produces a simple unstyled footer) or a **stringified Tiptap JSONContent** object (enables rich formatting such as bold, italic, links, etc.). When passing JSONContent, stringify the object with `JSON.stringify()` before sending it in the request body.
-</Callout>
+### Example with headers and footers
+
+```bash
+curl --output document.pdf -X POST "https://api.tiptap.dev/v2/convert/export/pdf" \
+    -H "Authorization: Bearer YOUR_TOKEN" \
+    -H "X-App-Id: YOUR_APP_ID" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "doc": "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Hello World\"}]}]}",
+      "headers": {
+        "default": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "My Header" }]
+            }
+          ]
+        }
+      },
+      "footers": {
+        "default": "Company name, 2026"
+      }
+    }'
+```
 
 #### Custom Fonts Configuration
 
@@ -194,6 +221,7 @@ On success the API returns the PDF file as a binary download:
 | Status | Code                            | Description                          |
 | ------ | ------------------------------- | ------------------------------------ |
 | 400    | `NO_DOCUMENT_PROVIDED`          | No document was provided in the body |
+| 400    | _(validation)_                  | A `headers` / `footers` slot contains an object without a `type` field, or another schema-level problem. The response body includes a ZodError describing which field failed. |
 | 422    | `FAILED_TO_PARSE_DOCX_FILE`    | Failed to parse JSON inputs          |
 | 422    | `FAILED_TO_EXPORT_PDF_FILE`    | Failed to export intermediate format |
 | 403    | `CUSTOM_FONTS_NOT_AVAILABLE`   | Custom fonts are only available in on-premises deployments |


### PR DESCRIPTION
This pull request updates and clarifies the documentation for configuring headers and footers in PDF export, both for the JavaScript API and the REST API. The main focus is to document the expanded set of accepted shapes for header and footer slots, including plain text, Tiptap JSONContent (as string or object), and—when the DOCX extension is installed—`docx` `Header`/`Footer` instances or async factories. The changes also add practical examples and detail validation rules and error responses.

**Documentation improvements for header/footer configuration:**

* Expanded documentation for header and footer slot values, explaining all accepted shapes (plain text, stringified Tiptap JSONContent, JSONContent object, `docx` `Header`/`Footer` instance, and async factory), and provided TypeScript type aliases for `HeaderSlotValue` and `FooterSlotValue`. [[1]](diffhunk://#diff-ddf26dd02fa6268093f0f66b1fd3dbd41727c4eaa81e251d3d790603785c0b5eR93-R133) [[2]](diffhunk://#diff-472fbcd0b5d4970efaf0ac8ebef5a4bdf852e91142de04017cf428ae447e1372R30-R76)
* Updated configuration tables for both headers and footers to use the new type aliases and clarified descriptions, replacing previous string-only descriptions. [[1]](diffhunk://#diff-ddf26dd02fa6268093f0f66b1fd3dbd41727c4eaa81e251d3d790603785c0b5eR93-R133) [[2]](diffhunk://#diff-472fbcd0b5d4970efaf0ac8ebef5a4bdf852e91142de04017cf428ae447e1372R30-R76)

**Examples and usage guidance:**

* Added detailed code examples for using Tiptap JSONContent objects and `docx` `Header`/`Footer` instances (including async factories) in header slots, showing both JavaScript and TypeScript usage.
* Improved REST API documentation to clarify that header/footer slots accept plain text, stringified Tiptap JSONContent, or JSONContent objects, and added a full example `curl` request using these shapes.

**Validation and error handling:**

* Documented validation rules for header/footer slot objects (must include a `type` field) and described the new `400` error response for invalid slot values, with details about the ZodError in the response body. [[1]](diffhunk://#diff-084d546a4becaf2fc5e2f0787832c9dc63997be19c9335c5a7ed2ebae8fcaad9L101-R156) [[2]](diffhunk://#diff-084d546a4becaf2fc5e2f0787832c9dc63997be19c9335c5a7ed2ebae8fcaad9R224)