### PR TITLE
docs(pages): Document header/footer editor event hooks

### DIFF
--- a/.changeset/mighty-moons-lay.md
+++ b/.changeset/mighty-moons-lay.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Expose header and footer inner editor event subscription helpers through pages storage. This helpers allow consumers to subscribe and unsubscribe from header/footer overlay editor events

--- a/.changeset/mighty-moons-lay.md
+++ b/.changeset/mighty-moons-lay.md
@@ -2,4 +2,4 @@
 'tiptap-docs': patch
 ---
 
-Expose header and footer inner editor event subscription helpers through pages storage. This helpers allow consumers to subscribe and unsubscribe from header/footer overlay editor events
+Expose header and footer inner editor event subscription helpers through pages storage. These helpers allow consumers to subscribe and unsubscribe from header/footer overlay editor events.

--- a/src/content/pages/core-concepts/options.mdx
+++ b/src/content/pages/core-concepts/options.mdx
@@ -175,7 +175,7 @@ When a header or footer editor overlay is open, the Pages extension exposes the 
 | `footerEditorOn`   | `Editor['on'] \| null`         | Bound event subscription helper for the footer inner editor            |
 | `footerEditorOff`  | `Editor['off'] \| null`        | Bound event unsubscribe helper for the footer inner editor             |
 
-The `headerEditorOn`/`headerEditorOff` and `footerEditorOn`/`footerEditorOff` helpers subscribe to the singleton inner Tiptap editors used by the header and footer overlays. The extension uses their `focus` events internally to keep `activeEditor`, `activeEditorType`, and `activePageNumber` in sync when an overlay editor regains focus.
+The `headerEditorOn` / `headerEditorOff` and `footerEditorOn` / `footerEditorOff` helpers let you subscribe to events from the header and footer editors. These are useful for reacting to events like focus, selection updates, or content changes.
 
 ```tsx
 useEffect(() => {

--- a/src/content/pages/core-concepts/options.mdx
+++ b/src/content/pages/core-concepts/options.mdx
@@ -176,6 +176,10 @@ editor.commands.setPageFormat({
 })
 ```
 
+<Callout title="Note">
+  The <code>header</code> and <code>footer</code> options accept either a string (with tokens <code>\{page\}</code> and <code>\{total\}</code>) or a function <code>(page, total) =&gt; string</code> for dynamic content.
+</Callout>
+
 ## Header and footer editor storage
 
 When a header or footer editor overlay is open, the Pages extension exposes the active inner editor through `editor.storage.pages`. This is useful for custom toolbars, status UI, and listening to editor events inside the header or footer overlay.

--- a/src/content/pages/core-concepts/options.mdx
+++ b/src/content/pages/core-concepts/options.mdx
@@ -161,6 +161,21 @@ The Pages extension provides the following commands:
 | `setPageFormat` | `pageFormat: PageFormat` | Changes the page format programmatically                                       |
 | `setZoom`       | `zoom: number`           | Sets the zoom level (clamped to 0.25–4). See [Zoom](/pages/core-concepts/zoom) |
 
+### Command usage
+
+```js
+// Change to built-in format
+editor.commands.setPageFormat('Letter')
+
+// Change to custom format
+editor.commands.setPageFormat({
+  id: 'wide-page-format',
+  width: 1000, // px
+  height: 700, // px
+  margins: { top: 20, right: 20, bottom: 20, left: 20 } // px
+})
+```
+
 ## Header and footer editor storage
 
 When a header or footer editor overlay is open, the Pages extension exposes the active inner editor through `editor.storage.pages`. This is useful for custom toolbars, status UI, and listening to editor events inside the header or footer overlay.
@@ -197,22 +212,3 @@ useEffect(() => {
 ```
 
 See [Page header and footer](/pages/core-concepts/page-header-footer#active-editor-state) for a complete toolbar example.
-
-### Command usage
-
-```js
-// Change to built-in format
-editor.commands.setPageFormat('Letter')
-
-// Change to custom format
-editor.commands.setPageFormat({
-  id: 'wide-page-format',
-  width: 1000, // px
-  height: 700, // px
-  margins: { top: 20, right: 20, bottom: 20, left: 20 } // px
-})
-```
-
-<Callout title="Note">
-  The <code>header</code> and <code>footer</code> options accept either a string (with tokens <code>\{page\}</code> and <code>\{total\}</code>) or a function <code>(page, total) =&gt; string</code> for dynamic content.
-</Callout>

--- a/src/content/pages/core-concepts/options.mdx
+++ b/src/content/pages/core-concepts/options.mdx
@@ -87,18 +87,18 @@ interface PageFormat {
 }
 ```
 
-| Option                | Type / Values                | Default   | Description                                                                                 |
-|-----------------------|------------------------------|-----------|---------------------------------------------------------------------------------------------|
-| `pageFormat`          | `string \| PageFormat`       | `'A4'`    | Built-in format name or custom page format object                                           |
-| `headerHeight`        | `number` (px)                | `50`      | Header height in pixels                                                                     |
-| `footerHeight`        | `number` (px)                | `50`      | Footer height in pixels                                                                     |
-| `pageGap`             | `number` (px)                | `50`      | Gap between pages in pixels                                                                 |
-| `header`              | `string \| fn`               | `''`      | Header content; string (supports `{page}`/`{total}`) or (pageNumber, totalPages) => string |
-| `footer`              | `string \| fn`               | `'{page}'`| Footer content; string (supports `{page}`/`{total}`) or (pageNumber, totalPages) => string |
-| `pageGapBackground` | `string` (CSS color)         | `undefined` | Background color for page gaps                                                          |
-| `onPageFormatChange`  | `fn`                         | `() => {}` | Callback when page format changes; receives new PageFormat                               |
-| `zoom`                | `number`                     | `1`        | Initial zoom level (0.25–4). See [Zoom](/pages/core-concepts/zoom)                      |
-| `onZoomChange`        | `fn`                         | `undefined`| Callback when zoom changes; receives new zoom level                                      |
+| Option               | Type / Values          | Default     | Description                                                                                |
+| -------------------- | ---------------------- | ----------- | ------------------------------------------------------------------------------------------ |
+| `pageFormat`         | `string \| PageFormat` | `'A4'`      | Built-in format name or custom page format object                                          |
+| `headerHeight`       | `number` (px)          | `50`        | Header height in pixels                                                                    |
+| `footerHeight`       | `number` (px)          | `50`        | Footer height in pixels                                                                    |
+| `pageGap`            | `number` (px)          | `50`        | Gap between pages in pixels                                                                |
+| `header`             | `string \| fn`         | `''`        | Header content; string (supports `{page}`/`{total}`) or (pageNumber, totalPages) => string |
+| `footer`             | `string \| fn`         | `'{page}'`  | Footer content; string (supports `{page}`/`{total}`) or (pageNumber, totalPages) => string |
+| `pageGapBackground`  | `string` (CSS color)   | `undefined` | Background color for page gaps                                                             |
+| `onPageFormatChange` | `fn`                   | `() => {}`  | Callback when page format changes; receives new PageFormat                                 |
+| `zoom`               | `number`               | `1`         | Initial zoom level (0.25–4). See [Zoom](/pages/core-concepts/zoom)                         |
+| `onZoomChange`       | `fn`                   | `undefined` | Callback when zoom changes; receives new zoom level                                        |
 
 ## Example usage
 
@@ -156,10 +156,47 @@ const editor = new Editor({
 
 The Pages extension provides the following commands:
 
-| Command          | Parameters               | Description                                    |
-|------------------|--------------------------|------------------------------------------------|
-| `setPageFormat`  | `pageFormat: PageFormat` | Changes the page format programmatically      |
-| `setZoom`        | `zoom: number`           | Sets the zoom level (clamped to 0.25–4). See [Zoom](/pages/core-concepts/zoom) |
+| Command         | Parameters               | Description                                                                    |
+| --------------- | ------------------------ | ------------------------------------------------------------------------------ |
+| `setPageFormat` | `pageFormat: PageFormat` | Changes the page format programmatically                                       |
+| `setZoom`       | `zoom: number`           | Sets the zoom level (clamped to 0.25–4). See [Zoom](/pages/core-concepts/zoom) |
+
+## Header and footer editor storage
+
+When a header or footer editor overlay is open, the Pages extension exposes the active inner editor through `editor.storage.pages`. This is useful for custom toolbars, status UI, and listening to editor events inside the header or footer overlay.
+
+| Storage property   | Type                           | Description                                                            |
+| ------------------ | ------------------------------ | ---------------------------------------------------------------------- |
+| `activeEditor`     | `Editor \| null`               | Active header/footer inner editor, or `null` when no overlay is active |
+| `activeEditorType` | `'header' \| 'footer' \| null` | Whether the active inner editor belongs to a header or footer          |
+| `activePageNumber` | `number \| null`               | Page number for the active header/footer editor                        |
+| `headerEditorOn`   | `Editor['on'] \| null`         | Bound event subscription helper for the header inner editor            |
+| `headerEditorOff`  | `Editor['off'] \| null`        | Bound event unsubscribe helper for the header inner editor             |
+| `footerEditorOn`   | `Editor['on'] \| null`         | Bound event subscription helper for the footer inner editor            |
+| `footerEditorOff`  | `Editor['off'] \| null`        | Bound event unsubscribe helper for the footer inner editor             |
+
+The `headerEditorOn`/`headerEditorOff` and `footerEditorOn`/`footerEditorOff` helpers subscribe to the singleton inner Tiptap editors used by the header and footer overlays. The extension uses their `focus` events internally to keep `activeEditor`, `activeEditorType`, and `activePageNumber` in sync when an overlay editor regains focus.
+
+```tsx
+useEffect(() => {
+  if (!editor) return
+
+  const handleFocus = () => {
+    const { activeEditorType, activePageNumber } = editor.storage.pages
+    console.log('Editing', activeEditorType, activePageNumber)
+  }
+
+  editor.storage.pages.headerEditorOn?.('focus', handleFocus)
+  editor.storage.pages.footerEditorOn?.('focus', handleFocus)
+
+  return () => {
+    editor.storage.pages.headerEditorOff?.('focus', handleFocus)
+    editor.storage.pages.footerEditorOff?.('focus', handleFocus)
+  }
+}, [editor])
+```
+
+See [Page header and footer](/pages/core-concepts/page-header-footer#active-editor-state) for a complete toolbar example.
 
 ### Command usage
 

--- a/src/content/pages/core-concepts/page-header-footer.mdx
+++ b/src/content/pages/core-concepts/page-header-footer.mdx
@@ -324,18 +324,18 @@ function HeaderFooterStatus({ editor }) {
   useEffect(() => {
     if (!editor) return
 
-    const syncActiveEditor = () => {
+    const syncActiveEditorState = () => {
       const { activeEditorType, activePageNumber } = editor.storage.pages
       setActiveEditorType(activeEditorType)
       setActivePageNumber(activePageNumber)
     }
 
-    editor.storage.pages.headerEditorOn?.('focus', syncActiveEditor)
-    editor.storage.pages.footerEditorOn?.('focus', syncActiveEditor)
+    editor.storage.pages.headerEditorOn?.('focus', syncActiveEditorState)
+    editor.storage.pages.footerEditorOn?.('focus', syncActiveEditorState)
 
     return () => {
-      editor.storage.pages.headerEditorOff?.('focus', syncActiveEditor)
-      editor.storage.pages.footerEditorOff?.('focus', syncActiveEditor)
+      editor.storage.pages.headerEditorOff?.('focus', syncActiveEditorState)
+      editor.storage.pages.footerEditorOff?.('focus', syncActiveEditorState)
     }
   }, [editor])
 

--- a/src/content/pages/core-concepts/page-header-footer.mdx
+++ b/src/content/pages/core-concepts/page-header-footer.mdx
@@ -310,9 +310,9 @@ When a user double-clicks a header or footer to edit it, the extension exposes t
 
 The extension also listens to `focus` events from the header and footer inner editors. When the user focuses an open header or footer editor, `activeEditor`, `activeEditorType`, and `activePageNumber` are refreshed from the active overlay.
 
-### Listening to inner editor events
+### Listening to header/footer editor events
 
-Headers and footers use separate singleton Tiptap editor instances. You can subscribe to those inner editors through storage and clean up with the matching `off` helper:
+Headers and footers have their own editors. You can subscribe to events from these editors via `editor.storage.pages`.
 
 ```tsx
 import { useEffect, useState } from 'react'

--- a/src/content/pages/core-concepts/page-header-footer.mdx
+++ b/src/content/pages/core-concepts/page-header-footer.mdx
@@ -305,6 +305,53 @@ When a user double-clicks a header or footer to edit it, the extension exposes t
 - `activeEditor` – The Tiptap Editor instance for the currently open header or footer editor (or `null`)
 - `activeEditorType` – `'header'`, `'footer'`, or `null`
 - `activePageNumber` – The page number being edited (or `null`)
+- `headerEditorOn` / `headerEditorOff` – Subscribe/unsubscribe to events on the header overlay's inner Tiptap editor
+- `footerEditorOn` / `footerEditorOff` – Subscribe/unsubscribe to events on the footer overlay's inner Tiptap editor
+
+The extension also listens to `focus` events from the header and footer inner editors. When the user focuses an open header or footer editor, `activeEditor`, `activeEditorType`, and `activePageNumber` are refreshed from the active overlay.
+
+### Listening to inner editor events
+
+Headers and footers use separate singleton Tiptap editor instances. You can subscribe to those inner editors through storage and clean up with the matching `off` helper:
+
+```tsx
+import { useEffect, useState } from 'react'
+
+function HeaderFooterStatus({ editor }) {
+  const [activeEditorType, setActiveEditorType] = useState(null)
+  const [activePageNumber, setActivePageNumber] = useState(null)
+
+  useEffect(() => {
+    if (!editor) return
+
+    const syncActiveEditor = () => {
+      const { activeEditorType, activePageNumber } = editor.storage.pages
+      setActiveEditorType(activeEditorType)
+      setActivePageNumber(activePageNumber)
+    }
+
+    editor.storage.pages.headerEditorOn?.('focus', syncActiveEditor)
+    editor.storage.pages.footerEditorOn?.('focus', syncActiveEditor)
+
+    return () => {
+      editor.storage.pages.headerEditorOff?.('focus', syncActiveEditor)
+      editor.storage.pages.footerEditorOff?.('focus', syncActiveEditor)
+    }
+  }, [editor])
+
+  if (!activeEditorType || !activePageNumber) {
+    return <span>Editing document</span>
+  }
+
+  return (
+    <span>
+      Editing {activeEditorType} on page {activePageNumber}
+    </span>
+  )
+}
+```
+
+You can use the same helpers for other Tiptap editor events, such as `update`, `selectionUpdate`, `blur`, or `transaction`.
 
 ### Building a custom toolbar
 
@@ -317,6 +364,7 @@ import { useEffect, useState } from 'react'
 function DocumentEditor() {
   const [headerFooterEditor, setHeaderFooterEditor] = useState(null)
   const [activeEditorType, setActiveEditorType] = useState(null)
+  const [activePageNumber, setActivePageNumber] = useState(null)
 
   const editor = useEditor({
     extensions: [
@@ -332,14 +380,22 @@ function DocumentEditor() {
   useEffect(() => {
     if (!editor) return
 
-    const handleUpdate = () => {
-      const { activeEditor, activeEditorType } = editor.storage.pages
+    const syncActiveHeaderFooterEditor = () => {
+      const { activeEditor, activeEditorType, activePageNumber } = editor.storage.pages
       setHeaderFooterEditor(activeEditor)
       setActiveEditorType(activeEditorType)
+      setActivePageNumber(activePageNumber)
     }
 
-    editor.on('update', handleUpdate)
-    return () => editor.off('update', handleUpdate)
+    editor.on('update', syncActiveHeaderFooterEditor)
+    editor.storage.pages.headerEditorOn?.('focus', syncActiveHeaderFooterEditor)
+    editor.storage.pages.footerEditorOn?.('focus', syncActiveHeaderFooterEditor)
+
+    return () => {
+      editor.off('update', syncActiveHeaderFooterEditor)
+      editor.storage.pages.headerEditorOff?.('focus', syncActiveHeaderFooterEditor)
+      editor.storage.pages.footerEditorOff?.('focus', syncActiveHeaderFooterEditor)
+    }
   }, [editor])
 
   // Use the active editor (header/footer or main)
@@ -355,7 +411,12 @@ function DocumentEditor() {
   return (
     <div>
       <div className="toolbar">
-        <span>Editing: {activeEditorType || 'Document'}</span>
+        <span>
+          Editing:{' '}
+          {activeEditorType && activePageNumber
+            ? `${activeEditorType} on page ${activePageNumber}`
+            : 'Document'}
+        </span>
         <button
           className={isBoldActive ? 'is-active' : ''}
           onClick={() => activeEditor?.chain().focus().toggleBold().run()}


### PR DESCRIPTION
- Documented the new `headerEditorOn` / `headerEditorOff` storage helpers.
- Documented the new `footerEditorOn` / `footerEditorOff` storage helpers.
- Updated header/footer active editor examples to sync `activeEditor`, `activeEditorType`, and `activePageNumber` from inner editor focus events.
- Added API reference coverage for the header/footer inner editor storage surface.