### PR TITLE
docs: add Safari clipboard limitation to paste handler

### DIFF
--- a/src/content/editor/extensions/functionality/paste-handler.mdx
+++ b/src/content/editor/extensions/functionality/paste-handler.mdx
@@ -76,3 +76,11 @@ The extension applies a series of transformations to pasted HTML, executed in a 
   ensure paste functionality is never broken.
 </Callout>
 
+## Known limitations
+
+### Safari clipboard strips table cell styling
+
+When copying table cells from SharePoint Excel (or similar sources) in Safari and pasting into the editor, in-cell formatting like bold, italic, colors, and links is lost. Safari writes a stripped-down HTML payload to the clipboard that contains only the table structure and cell text — the styling information is removed before it reaches the editor.
+
+This is a WebKit-level behavior and cannot be recovered by the paste handler. The same result occurs when pasting into other editors in Safari (e.g. SharePoint Word). Copies made from Chromium-based browsers or Firefox are not affected.
+


### PR DESCRIPTION
## Summary

Documents a known WebKit-level limitation in the paste handler extension: when copying table cells from SharePoint Excel (or similar sources) in Safari, in-cell styling (bold, italic, colors, links) is stripped by Safari before reaching the editor. Notes that this is not recoverable by the paste handler and does not affect Chromium or Firefox.

## Test plan
- [ ] Verify the new "Known limitations" section renders correctly on the paste-handler docs page