### PR TITLE
docs: document selectedOnTextSelection node view option

### DIFF
--- a/src/content/editor/extensions/custom-extensions/node-views/react.mdx
+++ b/src/content/editor/extensions/custom-extensions/node-views/react.mdx
@@ -130,6 +130,16 @@ export default Node.create({
 })
 ```
 
+## Updating `selected` on a text selection
+
+By default, the `selected` prop only becomes `true` when the node itself is selected with a `NodeSelection`. That works great for atom nodes, but it does not fire when the cursor is simply placed inside a node that has text content. If you want `selected` to also reflect that case, enable the `selectedOnTextSelection` option on the `ReactNodeViewRenderer`:
+
+```js
+return ReactNodeViewRenderer(Component, { selectedOnTextSelection: true })
+```
+
+With this option turned on, `selected` will also be `true` whenever a `TextSelection` is fully contained within the node’s range — for example, when the cursor is placed somewhere inside the node’s content. Selections that only partially overlap the node are not considered selected.
+
 ## All available props
 
 Here is the full list of what props you can expect:
@@ -139,7 +149,7 @@ Here is the full list of what props you can expect:
 | editor             | The editor instance                                             |
 | node               | The current node                                                |
 | decorations        | An array of decorations                                         |
-| selected           | `true` when there is a `NodeSelection` at the current node view |
+| selected           | `true` when there is a `NodeSelection` at the current node view. Also `true` on a `TextSelection` fully inside the node when [`selectedOnTextSelection`](#updating-selected-on-a-text-selection) is enabled. |
 | extension          | Access to the node extension, for example to get options        |
 | getPos()           | Get the document position of the current node                   |
 | updateAttributes() | Update attributes of the current node                           |

--- a/src/content/editor/extensions/custom-extensions/node-views/vue.mdx
+++ b/src/content/editor/extensions/custom-extensions/node-views/vue.mdx
@@ -123,6 +123,16 @@ Keep in mind that this content is rendered by Tiptap. That means you need to tel
 
 The `NodeViewWrapper` and `NodeViewContent` components render a `<div>` HTML tag (`<span>` for inline nodes), but you can change that. For example `<node-view-content as="p">` should render a paragraph. One limitation though: That tag must not change during runtime.
 
+## Updating `selected` on a text selection
+
+By default, the `selected` prop only becomes `true` when the node itself is selected with a `NodeSelection`. That works great for atom nodes, but it does not fire when the cursor is simply placed inside a node that has text content. If you want `selected` to also reflect that case, enable the `selectedOnTextSelection` option on the `VueNodeViewRenderer`:
+
+```js
+return VueNodeViewRenderer(Component, { selectedOnTextSelection: true })
+```
+
+With this option turned on, `selected` will also be `true` whenever a `TextSelection` is fully contained within the node’s range — for example, when the cursor is placed somewhere inside the node’s content. Selections that only partially overlap the node are not considered selected.
+
 ## All available props
 
 For advanced use cases, we pass a few more props to the component.
@@ -141,7 +151,7 @@ An array of decorations.
 
 ### selected
 
-`true` when there is a `NodeSelection` at the current node view.
+`true` when there is a `NodeSelection` at the current node view. Also `true` on a `TextSelection` fully inside the node when the [`selectedOnTextSelection`](#updating-selected-on-a-text-selection) option is enabled.
 
 ### extension
 
@@ -190,7 +200,9 @@ Here is the full list of what props you can expect:
         type: Array,
       },
 
-      // `true` when there is a `NodeSelection` at the current node view
+      // `true` when there is a `NodeSelection` at the current node view, or
+      // when the `selectedOnTextSelection` option is enabled and a `TextSelection`
+      // is fully inside the node
       selected: {
         type: Boolean,
       },


### PR DESCRIPTION
## Summary
Documents the new `selectedOnTextSelection` option for `ReactNodeViewRenderer` and `VueNodeViewRenderer`, which makes the `selected` prop also `true` when a `TextSelection` is fully contained within the node's range. Updates both the React and Vue node view guides with a dedicated section, a usage snippet, and clarifies the `selected` prop description in the props tables.

## Test plan
- [ ] Verify the new section renders correctly on the docs site for both React and Vue pages
- [ ] Confirm the in-page anchor link `#updating-selected-on-a-text-selection` resolves