### PR TITLE
fix: via.placeholder.com shut down in 2024 (now connection-refused)

### DIFF
--- a/src/content/ui-components/primitives/avatar.mdx
+++ b/src/content/ui-components/primitives/avatar.mdx
@@ -37,7 +37,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/tiptap-ui-prim
 export default function MyComponent() {
   return (
     <Avatar>
-      <AvatarImage src="https://via.placeholder.com/150" alt="User avatar" />
+      <AvatarImage src="https://placehold.co/150" alt="User avatar" />
       <AvatarFallback>JD</AvatarFallback>
     </Avatar>
   )


### PR DESCRIPTION
`src/content/ui-components/primitives/avatar.mdx` references `via.placeholder.com/*`. The service was shut down in 2024 and the DNS record no longer resolves.

---

#### Why this is needed

`via.placeholder.com` was shut down in 2024 and its DNS record no longer resolves — every request now hangs or returns a connection error. Any example that references it renders a broken-image icon (and any code that depends on a 200 from it silently breaks).

Verify in any shell:

```
curl -sI --max-time 3 https://via.placeholder.com/300x200 || echo "connection refused / DNS gone"
```

#### What this PR changes

Fixes the Avatar primitive's example `<AvatarImage>` src in the Tiptap UI components docs so the avatar primitive renders an image on the docsite and on anyone's local preview.

#### Replacement details

Docs-only. `placehold.co/150` is the canonical drop-in. Tiptap is one of the most-used rich-text editors; their UI components docs is a frequent landing page for library discovery.

#### Background

I'm tracking dead image-placeholder endpoints (`source.unsplash.com/*`, `via.placeholder.com/*`, `placekitten.com/*`) across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg is **not** a dependency of this PR — the diff uses the dependency-free canonical replacement (`placehold.co`, which accepts the same path shape as `via.placeholder.com`). If you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights dead-placeholder patterns in any landing page — useful for verifying the fix lands and for finding other places dead URLs slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.
