### PR TITLE
Add useDiffUtility field to ReviewOptions API reference

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/review-options.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/review-options.mdx
@@ -34,6 +34,7 @@ The `reviewOptions` property takes a `ReviewOptions` configuration object.
   - `'disabled'`: The edit is applied directly to the document.
   - `'trackedChanges'`: The edit is encoded as tracked changes using the [Tracked Changes](/tracked-changes/getting-started/overview) extension so users can accept or reject individual changes.
 - `trackedChangesOptions?` (`{ userId: string, userMetadata?: Record<string, unknown> | null }`): Author metadata for the `trackedChanges` mode. `userId` identifies the suggestion author. `userMetadata` stores additional author information such as a display name.
+- `useDiffUtility?` (`boolean`): Whether to use the diff utility for tracked-changes reconstruction. When `true`, changes are computed via fine-grained diffing. When `false` or absent, range-level tracked changes are applied directly.
 - `diffUtilityOptions?` (`object`): Advanced options for reconstructing tracked changes from the before/after document state.
   - `simplifyChanges?` (`boolean`): Simplify nearby changes before tracked changes are generated.
   - `ignoreAttributes?` (`string[]`): Ignore specific node attributes during diffing.


### PR DESCRIPTION
## Summary

- Adds the `useDiffUtility` boolean field to the `ReviewOptions` object in the Server AI Toolkit API reference.
- When `true`, changes are computed via fine-grained diffing. When `false` or absent, range-level tracked changes are applied directly.

## Test plan

- [ ] Verify the new field renders correctly on the docs site
- [ ] Confirm the field appears between `trackedChangesOptions` and `diffUtilityOptions` in the list