### PR TITLE
Update AI Toolkit changelog pages for 0.5.0

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 0.5.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 0.5.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 0.5.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 0.5.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,8 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,17 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 0.5.0
+
+### Minor Changes
+
+- 81a6803: Tracked Changes support for the Insert Content workflow
+- f41bb00: Add ignoreSuggestions option to the tiptapRead method
+
+### Patch Changes
+
+- 81a6803: Preserve other suggestions when the Insert Content workflow generates a new suggestion.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,6 +8,8 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
+## 0.5.0
+
 ## 0.4.0
 
 ## 0.3.10


### PR DESCRIPTION
## Summary
This updates the AI Toolkit and Server AI Toolkit changelog pages to match the current upstream package changelogs in `tiptap-pro`.

## What changed
- add the `0.5.0` changelog entry for `@tiptap-pro/ai-toolkit`
- add the `0.5.0` dependency bump entries for the AI Toolkit adapter packages
- add the `0.5.0` release heading for `@tiptap-pro/ai-toolkit-tool-definitions` and `@tiptap-pro/server-ai-toolkit`

## Why
The docs were still showing `0.4.0` as the latest AI Toolkit release. This sync brings the package changelog pages back in line with the source package changelogs.