### PR TITLE
Document Server AI Toolkit default values

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
@@ -77,7 +77,7 @@ Most tool and workflow endpoints accept exactly one document source:
 
 - `documentId` (`string`, required): The Tiptap Cloud document identifier.
 - `userId?` (`string | null`, optional): Identifier attributed to edits the AI performs.
-- `field?` (`string | null`, optional): Targets a specific collaborative field (Y.js XML fragment) inside the document. Defaults to `"default"` when omitted or `null`. Use this when your document stores multiple editable fields — for example a separate title and body — under the same `documentId`.
+- `field?` (`string | null`, optional, default: `"default"`): Targets a specific collaborative field (Y.js XML fragment) inside the document when omitted or `null`. Use this when your document stores multiple editable fields — for example a separate title and body — under the same `documentId`.
 
 Example with a Tiptap Cloud document:
 
@@ -146,8 +146,8 @@ Request body:
 
 - `schemaAwarenessData` (`SchemaAwarenessData`, required)
 - `tools?` (`object`, optional): Enable or disable individual tools
-- `operationMeta?` (`string | null`, optional)
-- `format?` (`'json' | 'shorthand'`, optional)
+- `operationMeta?` (`string | null`, optional, default: `""`)
+- `format?` (`'json' | 'shorthand'`, optional, default: `'json'`)
 
 Response:
 
@@ -171,9 +171,9 @@ Request body:
 - `input` (`unknown`, required)
 - `schemaAwarenessData` (`SchemaAwarenessData`, required)
 - `sessionId?` (`string | null`, optional): Reuse the session from a previous read or tool execution to enable stale-read protection.
-- `format?` (`'json' | 'shorthand'`, optional)
-- `chunkSize?` (`number`, optional)
-- `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/server-ai-toolkit/api-reference/review-options), optional)
+- `format?` (`'json' | 'shorthand'`, optional, default: `'json'`)
+- `chunkSize?` (`number`, optional, default: `32000`)
+- `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/server-ai-toolkit/api-reference/review-options), optional, default: `{ mode: 'disabled' }`)
 - `experimental_commentsOptions?` (`{ threadData?: Record<string, unknown>, commentData?: Record<string, unknown> }`, optional): Metadata attached to new threads and comments created during thread-related tool execution.
 - exactly one of:
   - `document`
@@ -199,7 +199,7 @@ Use one of these endpoints:
 
 Request body:
 
-- `format` (`'json' | 'shorthand'`, required)
+- `format?` (`'json' | 'shorthand'`, optional, default: `'json'`). The `proofreader` workflow only accepts `'shorthand'`.
 
 Response:
 
@@ -230,12 +230,12 @@ Reads document content and returns workflow-ready content.
 
 Request body:
 
-- `range?` (`{ from: number, to: number }`, optional): Defaults to the entire document when omitted.
+- `range?` (`{ from: number, to: number }`, optional, default: entire document)
 - `schemaAwarenessData` (`SchemaAwarenessData`, required)
-- `format` (`'json' | 'shorthand'`, required)
+- `format?` (`'json' | 'shorthand'`, optional, default: `'json'`)
 - `sessionId?` (`string | null`, optional)
-- `chunkSize?` (`number`, optional)
-- `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/server-ai-toolkit/api-reference/review-options), optional)
+- `chunkSize?` (`number`, optional, default: `32000`)
+- `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/server-ai-toolkit/api-reference/review-options), optional, default: `{ mode: 'disabled' }`)
 - exactly one of:
   - `document`
   - `experimental_documentOptions`
@@ -284,10 +284,10 @@ Request body:
 
 - `range` (`{ from: number, to: number }`, required)
 - `schemaAwarenessData` (`SchemaAwarenessData`, required)
-- `format` (`'json' | 'shorthand'`, required)
+- `format?` (`'json' | 'shorthand'`, optional, default: `'json'`)
 - `sessionId?` (`string | null`, optional)
-- `chunkSize?` (`number`, optional)
-- `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/server-ai-toolkit/api-reference/review-options), optional)
+- `chunkSize?` (`number`, optional, default: `32000`)
+- `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/server-ai-toolkit/api-reference/review-options), optional, default: `{ mode: 'disabled' }`)
 - exactly one of:
   - `document`
   - `experimental_documentOptions`
@@ -374,10 +374,10 @@ Request body:
 - `input` (`unknown`, required): Generated insert-content payload
 - `range?` (`{ from: number, to: number }`, optional)
 - `schemaAwarenessData` (`SchemaAwarenessData`, required)
-- `format` (`'json' | 'shorthand'`, required)
+- `format?` (`'json' | 'shorthand'`, optional, default: `'json'`)
 - `sessionId?` (`string | null`, optional)
-- `chunkSize?` (`number`, optional)
-- `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/server-ai-toolkit/api-reference/review-options), optional)
+- `chunkSize?` (`number`, optional, default: `32000`)
+- `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/server-ai-toolkit/api-reference/review-options), optional, default: `{ mode: 'disabled' }`)
 - exactly one of:
   - `document`
   - `experimental_documentOptions`
@@ -423,10 +423,10 @@ Request body:
 
 - `input` (`object`, required): Edit workflow operations
 - `schemaAwarenessData` (`SchemaAwarenessData`, required)
-- `format` (`'json' | 'shorthand'`, required)
+- `format?` (`'json' | 'shorthand'`, optional, default: `'json'`)
 - `sessionId?` (`string | null`, optional)
-- `chunkSize?` (`number`, optional)
-- `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/server-ai-toolkit/api-reference/review-options), optional)
+- `chunkSize?` (`number`, optional, default: `32000`)
+- `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/server-ai-toolkit/api-reference/review-options), optional, default: `{ mode: 'disabled' }`)
 - exactly one of:
   - `document`
   - `experimental_documentOptions`
@@ -482,8 +482,8 @@ Request body:
 - `schemaAwarenessData` (`SchemaAwarenessData`, required)
 - `format` (`'shorthand'`, required)
 - `sessionId?` (`string | null`, optional)
-- `chunkSize?` (`number`, optional)
-- `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/server-ai-toolkit/api-reference/review-options), optional)
+- `chunkSize?` (`number`, optional, default: `32000`)
+- `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/server-ai-toolkit/api-reference/review-options), optional, default: `{ mode: 'disabled' }`)
 - exactly one of:
   - `document`
   - `experimental_documentOptions`
@@ -531,7 +531,7 @@ Request body:
 
 - `input` (`object`, required): Thread operations
 - `schemaAwarenessData` (`SchemaAwarenessData`, required)
-- `format` (`'json' | 'shorthand'`, required)
+- `format?` (`'json' | 'shorthand'`, optional, default: `'json'`)
 - `experimental_documentOptions` (`{ documentId: string, userId?: string, field?: string | null }`, required)
 - `experimental_commentsOptions?` (`{ threadData?: Record<string, unknown>, commentData?: Record<string, unknown> }`, optional): Metadata attached to new threads and comments created by the workflow.
 

--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/review-options.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/review-options.mdx
@@ -33,16 +33,16 @@ The `reviewOptions` property takes a `ReviewOptions` configuration object.
 - `mode?` (`'disabled' | 'trackedChanges'`): Controls whether edits are applied directly or written as tracked changes. Default: `'disabled'`
   - `'disabled'`: The edit is applied directly to the document.
   - `'trackedChanges'`: The edit is encoded as tracked changes using the [Tracked Changes](/tracked-changes/getting-started/overview) extension so users can accept or reject individual changes.
-- `trackedChangesOptions?` (`{ userId: string, userMetadata?: Record<string, unknown> | null }`): Author metadata for the `trackedChanges` mode. `userId` identifies the suggestion author. `userMetadata` stores additional author information such as a display name.
+- `trackedChangesOptions?` (`{ userId: string, userMetadata?: Record<string, unknown> | null }`): Author metadata for the `trackedChanges` mode. `userId` identifies the suggestion author. Defaults to `'AI'` when omitted. `userMetadata` stores additional author information such as a display name. Defaults to `null`.
 - `useDiffUtility?` (`boolean`): Whether to use the diff utility for tracked-changes reconstruction. When `true`, changes are computed via fine-grained diffing. When `false` or absent, range-level tracked changes are applied directly.
 - `diffUtilityOptions?` (`object`): Advanced options for reconstructing tracked changes from the before/after document state.
-  - `simplifyChanges?` (`boolean`): Simplify nearby changes before tracked changes are generated.
-  - `ignoreAttributes?` (`string[]`): Ignore specific node attributes during diffing.
-  - `ignoreMarks?` (`string[]`): Ignore specific marks during diffing.
-  - `changeMergeDistance?` (`number | null`): Merge nearby changes within this distance.
-  - `mode?` (`'inline' | 'block' | 'smart'`): Diff strategy to use when generating tracked changes.
-  - `groupInlineChanges?` (`number`): Group inline edits that are within this distance.
-  - `expandBlockChanges?` (`string[]`): Node types that should be expanded as block changes.
+  - `simplifyChanges?` (`boolean`, default: `true`): Simplify nearby changes before tracked changes are generated.
+  - `ignoreAttributes?` (`string[]`, default: `['id', 'data-thread-id', '_hash']`): Ignore specific node attributes during diffing.
+  - `ignoreMarks?` (`string[]`, default: `['inlineThread']`): Ignore specific marks during diffing.
+  - `changeMergeDistance?` (`number | null`, default: auto-calculated): Merge nearby changes within this distance. Set to `null` to disable merging.
+  - `mode?` (`'inline' | 'block' | 'smart'`, default: `'smart'`): Diff strategy to use when generating tracked changes.
+  - `groupInlineChanges?` (`number`, default: `1`): Group inline edits that are within this distance.
+  - `expandBlockChanges?` (`string[]`, default: `['listItem']`): Node types that should be expanded as block changes.
 
 ## Typical configurations
 


### PR DESCRIPTION
## Summary

Document the default values used by the Server AI Toolkit REST API endpoints, including format, chunk size, review mode, document field, and session creation behavior.

Update the review options reference with the nested defaults used by tracked changes and diff utility configuration.

## Verification

- pnpm exec prettier --check src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx src/content/content-ai/capabilities/server-ai-toolkit/api-reference/review-options.mdx
- git diff --check