### PR TITLE
docs: embed server workflow tracked changes demos

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/workflows/insert-content.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/workflows/insert-content.mdx
@@ -186,7 +186,7 @@ reviewOptions: {
   src="https://ai-toolkit-demos.vercel.app/server-insert-content-workflow-tracked-changes"
 />
 
-See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
+See the [AI Toolkit demos](https://github.com/ueberdosis/ai-toolkit-demos) for examples on how to integrate Server AI Toolkit workflows with Tracked Changes.
 
 ## End result
 

--- a/src/content/content-ai/capabilities/server-ai-toolkit/workflows/insert-content.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/workflows/insert-content.mdx
@@ -180,7 +180,13 @@ reviewOptions: {
 }
 ```
 
-See the [AI Toolkit demos](https://github.com/ueberdosis/ai-toolkit-demos) for examples on how to integrate Server AI Toolkit workflows with Tracked Changes.
+<CodeDemo
+  path=""
+  isScrollable
+  src="https://ai-toolkit-demos.vercel.app/server-insert-content-workflow-tracked-changes"
+/>
+
+See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
 
 ## End result
 

--- a/src/content/content-ai/capabilities/server-ai-toolkit/workflows/tiptap-edit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/workflows/tiptap-edit.mdx
@@ -168,7 +168,7 @@ reviewOptions: {
   src="https://ai-toolkit-demos.vercel.app/server-edit-workflow-tracked-changes"
 />
 
-See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
+See the [AI Toolkit demos](https://github.com/ueberdosis/ai-toolkit-demos) for examples on how to integrate Server AI Toolkit workflows with Tracked Changes.
 
 ## End result
 

--- a/src/content/content-ai/capabilities/server-ai-toolkit/workflows/tiptap-edit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/workflows/tiptap-edit.mdx
@@ -162,7 +162,13 @@ reviewOptions: {
 }
 ```
 
-See the [AI Toolkit demos](https://github.com/ueberdosis/ai-toolkit-demos) for examples on how to integrate Server AI Toolkit workflows with Tracked Changes.
+<CodeDemo
+  path=""
+  isScrollable
+  src="https://ai-toolkit-demos.vercel.app/server-edit-workflow-tracked-changes"
+/>
+
+See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
 
 ## End result
 


### PR DESCRIPTION
## Summary

Embeds the new tracked-changes review UI demos (added in [ai-toolkit-demos#54](https://github.com/ueberdosis/ai-toolkit-demos/pull/54)) into the Server AI Toolkit workflow docs.

- `workflows/tiptap-edit.mdx` — `<CodeDemo>` for `/server-edit-workflow-tracked-changes` in the "Tracked changes" section
- `workflows/insert-content.mdx` — `<CodeDemo>` for `/server-insert-content-workflow-tracked-changes` in the "Tracked changes" section

Both follow the existing "End result" pattern (CodeDemo + GitHub source link).

### Out of scope

- Proofreader workflow tracked-changes demo embed — pending demo on the ai-toolkit-demos side
- Tracked Changes + Comments embeds — requires Server AI Toolkit support for `operationMeta` in workflow output schema (separate ticket/PR needed)

## Test plan

- [ ] `tiptap-edit.mdx` — Tracked changes section renders the new demo iframe
- [ ] `insert-content.mdx` — Tracked changes section renders the new demo iframe
- [ ] Demo iframes load `https://ai-toolkit-demos.vercel.app/...` (after the demos PR is merged & deployed)