### PR TITLE
Document range returned by acceptSuggestion

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/suggestions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/suggestions.mdx
@@ -168,10 +168,9 @@ This feedback can be used to inform the AI about what changes were accepted or r
 ### Example
 
 ```ts
-// Accept a suggestion by id and inspect the inserted range
+// Accept a suggestion by id and get feedback
 const result = toolkit.acceptSuggestion('suggestion-1')
 result.aiFeedback.events
-result.range // e.g. { from: 1, to: 8 }
 ```
 
 ## `acceptAllSuggestions`

--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/suggestions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/suggestions.mdx
@@ -161,7 +161,7 @@ Returns an object containing:
   - `delete` (`string`): HTML content that was deleted (or would be deleted)
   - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
   - `accepted` (`boolean`): Whether the suggestion was accepted by the user (`true`) or rejected (`false`)
-- `range` (`{ from: number; to: number } | null`): The range in the editor's document that the inserted replacement content occupies after the suggestion has been applied. In `review` mode, the replacement content is already present in the document before accepting, so the range points to that existing content (the suggestion's range). It is `null` when no content was inserted nor present in the editor — for example when the suggestion was not found, when it has no replacement options, or when the suggestion comes from the "Compare documents" feature (the change is applied to the other document).
+- `range` (`{ from: number; to: number } | null`): The range in the editor's document that the inserted replacement content occupies after the suggestion has been applied. In `review` mode (including suggestions from the "Compare documents" feature), the replacement content is already present in the document before accepting, so the range points to that existing content (the suggestion's range). It is `null` when no content was inserted nor present in the editor — for example when the suggestion was not found or when it has no replacement options.
 
 This feedback can be used to inform the AI about what changes were accepted or rejected by the user.
 

--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/suggestions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/suggestions.mdx
@@ -161,7 +161,7 @@ Returns an object containing:
   - `delete` (`string`): HTML content that was deleted (or would be deleted)
   - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
   - `accepted` (`boolean`): Whether the suggestion was accepted by the user (`true`) or rejected (`false`)
-- `range` (`{ from: number; to: number } | null`): The range in the editor's document that the inserted replacement content occupies after the suggestion has been applied. It is `null` when no content was inserted into the editor — for example when the suggestion was not found, when it has no replacement options, when the suggestion comes from the "Compare documents" feature (the change is applied to the other document), or when the suggestion is in `review` mode (the change is undone instead of inserted).
+- `range` (`{ from: number; to: number } | null`): The range in the editor's document that the inserted replacement content occupies after the suggestion has been applied. In `review` mode, the replacement content is already present in the document before accepting, so the range points to that existing content (the suggestion's range). It is `null` when no content was inserted nor present in the editor — for example when the suggestion was not found, when it has no replacement options, or when the suggestion comes from the "Compare documents" feature (the change is applied to the other document).
 
 This feedback can be used to inform the AI about what changes were accepted or rejected by the user.
 

--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/suggestions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/suggestions.mdx
@@ -161,15 +161,17 @@ Returns an object containing:
   - `delete` (`string`): HTML content that was deleted (or would be deleted)
   - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
   - `accepted` (`boolean`): Whether the suggestion was accepted by the user (`true`) or rejected (`false`)
+- `range` (`{ from: number; to: number } | null`): The range in the editor's document that the inserted replacement content occupies after the suggestion has been applied. It is `null` when no content was inserted into the editor — for example when the suggestion was not found, when it has no replacement options, when the suggestion comes from the "Compare documents" feature (the change is applied to the other document), or when the suggestion is in `review` mode (the change is undone instead of inserted).
 
 This feedback can be used to inform the AI about what changes were accepted or rejected by the user.
 
 ### Example
 
 ```ts
-// Accept a suggestion by id and get feedback
+// Accept a suggestion by id and inspect the inserted range
 const result = toolkit.acceptSuggestion('suggestion-1')
 result.aiFeedback.events
+result.range // e.g. { from: 1, to: 8 }
 ```
 
 ## `acceptAllSuggestions`

--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/suggestions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/suggestions.mdx
@@ -161,7 +161,7 @@ Returns an object containing:
   - `delete` (`string`): HTML content that was deleted (or would be deleted)
   - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
   - `accepted` (`boolean`): Whether the suggestion was accepted by the user (`true`) or rejected (`false`)
-- `range` (`{ from: number; to: number } | null`): The range of the inserted content in the document. It is `null` when the suggestion cannot be applied.
+- `range` (`Range | null`): The range of the inserted content in the document. It is `null` when the suggestion cannot be applied.
 
 This feedback can be used to inform the AI about what changes were accepted or rejected by the user.
 

--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/suggestions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/suggestions.mdx
@@ -161,7 +161,7 @@ Returns an object containing:
   - `delete` (`string`): HTML content that was deleted (or would be deleted)
   - `insert` (`string`): HTML content or text that was inserted (or would be inserted)
   - `accepted` (`boolean`): Whether the suggestion was accepted by the user (`true`) or rejected (`false`)
-- `range` (`{ from: number; to: number } | null`): The range in the editor's document that the inserted replacement content occupies after the suggestion has been applied. In `review` mode (including suggestions from the "Compare documents" feature), the replacement content is already present in the document before accepting, so the range points to that existing content (the suggestion's range). It is `null` when no content was inserted nor present in the editor — for example when the suggestion was not found or when it has no replacement options.
+- `range` (`{ from: number; to: number } | null`): The range of the inserted content in the document. It is `null` when the suggestion cannot be applied.
 
 This feedback can be used to inform the AI about what changes were accepted or rejected by the user.
 


### PR DESCRIPTION
## Summary

Documents the new `range` property returned by the AI Toolkit's `acceptSuggestion` method.

Implementation PR: https://github.com/ueberdosis/tiptap-pro/pull/750

## Test plan

- [x] Reviewed the rendered API reference page.