### PR TITLE
Update AI Toolkit changelogs for 0.6.0

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies [c0998e4]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies [c0998e4]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies [c0998e4]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies [c0998e4]
+  - @tiptap-pro/ai-toolkit-tool-definitions@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 0.6.0
+
+### Minor Changes
+
+- c0998e4: Simplify tool definitions of the tiptapRead and tiptapEdit tools
+
 ## 0.5.0
 
 ## 0.4.0

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,13 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 0.6.0
+
+### Minor Changes
+
+- 425d7bc: `acceptSuggestion` now returns a `range` property with the range of the inserted content in the document. The range is `null` when the suggestion cannot be applied.
+- a9134a5: Add the experimental `findContentRange` method for locating ProseMirror ranges by `_hash` and/or exact HTML content.
+
 ## 0.5.0
 
 ### Minor Changes


### PR DESCRIPTION
Updates the AI Toolkit package changelog pages to match the latest entries from tiptap-pro main.

Changed pages:
- @tiptap-pro/ai-toolkit
- @tiptap-pro/ai-toolkit-ai-sdk
- @tiptap-pro/ai-toolkit-anthropic
- @tiptap-pro/ai-toolkit-langchain
- @tiptap-pro/ai-toolkit-openai
- @tiptap-pro/ai-toolkit-tool-definitions

The Server AI Toolkit changelog did not need a content update because the package changelog has no new release notes in the latest pro pull.