### PR TITLE
docs: document tracked changes + comments for edit and proofreader workflows

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
@@ -129,16 +129,6 @@ See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
 
 You can make the AI provide a justification for each change. Each justification becomes a comment thread linked to its tracked change, using the [Comments](/comments/getting-started/overview) extension.
 
-<Callout title="Using workflows instead of agents?" variant="info">
-  The same comments + tracked changes integration is available for the [Tiptap
-  Edit](/content-ai/capabilities/server-ai-toolkit/workflows/tiptap-edit#tracked-changes-with-comments)
-  and
-  [Proofreader](/content-ai/capabilities/server-ai-toolkit/workflows/proofreader#tracked-changes-with-comments)
-  workflows. Pass `operationMeta` to the workflow definition request and
-  `experimental_commentsOptions` to the execute request — the same way as in
-  the agent flow.
-</Callout>
-
 ### API endpoint
 
 When fetching tool definitions, pass the top-level `operationMeta` option to add a `meta` field to `tiptapEdit` operations. Then instruct the AI to provide a justification in that `meta` field.

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
@@ -129,6 +129,16 @@ See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
 
 You can make the AI provide a justification for each change. Each justification becomes a comment thread linked to its tracked change, using the [Comments](/comments/getting-started/overview) extension.
 
+<Callout title="Using workflows instead of agents?" variant="info">
+  The same comments + tracked changes integration is available for the [Tiptap
+  Edit](/content-ai/capabilities/server-ai-toolkit/workflows/tiptap-edit#tracked-changes-with-comments)
+  and
+  [Proofreader](/content-ai/capabilities/server-ai-toolkit/workflows/proofreader#tracked-changes-with-comments)
+  workflows. Pass `operationMeta` to the workflow definition request and
+  `experimental_commentsOptions` to the execute request — the same way as in
+  the agent flow.
+</Callout>
+
 ### API endpoint
 
 When fetching tool definitions, pass the top-level `operationMeta` option to add a `meta` field to `tiptapEdit` operations. Then instruct the AI to provide a justification in that `meta` field.

--- a/src/content/content-ai/capabilities/server-ai-toolkit/workflows/proofreader.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/workflows/proofreader.mdx
@@ -169,6 +169,94 @@ reviewOptions: {
 
 See the [AI Toolkit demos](https://github.com/ueberdosis/ai-toolkit-demos) for examples on how to integrate Server AI Toolkit workflows with Tracked Changes.
 
+## Tracked changes with comments
+
+<CodeDemo
+  isLarge
+  path=""
+  isScrollable
+  src="https://ai-toolkit-demos.vercel.app/server-proofreader-workflow-tracked-comments"
+/>
+
+See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
+
+You can make the AI provide a justification for each correction. Each justification becomes a comment thread linked to its tracked change, using the [Comments](/comments/getting-started/overview) extension.
+
+### Workflow definition with `operationMeta`
+
+When fetching the proofreader workflow definition, pass `operationMeta` to require each operation to include a `meta` field. The string you provide describes what should go in the meta field.
+
+```ts
+const workflowResponse = await fetch(`${apiBaseUrl}/toolkit/workflows/proofreader`, {
+  method: 'POST',
+  headers: getAuthHeaders(),
+  body: JSON.stringify({
+    format: 'shorthand',
+    operationMeta:
+      'Specific reason for this correction (e.g., "spelling: excelent → excellent" or "subject-verb agreement").',
+  }),
+})
+```
+
+The returned `outputSchema` now requires a `meta` field on every operation, and the `systemPrompt` instructs the AI to fill it.
+
+### Execute the workflow with comments
+
+Pass `experimental_commentsOptions` alongside `reviewOptions` when executing the workflow:
+
+```ts
+const executeResponse = await fetch(`${apiBaseUrl}/toolkit/execute-workflow/proofreader`, {
+  method: 'POST',
+  headers: getAuthHeaders(),
+  body: JSON.stringify({
+    schemaAwarenessData,
+    format: 'shorthand',
+    input: output,
+    sessionId: readResult.sessionId,
+    reviewOptions: {
+      mode: 'trackedChanges',
+      trackedChangesOptions: {
+        userId: 'ai-assistant',
+      },
+    },
+    experimental_commentsOptions: {
+      threadData: { userName: 'Tiptap AI' },
+      commentData: { userName: 'Tiptap AI' },
+    },
+    experimental_documentOptions: {
+      documentId,
+      userId: 'ai-assistant',
+    },
+  }),
+})
+```
+
+Each non-empty `meta` field in the operations becomes a comment thread linked to its tracked change. The justification is stored as the thread's first comment content and as `suggestionReason` in the thread data.
+
+### Client-side setup
+
+On the client, add the `CommentsKit` extension with a `TiptapCollabProvider`:
+
+```tsx
+import { CommentsKit } from '@tiptap-pro/extension-comments'
+import { TrackedChanges } from '@tiptap-pro/extension-tracked-changes'
+import { ServerAiToolkit } from '@tiptap-pro/server-ai-toolkit'
+
+const editor = useEditor({
+  extensions: [
+    StarterKit.configure({ undoRedo: false }),
+    Collaboration.configure({ document: doc }),
+    TrackedChanges.configure({ enabled: false }),
+    ServerAiToolkit,
+    CommentsKit.configure({
+      provider, // Your TiptapCollabProvider instance
+    }),
+  ],
+})
+```
+
+Users can review each tracked change and read the AI's justification in the comments sidebar.
+
 ## End result
 
 The result is a collaborative proofreader workflow for server-side grammar and spelling fixes:

--- a/src/content/content-ai/capabilities/server-ai-toolkit/workflows/tiptap-edit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/workflows/tiptap-edit.mdx
@@ -170,6 +170,94 @@ reviewOptions: {
 
 See the [AI Toolkit demos](https://github.com/ueberdosis/ai-toolkit-demos) for examples on how to integrate Server AI Toolkit workflows with Tracked Changes.
 
+## Tracked changes with comments
+
+<CodeDemo
+  isLarge
+  path=""
+  isScrollable
+  src="https://ai-toolkit-demos.vercel.app/server-edit-workflow-tracked-comments"
+/>
+
+See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
+
+You can make the AI provide a justification for each change. Each justification becomes a comment thread linked to its tracked change, using the [Comments](/comments/getting-started/overview) extension.
+
+### Workflow definition with `operationMeta`
+
+When fetching the edit workflow definition, pass `operationMeta` to require each operation to include a `meta` field. The string you provide describes what should go in the meta field.
+
+```ts
+const workflowResponse = await fetch(`${apiBaseUrl}/toolkit/workflows/edit`, {
+  method: 'POST',
+  headers: getAuthHeaders(),
+  body: JSON.stringify({
+    format: 'shorthand',
+    operationMeta:
+      'Specific reason for this edit (what is changing in this exact operation).',
+  }),
+})
+```
+
+The returned `outputSchema` now requires a `meta` field on every operation, and the `systemPrompt` instructs the AI to fill it.
+
+### Execute the workflow with comments
+
+Pass `experimental_commentsOptions` alongside `reviewOptions` when executing the workflow:
+
+```ts
+const executeResponse = await fetch(`${apiBaseUrl}/toolkit/execute-workflow/tiptap-edit`, {
+  method: 'POST',
+  headers: getAuthHeaders(),
+  body: JSON.stringify({
+    schemaAwarenessData,
+    format: 'shorthand',
+    input: output,
+    sessionId: readResult.sessionId,
+    reviewOptions: {
+      mode: 'trackedChanges',
+      trackedChangesOptions: {
+        userId: 'ai-assistant',
+      },
+    },
+    experimental_commentsOptions: {
+      threadData: { userName: 'Tiptap AI' },
+      commentData: { userName: 'Tiptap AI' },
+    },
+    experimental_documentOptions: {
+      documentId,
+      userId: 'ai-assistant',
+    },
+  }),
+})
+```
+
+Each non-empty `meta` field in the operations becomes a comment thread linked to its tracked change. The justification is stored as the thread's first comment content and as `suggestionReason` in the thread data.
+
+### Client-side setup
+
+On the client, add the `CommentsKit` extension with a `TiptapCollabProvider`:
+
+```tsx
+import { CommentsKit } from '@tiptap-pro/extension-comments'
+import { TrackedChanges } from '@tiptap-pro/extension-tracked-changes'
+import { ServerAiToolkit } from '@tiptap-pro/server-ai-toolkit'
+
+const editor = useEditor({
+  extensions: [
+    StarterKit.configure({ undoRedo: false }),
+    Collaboration.configure({ document: doc }),
+    TrackedChanges.configure({ enabled: false }),
+    ServerAiToolkit,
+    CommentsKit.configure({
+      provider, // Your TiptapCollabProvider instance
+    }),
+  ],
+})
+```
+
+Users can review each tracked change and read the AI's justification in the comments sidebar.
+
 ## End result
 
 The finished demo rewrites the collaborative document entirely on the server:


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE YET** — this PR depends on:
> 1. The Server AI Toolkit \`operationMeta\` fix being merged and deployed to production
> 2. The [ai-toolkit-demos PR #56](https://github.com/ueberdosis/ai-toolkit-demos/pull/56) being merged and deployed to Vercel (so the embedded demo URLs resolve)
>
> Merge order: Server AI Toolkit fix → ai-toolkit-demos#56 → this PR.

## Summary

Documents the **Tracked Changes + Comments** integration for the Tiptap Edit and Proofreader server workflows. Mirrors the existing agent-flow guide (\`agents/tracked-changes.mdx\`).

## Changes

**\`workflows/tiptap-edit.mdx\`** — new \`## Tracked changes with comments\` section:
- CodeDemo (\`/server-edit-workflow-tracked-comments\`)
- \`### Workflow definition with operationMeta\`
- \`### Execute the workflow with comments\`
- \`### Client-side setup\` (CommentsKit + TiptapCollabProvider)

**\`workflows/proofreader.mdx\`** — same new section structure with proofreader-specific code samples and the new \`/server-proofreader-workflow-tracked-comments\` demo.

**\`agents/tracked-changes.mdx\`** — adds a Callout in the existing "Add comments with tracked changes" section pointing readers to the new workflow guides for non-agent use cases.

## Pattern reference

Section structure mirrors the agent-flow guide (\`agents/tracked-changes.mdx\` — "Add comments with tracked changes"). Same three subsections (definition / execute / client setup), same callout style, same demo embed pattern. The only differences are the API endpoints and the new workflow-specific demo URLs.

## Test plan

- [ ] Merge **after** Server AI Toolkit \`operationMeta\` fix lands in prod
- [ ] Merge **after** [ai-toolkit-demos#56](https://github.com/ueberdosis/ai-toolkit-demos/pull/56) is deployed to Vercel
- [ ] \`/content-ai/capabilities/server-ai-toolkit/workflows/tiptap-edit\` renders the new section with a working demo iframe
- [ ] \`/content-ai/capabilities/server-ai-toolkit/workflows/proofreader\` renders the new section with a working demo iframe
- [ ] \`/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes\` renders the new cross-reference Callout
- [ ] Anchor links in the Callout (\`#tracked-changes-with-comments\`) resolve correctly