### PR TITLE
Sync Server AI Toolkit changelog

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,6 +8,8 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
+## 0.6.0
+
 ## 0.5.0
 
 ## 0.4.0


### PR DESCRIPTION
## Summary

- Add the missing `0.6.0` entry to the Server AI Toolkit changelog page.
- Verified the AI Toolkit package changelog pages against the current `tiptap-pro` changelog sources.

## Validation

- `git diff --check`
- `pnpm exec prettier --check src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx`