### PR TITLE
Sync AI Toolkit changelogs

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -310,7 +310,7 @@ meta:
 
 ### Minor Changes
 
-- Add `activeNodeRange` position to the `insertContent` tool to allow the AI to insert content at the active node range. This improves the accuracy of the edits when the `applyDiff` tool is disabled.
+- Add `activeNodeRange` position to the `insertContent` tool to allow the AI to insert content at the active node range. This improves the accuracy of the edits when the `applyPatch` tool is disabled.
 
 ## 3.0.0-alpha.9
 
@@ -353,7 +353,7 @@ meta:
 
 ### Minor changes
 
-- Simplify and improve prompt to use applyDiff tool more often
+- Simplify and improve prompt to use applyPatch tool more often
 
 ## 3.1.0-alpha.2
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 0.6.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.6.1
+
 ## 0.6.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 0.6.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.6.1
+
 ## 0.6.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -292,7 +292,7 @@ meta:
 
 ### Minor Changes
 
-- Add `activeNodeRange` position to the `insertContent` tool to allow the AI to insert content at the active node range. This improves the accuracy of the edits when the `applyDiff` tool is disabled.
+- Add `activeNodeRange` position to the `insertContent` tool to allow the AI to insert content at the active node range. This improves the accuracy of the edits when the `applyPatch` tool is disabled.
 
 ## 3.0.0-alpha.1
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 0.6.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.6.1
+
 ## 0.6.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -298,7 +298,7 @@ meta:
 
 ### Minor Changes
 
-- Add `activeNodeRange` position to the `insertContent` tool to allow the AI to insert content at the active node range. This improves the accuracy of the edits when the `applyDiff` tool is disabled.
+- Add `activeNodeRange` position to the `insertContent` tool to allow the AI to insert content at the active node range. This improves the accuracy of the edits when the `applyPatch` tool is disabled.
 
 ## 3.0.0-alpha.5
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -298,7 +298,7 @@ meta:
 
 ### Minor Changes
 
-- Add `activeNodeRange` position to the `insertContent` tool to allow the AI to insert content at the active node range. This improves the accuracy of the edits when the `applyDiff` tool is disabled.
+- Add `activeNodeRange` position to the `insertContent` tool to allow the AI to insert content at the active node range. This improves the accuracy of the edits when the `applyPatch` tool is disabled.
 
 ## 3.0.0-alpha.4
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 0.6.1
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.6.1
+
 ## 0.6.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -291,7 +291,7 @@ meta:
 
 ### Minor Changes
 
-- Add `activeNodeRange` position to the `insertContent` tool to allow the AI to insert content at the active node range. This improves the accuracy of the edits when the `applyDiff` tool is disabled.
+- Add `activeNodeRange` position to the `insertContent` tool to allow the AI to insert content at the active node range. This improves the accuracy of the edits when the `applyPatch` tool is disabled.
 
 ## 3.0.0-alpha.6
 

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,8 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 0.6.1
+
 ## 0.6.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 0.6.1
+
+### Patch Changes
+
+- 46deb98: Fix streaming preview suggestions accumulating across stream ticks.
+
 ## 0.6.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -311,8 +311,6 @@ meta:
 - **Breaking**: Rename `displayOptions.showAsDiff` to `displayOptions.showReplacement`.
 - **Breaking**: Remove `displayOptions.diffPosition`.
 - **Breaking**: Rename `displayOptions.diffAttributes` to `displayOptions.replacementAttributes`.
-- **Breaking**: Rename `DiffUtilityConfig` type to `ExternalDiffUtilityOptions`.
-- **Breaking**: Rename `diffUtilityConfig` property to `diffUtilityOptions` in all methods and options interfaces.
 
 ### Deprecations
 
@@ -322,7 +320,7 @@ meta:
 
 - Improve performance of the inline diff mode.
 - Fix bug in diff utility where the added content and the deleted content would both end with a space.
-- Add `groupInlineChanges` to `diffUtility` and `diffUtilityOptions` to control when inline edits are grouped into one suggestion.
+- Add `groupInlineChanges` to `diffUtilityOptions` (`ExternalDiffUtilityOptions`) to control when inline edits are grouped into one suggestion.
 - Add `displayOptions.showSubChanges`, `displayOptions.subChangeAttributes`, and `displayOptions.replacementSubChangeAttributes` to customize grouped inline changes.
 - Add `isInlineGroup` to `Suggestion` for grouped inline changes.
 - In `proofreaderWorkflow`, inline changes are no longer grouped by default. Override with `reviewOptions.diffUtilityOptions.groupInlineChanges` when needed.
@@ -605,11 +603,11 @@ meta:
 
 ### Major changes
 
-- Replace `changeMergeDistance` option with `diffUtilityOptions`, to provide more customization options for the document comparison utility.
+- Replace `changeMergeDistance` option with `diffUtilityConfig`, to provide more customization options for the document comparison utility.
 
 ### Minor Changes
 
-- Add `diffUtilityOptions` option to `compareDocuments` format in `setSuggestions` method. This allows configuring the document comparison utility.
+- Add `diffUtilityConfig` option to `compareDocuments` format in `setSuggestions` method. This allows configuring the document comparison utility.
 - Add `diffAttributes` option to `displayOptions` of `Suggestion` type to allow customizing the attributes of the diff decoration.
 
 ## 3.0.0-alpha.40
@@ -672,7 +670,7 @@ meta:
 ### Minor Changes
 
 - Add `changeMergeDistance` option to `diffUtility`, `startComparingDocuments`, `setSuggestions` (compareDocuments format), `setHtmlSuggestions`, and all edit methods' `reviewOptions`. This allows merging nearby changes when comparing documents by specifying the maximum distance (in document positions) between changes to merge them into a single change.
-- Add `reviewOptions` parameter to `setHtmlSuggestions` method. Users can now customize suggestion display options (like `diffPosition`, `showAsDiff`, custom `renderDecorations`) and add custom metadata, following the same pattern as other edit methods.
+- Add `reviewOptions` parameter to `setHtmlSuggestions` method. Users can now customize suggestion display options (like `diffPosition`, `showReplacement`, custom `renderDecorations`) and add custom metadata, following the same pattern as other edit methods.
 - Fix range offset calculation in `setHtmlSuggestions`. Suggestions now correctly highlight the exact text when no `range` parameter is provided, fixing a bug where positions were incorrectly shifted by -1.
 - Fix default `diffPosition` in `setHtmlSuggestions` to use 'after' instead of 'before', and make it configurable through `reviewOptions.displayOptions.diffPosition`.
 

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,6 +8,8 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
+## 0.6.1
+
 ## 0.6.0
 
 ## 0.5.0


### PR DESCRIPTION
## What changed

- Synced AI Toolkit changelog pages with the package changelogs from the latest `tiptap-pro` main branch.
- Updated the provider/tool-definition historical entries so the docs match the upstream changelog text while preserving MDX formatting.
- Confirmed the Server AI Toolkit changelog page already matches upstream.

## Verification

- Pulled/fetched the latest `tiptap-pro` main branch before comparing changelogs.
- Compared all AI Toolkit and Server AI Toolkit docs changelog bodies against the upstream package changelogs.
- `git diff --check`
- `pnpm exec prettier --check src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx`

## Notes

- `NODE_ENV=development pnpm lint` currently fails before reaching these MDX files with `TypeError: Error while loading rule 'react/display-name': contextOrFilename.getFilename is not a function` while linting `custom.d.ts`.