### PR TITLE
Update AI Toolkit changelogs

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 0.7.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.7.0
+
 ## 0.6.1
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 0.7.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.7.0
+
 ## 0.6.1
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 0.7.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.7.0
+
 ## 0.6.1
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 0.7.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.7.0
+
 ## 0.6.1
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,8 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 0.7.0
+
 ## 0.6.1
 
 ## 0.6.0

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 0.7.0
+
+### Minor Changes
+
+- e656fc6: Add a `tr` option to `acceptSuggestion` so callers can apply accepted suggestions to an existing ProseMirror transaction without dispatching it.
+
 ## 0.6.1
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,6 +8,8 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
+## 0.7.0
+
 ## 0.6.1
 
 ## 0.6.0


### PR DESCRIPTION
## What changed

- Added the 0.7.0 changelog entries for all AI Toolkit integration packages.
- Added the 0.7.0 changelog entry for the core AI Toolkit package.
- Added the 0.7.0 changelog entry for Server AI Toolkit.

## Why

The package changelogs in tiptap-pro now include the 0.7.0 release, so the documentation needs to reflect the latest published AI Toolkit and Server AI Toolkit versions.

## Related PRs

- Demo package update: https://github.com/ueberdosis/ai-toolkit-demos/pull/59

## Verification

- `pnpm exec prettier --check` on the changed changelog files passed.
- `pnpm run lint` is blocked by an ESLint runtime error: `scopeManager.addGlobals is not a function`.