### PR TITLE
docs(pages): document Word/gdoc-matching behavior for different first page and odd/even

### DIFF
--- a/src/content/pages/core-concepts/page-header-footer.mdx
+++ b/src/content/pages/core-concepts/page-header-footer.mdx
@@ -203,6 +203,13 @@ Enable a different header and/or footer for the first page, similar to Microsoft
   together, matching Microsoft Word's behavior.
 </Callout>
 
+<Callout title="First page slot starts empty" variant="info">
+  Calling `setDifferentFirstPage(true)` does **not** copy the default header/footer into the first
+  page slot — it starts empty, matching Microsoft Word. To pre-populate the first page header or
+  footer, call `setHeaderFirstPage` / `setFooterFirstPage` after enabling the flag, or set
+  `headerFirstPage` / `footerFirstPage` in `Pages.configure()`.
+</Callout>
+
 ### Configuration
 
 ```js
@@ -233,6 +240,15 @@ Enable different headers and/or footers for odd-numbered pages (1, 3, 5...) and 
 <Callout title="Note" variant="info">
   The `setDifferentOddEven()` command enables both different odd/even headers and footers together,
   matching Microsoft Word's behavior.
+</Callout>
+
+<Callout title="Odd slot inherits the default on enable" variant="info">
+  When you call `setDifferentOddEven(true)`, the existing default header/footer content is copied
+  into the **odd** slot if the odd slot is empty. This matches Microsoft Word's continuity
+  behavior — pages 1, 3, 5… keep showing what was there before the flag was toggled, while the
+  even slot starts empty for you to fill in. If you toggle the flag off and on again, content you
+  previously typed into the odd slot is preserved (the copy only happens when the odd slot is
+  empty).
 </Callout>
 
 ### Configuration
@@ -270,7 +286,15 @@ When both `differentFirstPage` and `differentOddEven` are enabled, the first pag
 
 1. First page (if `differentFirstPage` is enabled) - applies to page 1
 2. Odd/even (if `differentOddEven` is enabled) - applies to pages 2+
-3. Default header/footer - fallback
+3. Default header/footer - fallback (used only when no `different*` flag is enabled for that zone)
+
+<Callout title="Empty type-specific slots render empty" variant="info">
+  When a `different*` flag is enabled, the corresponding slot is authoritative for the pages it
+  covers — even when empty. For example, with `differentFirstPage: true` and an empty
+  `headerFirstPage`, page 1 renders an empty header (it does **not** silently fall back to the
+  default header). This matches Microsoft Word and Google Docs. The default header/footer is only
+  used as a fallback when its `different*` flag is **off**.
+</Callout>
 
 ```js
 Pages.configure({
@@ -742,10 +766,10 @@ Header and footer editors participate in collaboration alongside the main docume
 | `resetHeaderTopMargin`     | none                        | Clear the header top margin override; falls back to the active format's default (50% of the format's top margin). |
 | `setFooterBottomMargin`    | `margin: number`            | Set footer bottom margin (pixels). Rejects negative values and `NaN`. |
 | `resetFooterBottomMargin`  | none                        | Clear the footer bottom margin override; falls back to the active format's default (50% of the format's bottom margin). |
-| `setDifferentFirstPage`    | `enabled: boolean`          | Toggle different first page (header + footer)      |
+| `setDifferentFirstPage`    | `enabled: boolean`          | Toggle different first page (header + footer). First page slot starts empty, matching Word. If a header/footer overlay is open, it refreshes to show the new variant. |
 | `setHeaderFirstPage`       | `header: PagesHeaderFooter` | Set first page header content                      |
 | `setFooterFirstPage`       | `footer: PagesHeaderFooter` | Set first page footer content                      |
-| `setDifferentOddEven`      | `enabled: boolean`          | Toggle different odd/even pages (header + footer)  |
+| `setDifferentOddEven`      | `enabled: boolean`          | Toggle different odd/even pages (header + footer). When enabling, the default header/footer is copied into the odd slot (if empty) for Word continuity. If a header/footer overlay is open, it refreshes to show the new variant. |
 | `setHeaderOdd`             | `header: PagesHeaderFooter` | Set odd pages header content                       |
 | `setHeaderEven`            | `header: PagesHeaderFooter` | Set even pages header content                      |
 | `setFooterOdd`             | `footer: PagesHeaderFooter` | Set odd pages footer content                       |

--- a/src/content/pages/core-concepts/page-header-footer.mdx
+++ b/src/content/pages/core-concepts/page-header-footer.mdx
@@ -286,14 +286,15 @@ When both `differentFirstPage` and `differentOddEven` are enabled, the first pag
 
 1. First page (if `differentFirstPage` is enabled) - applies to page 1
 2. Odd/even (if `differentOddEven` is enabled) - applies to pages 2+
-3. Default header/footer - fallback (used only when no `different*` flag is enabled for that zone)
+3. Default header/footer - fallback (used only when neither `differentFirstPage` nor `differentOddEven` is enabled for that zone)
 
 <Callout title="Empty type-specific slots render empty" variant="info">
-  When a `different*` flag is enabled, the corresponding slot is authoritative for the pages it
-  covers — even when empty. For example, with `differentFirstPage: true` and an empty
-  `headerFirstPage`, page 1 renders an empty header (it does **not** silently fall back to the
-  default header). This matches Microsoft Word and Google Docs. The default header/footer is only
-  used as a fallback when its `different*` flag is **off**.
+  When `differentFirstPage` or `differentOddEven` is enabled, the corresponding slot is
+  authoritative for the pages it covers — even when empty. For example, with
+  `differentFirstPage: true` and an empty `headerFirstPage`, page 1 renders an empty header (it
+  does **not** silently fall back to the default header). This matches Microsoft Word and Google
+  Docs. The default header/footer is only used as a fallback when the relevant flag
+  (`differentFirstPage` or `differentOddEven`) is **off**.
 </Callout>
 
 ```js


### PR DESCRIPTION
## Summary

- **Different first page** — added a callout clarifying that `setDifferentFirstPage(true)` does not copy the default header/footer into the first page slot. The slot starts empty, matching Word.
- **Different odd and even pages** — added a callout explaining that `setDifferentOddEven(true)` copies the default header/footer into the odd slot (when empty) for Word continuity. Pages 1, 3, 5… keep showing the previous content; the even slot starts empty. Re-enabling preserves any odd-slot content the user typed.
- **Combining first page and odd/even pages** — clarified the precedence list: the default header/footer is a fallback only when its `different*` flag is **off**. Added a callout explaining that empty type-specific slots now render empty instead of silently falling back to the default.
- **Commands reference** — annotated `setDifferentFirstPage` and `setDifferentOddEven` with the new copy/refresh behavior (overlays now refresh when toggled while open).