### PR TITLE
docs: element overrides + subscript & superscript

### DIFF
--- a/src/content/conversion/content-types/text-and-formatting/subscript-superscript.mdx
+++ b/src/content/conversion/content-types/text-and-formatting/subscript-superscript.mdx
@@ -4,13 +4,13 @@ tags:
   - type: beta
 meta:
   title: Subscript and Superscript | Tiptap Conversion
-  description: How subscript and superscript marks convert between DOCX and Tiptap, including the current export limitation.
+  description: How subscript and superscript marks round-trip between DOCX and Tiptap.
   category: Conversion
 ---
 
 import { Callout } from '@/components/ui/Callout'
 
-Subscript and superscript marks import from DOCX and render in the editor, but are not preserved on export. Content like H₂O will import and display correctly but export as plain H2O.
+Subscript and superscript marks round-trip between DOCX and Tiptap. Content like H₂O imports, renders in the editor, and exports back to DOCX with formatting preserved.
 
 ## What you need
 
@@ -21,8 +21,8 @@ Subscript and superscript marks import from DOCX and render in the editor, but a
 
 | | Import | Editor | Export |
 | --- | --- | --- | --- |
-| Subscript | Supported | Supported via ConvertKit | Not supported |
-| Superscript | Supported | Supported via ConvertKit | Not supported |
+| Subscript | Supported | Supported via ConvertKit | Supported |
+| Superscript | Supported | Supported via ConvertKit | Supported |
 
 ## Import
 
@@ -68,12 +68,13 @@ ConvertKit.configure({
 
 ## Export
 
-Neither the [editor extension](/conversion/export/docx/editor-extension) nor the [REST API](/conversion/export/docx/rest-api) exports subscript or superscript marks.
+Both the [editor extension](/conversion/export/docx/editor-extension) and the [REST API](/conversion/export/docx/rest-api) export subscript and superscript marks back to DOCX run properties:
 
-<Callout title="Subscript and superscript are not exported" variant="danger">
-  The DOCX export converter does not handle `subscript` or `superscript` marks. They are not converted during export. Content like H₂O will appear as plain H2O in the exported document. This affects chemical formulas, mathematical notation, footnote references, and any other use of sub/superscript text.
-</Callout>
+| Tiptap mark | Word element |
+| --- | --- |
+| `subscript` | `<w:vertAlign val="subscript">` |
+| `superscript` | `<w:vertAlign val="superscript">` |
 
-Subscript and superscript applied in the editor work correctly for display. The limitation only affects export to DOCX.
+Chemical formulas (H₂O, CO₂), mathematical notation (x², E=mc²), and footnote references all round-trip without loss.
 
-Subscript and superscript within math or LaTeX expressions follow a separate code path (using OOXML math elements `m:sSub` and `m:sSup`) and are not affected by this limitation.
+Subscript and superscript within math or LaTeX expressions follow a separate code path (using OOXML math elements `m:sSub` and `m:sSup`).

--- a/src/content/conversion/export/_shared/_element-overrides-rest-api.mdx
+++ b/src/content/conversion/export/_shared/_element-overrides-rest-api.mdx
@@ -1,0 +1,81 @@
+import { Callout } from '@/components/ui/Callout'
+
+The five element override objects let you tune how individual DOCX elements
+(tables, paragraphs, text runs, table cells, images) are rendered. Each
+override is forwarded to the underlying DOCX conversion library as a base
+default; per-node values from the document still win where they are computed.
+
+<Callout title="No deep merging" variant="info">
+    Nested objects inside an override (for example `borders`, `margins`, `transformation`) are **replaced entirely**, not deep-merged. When customizing one side of a border, provide every side you need so undefined values do not slip through.
+</Callout>
+
+#### `tableOverrides`
+
+Defaults applied to every table. Most useful properties:
+
+| Property               | Type      | Description                                                                                                              |
+| ---------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `borders`              | `Object`  | Per-side definitions for `top`, `bottom`, `left`, `right`, `insideHorizontal`, `insideVertical`. Each accepts `{ style, size, color }`. |
+| `margins`              | `Object`  | Default cell margins `{ top, bottom, left, right }` (twentieths of a point).                                              |
+| `width`                | `Object`  | Table width `{ size, type }` where `type` is `"pct"`, `"dxa"`, or `"auto"`.                                              |
+| `layout`               | `string`  | `"fixed"` or `"autofit"`.                                                                                                |
+| `alignment`            | `string`  | `"left" \| "center" \| "right" \| "start" \| "end"`.                                                                     |
+| `cantSplit`            | `boolean` | Prevent the table from splitting across pages.                                                                           |
+| `visuallyRightToLeft`  | `boolean` | Render the table right-to-left.                                                                                          |
+
+#### `paragraphOverrides`
+
+Defaults applied to every paragraph. Most useful properties:
+
+| Property            | Type      | Description                                                                                              |
+| ------------------- | --------- | -------------------------------------------------------------------------------------------------------- |
+| `spacing`           | `Object`  | `{ before, after, line, lineRule }` in twentieths of a point. `line` is overwritten by computed line height. |
+| `alignment`         | `string`  | `"left" \| "center" \| "right" \| "justified" \| "start" \| "end"`.                                      |
+| `indent`            | `Object`  | `{ left, right, firstLine, hanging, start, end }` in twentieths of a point.                              |
+| `keepNext`          | `boolean` | Keep this paragraph with the next one.                                                                   |
+| `keepLines`         | `boolean` | Keep all lines in the paragraph together.                                                                |
+| `pageBreakBefore`   | `boolean` | Insert a page break before the paragraph.                                                                |
+| `bidirectional`     | `boolean` | Render paragraph right-to-left.                                                                          |
+| `style`             | `string`  | Reference to a paragraph style id defined in `styleOverrides`.                                           |
+
+#### `textRunOverrides`
+
+Defaults applied to every text run. Per-mark formatting (bold, italic, color,
+…) still overrides these values. Most useful properties:
+
+| Property        | Type      | Description                                                            |
+| --------------- | --------- | ---------------------------------------------------------------------- |
+| `font`          | `string`  | Font family name.                                                      |
+| `size`          | `number`  | Font size in half-points (`24` = 12pt).                                |
+| `bold`          | `boolean` | Render bold by default.                                                |
+| `italics`       | `boolean` | Render italic by default.                                              |
+| `underline`     | `Object`  | `{ type, color }` — e.g. `{ type: "single", color: "auto" }`.          |
+| `strike`        | `boolean` | Strikethrough.                                                         |
+| `color`         | `string`  | Hex color without the leading `#` (`"FF0000"`).                        |
+| `highlight`     | `string`  | Predefined highlight color name (`"yellow"`, `"green"`, …).            |
+| `superScript`   | `boolean` | Render as superscript.                                                 |
+| `subScript`     | `boolean` | Render as subscript.                                                   |
+
+#### `tableCellOverrides`
+
+Defaults applied to every table cell. Most useful properties:
+
+| Property        | Type      | Description                                                              |
+| --------------- | --------- | ------------------------------------------------------------------------ |
+| `shading`       | `Object`  | `{ fill, type, color }` — e.g. `{ fill: "F0F0F0", type: "clear" }`.       |
+| `verticalAlign` | `string`  | `"top" \| "center" \| "bottom"`.                                         |
+| `borders`       | `Object`  | Per-side cell border definitions, same shape as `tableOverrides.borders`. |
+| `margins`       | `Object`  | Cell padding `{ top, bottom, left, right }` in twentieths of a point.     |
+| `width`         | `Object`  | Cell width `{ size, type }`.                                             |
+
+#### `imageOverrides`
+
+Defaults applied to every image. Image dimensions computed from the document
+(intrinsic size or user-resized values) still win where present. Most useful
+properties:
+
+| Property         | Type      | Description                                                                       |
+| ---------------- | --------- | --------------------------------------------------------------------------------- |
+| `transformation` | `Object`  | `{ width, height, rotation?, flip? }` — pixels at 96 dpi.                          |
+| `altText`        | `Object`  | `{ title, description, name }`.                                                   |
+| `floating`       | `Object`  | Floating positioning options (anchor, alignment, offset, wrap).                    |

--- a/src/content/conversion/export/doc/rest-api.mdx
+++ b/src/content/conversion/export/doc/rest-api.mdx
@@ -14,6 +14,7 @@ meta:
 import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+import ElementOverridesRestApi from '../_shared/_element-overrides-rest-api.mdx'
 
 <EnterpriseCalloutAuto variant="doc" renderMode="sidebar" disableWaitlist />
 
@@ -69,15 +70,20 @@ curl --output document.doc -X POST "https://api.tiptap.dev/v2/convert/export/doc
 
 ### Body
 
-| Name             | Type     | Description                        | Default     |
-| ---------------- | -------- | ---------------------------------- | ----------- |
-| `doc`            | `String` | Tiptap JSON document as a string   | `N/A`       |
-| `exportType`     | `string` | The expected export type           | `blob`      |
-| `styleOverrides` | `Object` | Style overrides                    | `{}`        |
-| `pageSize`       | `Object` | Page size configuration            | `undefined` |
-| `pageMargins`    | `Object` | Page margins configuration         | `undefined` |
-| `headers`        | `Object` | Page header configuration          | `undefined` |
-| `footers`        | `Object` | Page footer configuration          | `undefined` |
+| Name                 | Type     | Description                                                            | Default     |
+| -------------------- | -------- | ---------------------------------------------------------------------- | ----------- |
+| `doc`                | `String` | Tiptap JSON document as a string                                       | `N/A`       |
+| `exportType`         | `string` | The expected export type                                               | `blob`      |
+| `styleOverrides`     | `Object` | Style overrides                                                        | `{}`        |
+| `pageSize`           | `Object` | Page size configuration                                                | `undefined` |
+| `pageMargins`        | `Object` | Page margins configuration                                             | `undefined` |
+| `headers`            | `Object` | Page header configuration                                              | `undefined` |
+| `footers`            | `Object` | Page footer configuration                                              | `undefined` |
+| `tableOverrides`     | `Object` | Table-level rendering overrides forwarded to the DOCX step             | `undefined` |
+| `paragraphOverrides` | `Object` | Paragraph-level rendering overrides forwarded to the DOCX step         | `undefined` |
+| `textRunOverrides`   | `Object` | Text run rendering overrides forwarded to the DOCX step                | `undefined` |
+| `tableCellOverrides` | `Object` | Table cell rendering overrides forwarded to the DOCX step              | `undefined` |
+| `imageOverrides`     | `Object` | Image rendering overrides forwarded to the DOCX step                   | `undefined` |
 
 #### Page Size Configuration
 
@@ -130,6 +136,33 @@ The `footers` object allows you to customize the footers of your exported DOC do
 <Callout title="Plain text vs. Tiptap JSONContent">
     Each footer value can be either a **plain text string** (produces a simple unstyled footer) or a **stringified Tiptap JSONContent** object (enables rich formatting such as bold, italic, links, etc.). When passing JSONContent, stringify the object with `JSON.stringify()` before sending it in the request body.
 </Callout>
+
+### Element Overrides
+
+DOC generation goes through the DOCX pipeline, so the same five element
+overrides accepted by `/export/docx` also apply here when sending Tiptap JSON.
+They have **no effect** when uploading a pre-built DOCX via `docxFile`.
+
+<ElementOverridesRestApi />
+
+#### Example cURL combining multiple element overrides
+
+```bash
+curl --output document.doc -X POST "https://api.tiptap.dev/v2/convert/export/doc" \
+    -H "Authorization: Bearer YOUR_TOKEN" \
+    -H "X-App-Id: YOUR_APP_ID" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "doc": "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"DOC with element-level overrides\"}]}]}",
+      "paragraphOverrides": {
+        "spacing": { "before": 200, "after": 200 }
+      },
+      "textRunOverrides": {
+        "font": "Arial",
+        "size": 24
+      }
+    }'
+```
 
 ### Example with custom page layout
 

--- a/src/content/conversion/export/docx/editor-extension.mdx
+++ b/src/content/conversion/export/docx/editor-extension.mdx
@@ -305,7 +305,7 @@ The DOCX export automatically respects node-level attributes set by the editor, 
 
 ## What not to expect
 
-- **Round-trip identity.** Importing a DOCX, editing it, and exporting it back is not byte-identical. A handful of attributes (subscript/superscript marks, paragraph line-height) are extracted on import but not written on export today. See the [feature support matrix](/conversion/getting-started/feature-support-matrix) for the full list.
+- **Round-trip identity.** Importing a DOCX, editing it, and exporting it back is not byte-identical. A handful of attributes (paragraph line-height, tab stops) are extracted on import but not written on export today. See the [feature support matrix](/conversion/getting-started/feature-support-matrix) for the full list.
 - **Pixel-perfect Word match.** We aim for visually faithful round-trips on the supported feature set; absolute parity with Word's rendering engine is out of scope.
 - **Page layout from the editor.** DOCX export preserves headers, footers, and page-format settings you configure on the export options. It does not infer page boundaries from on-screen pagination — pair with the [Pages extension](/pages/getting-started/overview) when you need pagination-aware exports.
 

--- a/src/content/conversion/export/docx/rest-api.mdx
+++ b/src/content/conversion/export/docx/rest-api.mdx
@@ -14,6 +14,7 @@ meta:
 import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+import ElementOverridesRestApi from '../_shared/_element-overrides-rest-api.mdx'
 
 <EnterpriseCalloutAuto variant="docx" renderMode="sidebar" disableWaitlist />
 
@@ -28,7 +29,7 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
 The DOCX export API converts Tiptap JSON documents into `.docx` (Microsoft Word) files. It uses the same conversion library as the [editor extension](/conversion/export/docx/editor-extension) and produces equivalent DOCX output for standard content.
 
-The REST API supports [style overrides](/conversion/export/docx/styles), page size and margins, and headers/footers. It does not support custom node rendering, element overrides (`paragraphOverrides`, `textRunOverrides`, etc.), or any option that requires JavaScript functions. If you need those capabilities, use the [editor extension](/conversion/export/docx/editor-extension), which also works server-side.
+The REST API supports [style overrides](/conversion/export/docx/styles), page size and margins, headers/footers, and element-level overrides (`tableOverrides`, `paragraphOverrides`, `textRunOverrides`, `tableCellOverrides`, `imageOverrides`). It does not support custom node rendering or any option that requires JavaScript functions. If you need those capabilities, use the [editor extension](/conversion/export/docx/editor-extension), which also works server-side.
 
 <Callout title="Review the postman collection" variant="hint">
     You can also experiment with the Document Conversion API by heading over to our [Postman
@@ -44,7 +45,7 @@ The `/v2/convert/export/docx` endpoint converts Tiptap documents into `DOCX` for
 
 
 <Callout title="Export customization support" variant="info">
-    The `/v2/convert/export/docx` endpoint does not support custom node conversions or element overrides (`paragraphOverrides`, `textRunOverrides`, `tableOverrides`, `tableCellOverrides`, `imageOverrides`) as these require JavaScript functions that cannot be serialized. It does support [custom style overrides](/conversion/export/docx/styles), page size/margins, and headers/footers. If you need custom node conversions or element overrides, use the [editor extension](/conversion/export/docx/editor-extension) or the [server side export guide](/conversion/export/docx/editor-extension#server-side-export).
+    The `/v2/convert/export/docx` endpoint accepts [style overrides](/conversion/export/docx/styles), page size/margins, headers/footers, and the five element-level overrides (`tableOverrides`, `paragraphOverrides`, `textRunOverrides`, `tableCellOverrides`, `imageOverrides`). It does not support custom node conversions, since those require JavaScript functions that cannot be serialized. For custom node conversions, use the [editor extension](/conversion/export/docx/editor-extension) or the [server side export guide](/conversion/export/docx/editor-extension#server-side-export).
 </Callout>
 
 ### Example (cURL)
@@ -73,15 +74,20 @@ curl --output example.docx -X POST "https://api.tiptap.dev/v2/convert/export/doc
 
 ### Body
 
-| Name                     | Type     | Description               | Default     |
-| ------------------------ | -------- | --------------------------|-------------|
-| `doc`                    | `String` | Tiptap's JSON             | `N/A`       |
-| `exportType`             | `string` | The expected export type  | `blob`      |
-| `styleOverrides`         | `Object` | Style overrides           | `{}`        |
-| `pageSize`               | `Object` | Page size configuration   | `undefined` |
-| `pageMargins`            | `Object` | Page margins configuration| `undefined` |
-| `headers`                | `Object` | Page header configuration | `undefined` |
-| `footers`                | `Object` | Page footer configuration | `undefined` |
+| Name                     | Type     | Description                                                        | Default     |
+| ------------------------ | -------- | ------------------------------------------------------------------ | ----------- |
+| `doc`                    | `String` | Tiptap's JSON                                                      | `N/A`       |
+| `exportType`             | `string` | The expected export type                                           | `blob`      |
+| `styleOverrides`         | `Object` | Style overrides                                                    | `{}`        |
+| `pageSize`               | `Object` | Page size configuration                                            | `undefined` |
+| `pageMargins`            | `Object` | Page margins configuration                                         | `undefined` |
+| `headers`                | `Object` | Page header configuration                                          | `undefined` |
+| `footers`                | `Object` | Page footer configuration                                          | `undefined` |
+| `tableOverrides`         | `Object` | Table-level rendering overrides                                    | `undefined` |
+| `paragraphOverrides`     | `Object` | Paragraph-level rendering overrides                                | `undefined` |
+| `textRunOverrides`       | `Object` | Text run rendering overrides                                       | `undefined` |
+| `tableCellOverrides`     | `Object` | Table cell rendering overrides                                     | `undefined` |
+| `imageOverrides`         | `Object` | Image rendering overrides                                          | `undefined` |
 
 #### Page Size Configuration
 
@@ -189,6 +195,46 @@ curl --output example.docx -X POST "https://api.tiptap.dev/v2/convert/export/doc
       "doc": "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Document with custom footers\"}]}]}",
       "exportType": "blob",
       "footers": {"evenAndOddFooters": true, "default": "Default Footer", "first": "First Page Footer", "even": "Even Page Footer"}
+    }'
+```
+
+### Element Overrides
+
+<ElementOverridesRestApi />
+
+#### Example cURL combining multiple element overrides
+
+```bash
+curl --output example.docx -X POST "https://api.tiptap.dev/v2/convert/export/docx" \
+    -H "Authorization: Bearer YOUR_TOKEN" \
+    -H "X-App-Id: YOUR_APP_ID" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "doc": "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Doc with element-level overrides\"}]}]}",
+      "tableOverrides": {
+        "borders": {
+          "top": { "style": "none" },
+          "bottom": { "style": "none" },
+          "left": { "style": "none" },
+          "right": { "style": "none" },
+          "insideHorizontal": { "style": "none" },
+          "insideVertical": { "style": "none" }
+        }
+      },
+      "paragraphOverrides": {
+        "spacing": { "before": 200, "after": 200 }
+      },
+      "textRunOverrides": {
+        "font": "Arial",
+        "size": 24
+      },
+      "tableCellOverrides": {
+        "shading": { "fill": "F0F0F0", "type": "clear" },
+        "verticalAlign": "center"
+      },
+      "imageOverrides": {
+        "transformation": { "width": 400, "height": 300 }
+      }
     }'
 ```
 

--- a/src/content/conversion/export/epub/rest-api.mdx
+++ b/src/content/conversion/export/epub/rest-api.mdx
@@ -14,6 +14,7 @@ meta:
 import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+import ElementOverridesRestApi from '../_shared/_element-overrides-rest-api.mdx'
 
 <EnterpriseCalloutAuto variant="epub" renderMode="sidebar" disableWaitlist />
 
@@ -65,15 +66,20 @@ curl --output document.epub -X POST "https://api.tiptap.dev/v2/convert/export/ep
 
 ### Body
 
-| Name             | Type     | Description                        | Default     |
-| ---------------- | -------- | ---------------------------------- | ----------- |
-| `doc`            | `String` | Tiptap JSON document as a string   | `N/A`       |
-| `exportType`     | `string` | The expected export type           | `blob`      |
-| `styleOverrides` | `Object` | Style overrides                    | `{}`        |
-| `pageSize`       | `Object` | Page size configuration            | `undefined` |
-| `pageMargins`    | `Object` | Page margins configuration         | `undefined` |
-| `headers`        | `Object` | Page header configuration          | `undefined` |
-| `footers`        | `Object` | Page footer configuration          | `undefined` |
+| Name                 | Type     | Description                                                            | Default     |
+| -------------------- | -------- | ---------------------------------------------------------------------- | ----------- |
+| `doc`                | `String` | Tiptap JSON document as a string                                       | `N/A`       |
+| `exportType`         | `string` | The expected export type                                               | `blob`      |
+| `styleOverrides`     | `Object` | Style overrides                                                        | `{}`        |
+| `pageSize`           | `Object` | Page size configuration                                                | `undefined` |
+| `pageMargins`        | `Object` | Page margins configuration                                             | `undefined` |
+| `headers`            | `Object` | Page header configuration                                              | `undefined` |
+| `footers`            | `Object` | Page footer configuration                                              | `undefined` |
+| `tableOverrides`     | `Object` | Table-level rendering overrides forwarded to the DOCX step             | `undefined` |
+| `paragraphOverrides` | `Object` | Paragraph-level rendering overrides forwarded to the DOCX step         | `undefined` |
+| `textRunOverrides`   | `Object` | Text run rendering overrides forwarded to the DOCX step                | `undefined` |
+| `tableCellOverrides` | `Object` | Table cell rendering overrides forwarded to the DOCX step              | `undefined` |
+| `imageOverrides`     | `Object` | Image rendering overrides forwarded to the DOCX step                   | `undefined` |
 
 #### Page Size Configuration
 
@@ -126,6 +132,33 @@ The `footers` object allows you to customize the footers of your exported EPUB d
 <Callout title="Plain text vs. Tiptap JSONContent">
     Each footer value can be either a **plain text string** (produces a simple unstyled footer) or a **stringified Tiptap JSONContent** object (enables rich formatting such as bold, italic, links, etc.). When passing JSONContent, stringify the object with `JSON.stringify()` before sending it in the request body.
 </Callout>
+
+### Element Overrides
+
+EPUB generation goes through the DOCX pipeline, so the same five element
+overrides accepted by `/export/docx` also apply here when sending Tiptap JSON.
+They have **no effect** when uploading a pre-built DOCX via `docxFile`.
+
+<ElementOverridesRestApi />
+
+#### Example cURL combining multiple element overrides
+
+```bash
+curl --output document.epub -X POST "https://api.tiptap.dev/v2/convert/export/epub" \
+    -H "Authorization: Bearer YOUR_TOKEN" \
+    -H "X-App-Id: YOUR_APP_ID" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "doc": "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"EPUB with element-level overrides\"}]}]}",
+      "paragraphOverrides": {
+        "spacing": { "before": 200, "after": 200 }
+      },
+      "textRunOverrides": {
+        "font": "Arial",
+        "size": 24
+      }
+    }'
+```
 
 ### Example with custom page layout
 

--- a/src/content/conversion/export/odt/rest-api.mdx
+++ b/src/content/conversion/export/odt/rest-api.mdx
@@ -14,6 +14,7 @@ meta:
 import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+import ElementOverridesRestApi from '../_shared/_element-overrides-rest-api.mdx'
 
 <EnterpriseCalloutAuto variant="odt" renderMode="sidebar" disableWaitlist />
 
@@ -65,15 +66,20 @@ curl --output document.odt -X POST "https://api.tiptap.dev/v2/convert/export/odt
 
 ### Body
 
-| Name             | Type     | Description                        | Default     |
-| ---------------- | -------- | ---------------------------------- | ----------- |
-| `doc`            | `String` | Tiptap JSON document as a string   | `N/A`       |
-| `exportType`     | `string` | The expected export type           | `blob`      |
-| `styleOverrides` | `Object` | Style overrides                    | `{}`        |
-| `pageSize`       | `Object` | Page size configuration            | `undefined` |
-| `pageMargins`    | `Object` | Page margins configuration         | `undefined` |
-| `headers`        | `Object` | Page header configuration          | `undefined` |
-| `footers`        | `Object` | Page footer configuration          | `undefined` |
+| Name                 | Type     | Description                                                            | Default     |
+| -------------------- | -------- | ---------------------------------------------------------------------- | ----------- |
+| `doc`                | `String` | Tiptap JSON document as a string                                       | `N/A`       |
+| `exportType`         | `string` | The expected export type                                               | `blob`      |
+| `styleOverrides`     | `Object` | Style overrides                                                        | `{}`        |
+| `pageSize`           | `Object` | Page size configuration                                                | `undefined` |
+| `pageMargins`        | `Object` | Page margins configuration                                             | `undefined` |
+| `headers`            | `Object` | Page header configuration                                              | `undefined` |
+| `footers`            | `Object` | Page footer configuration                                              | `undefined` |
+| `tableOverrides`     | `Object` | Table-level rendering overrides forwarded to the DOCX step             | `undefined` |
+| `paragraphOverrides` | `Object` | Paragraph-level rendering overrides forwarded to the DOCX step         | `undefined` |
+| `textRunOverrides`   | `Object` | Text run rendering overrides forwarded to the DOCX step                | `undefined` |
+| `tableCellOverrides` | `Object` | Table cell rendering overrides forwarded to the DOCX step              | `undefined` |
+| `imageOverrides`     | `Object` | Image rendering overrides forwarded to the DOCX step                   | `undefined` |
 
 #### Page Size Configuration
 
@@ -126,6 +132,33 @@ The `footers` object allows you to customize the footers of your exported ODT do
 <Callout title="Plain text vs. Tiptap JSONContent">
     Each footer value can be either a **plain text string** (produces a simple unstyled footer) or a **stringified Tiptap JSONContent** object (enables rich formatting such as bold, italic, links, etc.). When passing JSONContent, stringify the object with `JSON.stringify()` before sending it in the request body.
 </Callout>
+
+### Element Overrides
+
+ODT generation goes through the DOCX pipeline, so the same five element
+overrides accepted by `/export/docx` also apply here when sending Tiptap JSON.
+They have **no effect** when uploading a pre-built DOCX via `docxFile`.
+
+<ElementOverridesRestApi />
+
+#### Example cURL combining multiple element overrides
+
+```bash
+curl --output document.odt -X POST "https://api.tiptap.dev/v2/convert/export/odt" \
+    -H "Authorization: Bearer YOUR_TOKEN" \
+    -H "X-App-Id: YOUR_APP_ID" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "doc": "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"ODT with element-level overrides\"}]}]}",
+      "paragraphOverrides": {
+        "spacing": { "before": 200, "after": 200 }
+      },
+      "textRunOverrides": {
+        "font": "Arial",
+        "size": 24
+      }
+    }'
+```
 
 ### Example with custom page layout
 

--- a/src/content/conversion/export/pdf/rest-api.mdx
+++ b/src/content/conversion/export/pdf/rest-api.mdx
@@ -14,6 +14,7 @@ meta:
 import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+import ElementOverridesRestApi from '../_shared/_element-overrides-rest-api.mdx'
 
 <EnterpriseCalloutAuto variant="pdf" renderMode="sidebar" disableWaitlist />
 
@@ -65,16 +66,21 @@ curl --output document.pdf -X POST "https://api.tiptap.dev/v2/convert/export/pdf
 
 ### Body
 
-| Name             | Type     | Description                        | Default     |
-| ---------------- | -------- | ---------------------------------- | ----------- |
-| `doc`            | `String` | Tiptap JSON document as a string   | `N/A`       |
-| `exportType`     | `string` | The expected export type           | `blob`      |
-| `styleOverrides` | `Object` | Style overrides                    | `{}`        |
-| `pageSize`       | `Object` | Page size configuration            | `undefined` |
-| `pageMargins`    | `Object` | Page margins configuration         | `undefined` |
-| `headers`        | `Object` | Page header configuration          | `undefined` |
-| `footers`        | `Object` | Page footer configuration          | `undefined` |
-| `customFonts`    | `Array`  | Custom font files to provision (on-premises only) | `undefined` |
+| Name                 | Type     | Description                                                            | Default     |
+| -------------------- | -------- | ---------------------------------------------------------------------- | ----------- |
+| `doc`                | `String` | Tiptap JSON document as a string                                       | `N/A`       |
+| `exportType`         | `string` | The expected export type                                               | `blob`      |
+| `styleOverrides`     | `Object` | Style overrides                                                        | `{}`        |
+| `pageSize`           | `Object` | Page size configuration                                                | `undefined` |
+| `pageMargins`        | `Object` | Page margins configuration                                             | `undefined` |
+| `headers`            | `Object` | Page header configuration                                              | `undefined` |
+| `footers`            | `Object` | Page footer configuration                                              | `undefined` |
+| `customFonts`        | `Array`  | Custom font files to provision (on-premises only)                      | `undefined` |
+| `tableOverrides`     | `Object` | Table-level rendering overrides forwarded to the DOCX step             | `undefined` |
+| `paragraphOverrides` | `Object` | Paragraph-level rendering overrides forwarded to the DOCX step         | `undefined` |
+| `textRunOverrides`   | `Object` | Text run rendering overrides forwarded to the DOCX step                | `undefined` |
+| `tableCellOverrides` | `Object` | Table cell rendering overrides forwarded to the DOCX step              | `undefined` |
+| `imageOverrides`     | `Object` | Image rendering overrides forwarded to the DOCX step                   | `undefined` |
 
 #### Page Size Configuration
 
@@ -183,6 +189,33 @@ curl --output document.pdf -X POST "https://api.tiptap.dev/v2/convert/export/pdf
           "fontFamily": "Custom Font"
         }
       ]
+    }'
+```
+
+### Element Overrides
+
+PDF generation goes through the DOCX pipeline, so the same five element
+overrides accepted by `/export/docx` also apply here when sending Tiptap JSON.
+They have **no effect** when uploading a pre-built DOCX via `docxFile`.
+
+<ElementOverridesRestApi />
+
+#### Example cURL combining multiple element overrides
+
+```bash
+curl --output document.pdf -X POST "https://api.tiptap.dev/v2/convert/export/pdf" \
+    -H "Authorization: Bearer YOUR_TOKEN" \
+    -H "X-App-Id: YOUR_APP_ID" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "doc": "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"PDF with element-level overrides\"}]}]}",
+      "paragraphOverrides": {
+        "spacing": { "before": 200, "after": 200 }
+      },
+      "textRunOverrides": {
+        "font": "Arial",
+        "size": 24
+      }
     }'
 ```
 

--- a/src/content/conversion/getting-started/feature-support-matrix.mdx
+++ b/src/content/conversion/getting-started/feature-support-matrix.mdx
@@ -16,7 +16,7 @@ The tables below show how each document feature behaves across the three stages 
 2. **Editor** renders that JSON in the browser. Each node and mark type requires a matching Tiptap extension to display correctly.
 3. **Export** converts the editor's content back into a DOCX file.
 
-A feature can be supported at one stage and unsupported at another. For example, subscript text is imported and rendered correctly, but the export extension does not yet write it back to DOCX.
+A feature can be supported at one stage and unsupported at another. For example, tab characters are imported and rendered in the editor, but the export extension does not yet write them back to DOCX.
 
 Import and export each have two integration paths: an [editor extension](/conversion/import/docx/editor-extension) and a [REST API](/conversion/import/docx/rest-api). For most features, both paths produce identical results. Where they differ (footnotes, headers/footers, export customization), the relevant install pages document the specifics.
 
@@ -38,8 +38,8 @@ These tables describe the DOCX pipeline specifically because DOCX is the referen
 | [Italic](/conversion/content-types/text-and-formatting/bold-italic-underline-strike) | ✓ | ✓ | ✓ |
 | [Underline](/conversion/content-types/text-and-formatting/bold-italic-underline-strike) | ✓ | ✓ | ✓ |
 | [Strikethrough](/conversion/content-types/text-and-formatting/bold-italic-underline-strike) | ✓ | ✓ | ✓ |
-| [Subscript](/conversion/content-types/text-and-formatting/subscript-superscript) | ✓ | ✓ | ✕ |
-| [Superscript](/conversion/content-types/text-and-formatting/subscript-superscript) | ✓ | ✓ | ✕ |
+| [Subscript](/conversion/content-types/text-and-formatting/subscript-superscript) | ✓ | ✓ | ✓ |
+| [Superscript](/conversion/content-types/text-and-formatting/subscript-superscript) | ✓ | ✓ | ✓ |
 | Inline code | ✓ | ✓ | ✓ |
 | [Text color](/conversion/content-types/text-and-formatting/text-color-highlight) | ✓ | ✓ | ✓ |
 | [Highlight](/conversion/content-types/text-and-formatting/text-color-highlight) | ✓ | ✓ | ✓ |


### PR DESCRIPTION
This pull request updates the documentation for DOCX and DOC export APIs, focusing on two major areas: (1) improved support and clearer documentation for subscript and superscript round-tripping, and (2) expanded and clarified documentation for the five element-level override objects (`tableOverrides`, `paragraphOverrides`, `textRunOverrides`, `tableCellOverrides`, `imageOverrides`) now supported by the REST APIs. The changes include corrections to feature matrices, new shared documentation components, and updated usage examples.

**DOCX/Tiptap round-trip and feature support:**

- Updated the documentation to clarify that subscript and superscript marks now round-trip fully between DOCX and Tiptap, including import, editor rendering, and export. The feature matrix and explanatory text have been revised to reflect this improvement. [[1]](diffhunk://#diff-34138824a0a9f000c78dc414ea372c6d4e71be497c6be2e6334764b189174fd6L7-R13) [[2]](diffhunk://#diff-34138824a0a9f000c78dc414ea372c6d4e71be497c6be2e6334764b189174fd6L24-R25) [[3]](diffhunk://#diff-34138824a0a9f000c78dc414ea372c6d4e71be497c6be2e6334764b189174fd6L71-R80) [[4]](diffhunk://#diff-bee33ecb645a660ab945f7a54b25bd960b666dacbfcc080672be3078cd1b016dL308-R308)

**REST API element-level override support:**

- Added and documented support for five element-level override objects (`tableOverrides`, `paragraphOverrides`, `textRunOverrides`, `tableCellOverrides`, `imageOverrides`) in both the DOCX and DOC REST APIs. The documentation now explains their structure, usage, and merging behavior, with new example cURL requests and a shared documentation component for consistency. [[1]](diffhunk://#diff-5ad30451be9e07d1f3256bdc391163450be54e362f09d40bef31ddd7b4b6993dR1-R81) [[2]](diffhunk://#diff-90f23440e34d5eb9594b6f05f9eef78226bc9890af2d1096133188c203df2a5dR17) [[3]](diffhunk://#diff-90f23440e34d5eb9594b6f05f9eef78226bc9890af2d1096133188c203df2a5dL73-R86) [[4]](diffhunk://#diff-90f23440e34d5eb9594b6f05f9eef78226bc9890af2d1096133188c203df2a5dR140-R166) [[5]](diffhunk://#diff-ecd33df1d0541a5766bc2e04147dd045b5010851ed4413332fd67abb88bb6fbbR17) [[6]](diffhunk://#diff-ecd33df1d0541a5766bc2e04147dd045b5010851ed4413332fd67abb88bb6fbbL31-R32) [[7]](diffhunk://#diff-ecd33df1d0541a5766bc2e04147dd045b5010851ed4413332fd67abb88bb6fbbL47-R48) [[8]](diffhunk://#diff-ecd33df1d0541a5766bc2e04147dd045b5010851ed4413332fd67abb88bb6fbbL77-R90) [[9]](diffhunk://#diff-ecd33df1d0541a5766bc2e04147dd045b5010851ed4413332fd67abb88bb6fbbR201-R240) [[10]](diffhunk://#diff-0fd8755fd21f2eece63ba1dbe235c6d1dfd7189d4268f9a0f23bcbaae45ba9caR17)

**Other documentation improvements:**

- Updated descriptions and tables to clarify the default values and effects of the new override options in the API request bodies. [[1]](diffhunk://#diff-90f23440e34d5eb9594b6f05f9eef78226bc9890af2d1096133188c203df2a5dL73-R86) [[2]](diffhunk://#diff-ecd33df1d0541a5766bc2e04147dd045b5010851ed4413332fd67abb88bb6fbbL77-R90)
- Improved the accuracy of the "What not to expect" section by removing subscript/superscript from the list of unsupported round-trip features.

These changes ensure the documentation accurately reflects current capabilities and provides clear guidance for customizing DOCX/DOC exports.