### PR TITLE
Update broken documentation links and format code

### DIFF
--- a/src/content/conversion/content-types/page-layout/headers-footers.mdx
+++ b/src/content/conversion/content-types/page-layout/headers-footers.mdx
@@ -15,54 +15,57 @@ Headers and footers in Word carry repeated content at the top and bottom of ever
 ## What you need
 
 - **Extensions:** `@tiptap-pro/extension-import-docx` for import, `@tiptap-pro/extension-export-docx` for export
-- **For editor rendering:** [`Pages`](/pages/getting-started/overview) extension for header/footer editing and auto-applying imported headers/footers
+- **For editor rendering:** [`Pages`](/editor/extensions/functionality/pages) extension for header/footer editing and auto-applying imported headers/footers
 
 ## Support overview
 
-| Feature | Import | Editor | Export |
-| --- | --- | --- | --- |
-| Default header/footer | Supported | Supported ([Pages](/pages/getting-started/overview)) | Supported |
-| Different first page | Supported | Supported | Supported |
-| Different odd/even pages | Supported | Supported | Supported |
-| Page number placeholders | Not converted from DOCX (PAGE/NUMPAGES fields import as their cached display value, e.g. the literal text `1`) | Supported (`{page}`, `{total}` substituted at render time by the Pages extension) | Supported. `{page}` and `{total}` tokens in plain-text headers and footers are emitted as live DOCX `PAGE` / `NUMPAGES` fields, so Word renders the actual page number and total page count. |
-| Rich text in headers/footers | Supported | Supported | Supported |
+| Feature                      | Import                                                                                                         | Editor                                                                            | Export                                                                                                                                                                                       |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Default header/footer        | Supported                                                                                                      | Supported ([Pages](/editor/extensions/functionality/pages))                       | Supported                                                                                                                                                                                    |
+| Different first page         | Supported                                                                                                      | Supported                                                                         | Supported                                                                                                                                                                                    |
+| Different odd/even pages     | Supported                                                                                                      | Supported                                                                         | Supported                                                                                                                                                                                    |
+| Page number placeholders     | Not converted from DOCX (PAGE/NUMPAGES fields import as their cached display value, e.g. the literal text `1`) | Supported (`{page}`, `{total}` substituted at render time by the Pages extension) | Supported. `{page}` and `{total}` tokens in plain-text headers and footers are emitted as live DOCX `PAGE` / `NUMPAGES` fields, so Word renders the actual page number and total page count. |
+| Rich text in headers/footers | Supported                                                                                                      | Supported                                                                         | Supported                                                                                                                                                                                    |
 
 ## Import
 
-Import headers and footers using the [editor extension](/conversion/import/docx/editor-extension) or the [REST API](/conversion/import/docx/rest-api). Both return identical header/footer data. The extension additionally auto-applies headers and footers to the editor when the [Pages extension](/pages/getting-started/overview) is installed. The REST API returns the raw data for you to handle.
+Import headers and footers using the [editor extension](/conversion/import/docx/editor-extension) or the [REST API](/conversion/import/docx/rest-api). Both return identical header/footer data. The extension additionally auto-applies headers and footers to the editor when the [Pages extension](/editor/extensions/functionality/pages) is installed. The REST API returns the raw data for you to handle.
 
 The DOCX import service extracts header and footer content from the source document. The response includes up to six fields with content (plus two placeholder fields that are always null) covering default, first-page, and odd/even variants for both headers and footers.
 
-When using the editor extension with the [Pages extension](/pages/getting-started/overview) installed, imported headers and footers are automatically applied to the editor via `setEditorContent()`. Without the Pages extension, the header/footer data is still available in the `onImport` callback for manual handling.
+When using the editor extension with the [Pages extension](/editor/extensions/functionality/pages) installed, imported headers and footers are automatically applied to the editor via `setEditorContent()`. Without the Pages extension, the header/footer data is still available in the `onImport` callback for manual handling.
 
 ### Available fields
 
-| Field | Description |
-| --- | --- |
-| `header` | Default header content |
-| `footer` | Default footer content |
+| Field             | Description                                                        |
+| ----------------- | ------------------------------------------------------------------ |
+| `header`          | Default header content                                             |
+| `footer`          | Default footer content                                             |
 | `headerFirstPage` | First page header (when "Different First Page" is enabled in Word) |
-| `footerFirstPage` | First page footer |
-| `headerOdd` | Always `null` (see note below) |
-| `footerOdd` | Always `null` (see note below) |
-| `headerEven` | Even page header |
-| `footerEven` | Even page footer |
+| `footerFirstPage` | First page footer                                                  |
+| `headerOdd`       | Always `null` (see note below)                                     |
+| `footerOdd`       | Always `null` (see note below)                                     |
+| `headerEven`      | Even page header                                                   |
+| `footerEven`      | Even page footer                                                   |
 
 Each field contains valid Tiptap JSON or `null` if the source document does not include that variant.
 
 <Callout variant="info" title="Odd-page headers come back in the default fields">
   Word's OOXML model uses three header types: `default`, `first`, and `even`. When "Different odd and even pages" is enabled in Word, the **default** header is what shows on odd pages. The API mirrors this:
 
-  - `header` / `footer` carry the **default** (odd-page) content.
-  - `headerEven` / `footerEven` carry the even-page content.
-  - `headerFirstPage` / `footerFirstPage` carry the first-page content.
-  - `headerOdd` / `footerOdd` are always `null`. They exist as fields in the response shape for symmetry only.
+- `header` / `footer` carry the **default** (odd-page) content.
+- `headerEven` / `footerEven` carry the even-page content.
+- `headerFirstPage` / `footerFirstPage` carry the first-page content.
+- `headerOdd` / `footerOdd` are always `null`. They exist as fields in the response shape for symmetry only.
 
-  To get the odd-page header, read `context.header` (not `context.headerOdd`). If a source document only references first-page and even-page headers without a default, no odd-page content will be present in the response: the importer can't synthesize content the source did not include.
+To get the odd-page header, read `context.header` (not `context.headerOdd`). If a source document only references first-page and even-page headers without a default, no odd-page content will be present in the response: the importer can't synthesize content the source did not include.
+
 </Callout>
 
 <Callout variant="info" title="Pages extension required for auto-application">
-  Without the Pages extension, the import extension still returns header/footer data in the callback, but it cannot apply them to the editor automatically. You can access them via the `onImport` callback and handle them in your own code.
+  Without the Pages extension, the import extension still returns header/footer data in the
+  callback, but it cannot apply them to the editor automatically. You can access them via the
+  `onImport` callback and handle them in your own code.
 </Callout>
 
 <Callout variant="warning" title="Page number fields in headers come in as static text">
@@ -71,7 +74,7 @@ Each field contains valid Tiptap JSON or `null` if the source document does not 
 
 ## Editor
 
-The [Pages extension](/pages/getting-started/overview) provides full header and footer support with paginated layout. For complete setup and configuration, see the [Page header and footer guide](/pages/core-concepts/page-header-footer).
+The [Pages extension](/editor/extensions/functionality/pages) provides full header and footer support with paginated layout. For complete setup and configuration, see the [Page header and footer guide](/pages/core-concepts/page-header-footer).
 
 The Pages extension supports three header/footer modes matching Word's behavior:
 
@@ -115,7 +118,13 @@ The export supports `default`, `first`, and `even` variants for both headers and
 Explicit header/footer options override automatic extraction from the Pages extension.
 
 <Callout variant="info" title="`{page}` and `{total}` render as live DOCX page-number fields">
-  When a plain-text header or footer contains `{page}` or `{total}`, the export converts each token to a live `PAGE` / `NUMPAGES` field on the DOCX side, so Word displays the actual current page and total page count instead of the literal token strings. This works for headers and footers auto-extracted from the Pages extension and for plain-text headers and footers passed through `headers` / `footers` options. For richer constructions (e.g. `"Page X of Y"` formatting beyond the bare tokens), you can still supply a `Docx.Header` / `Docx.Footer` instance manually with `Docx.PageNumber.CURRENT` / `Docx.PageNumber.TOTAL_PAGES`.
+  When a plain-text header or footer contains `{page}` or `{total}`, the export converts each token
+  to a live `PAGE` / `NUMPAGES` field on the DOCX side, so Word displays the actual current page and
+  total page count instead of the literal token strings. This works for headers and footers
+  auto-extracted from the Pages extension and for plain-text headers and footers passed through
+  `headers` / `footers` options. For richer constructions (e.g. `"Page X of Y"` formatting beyond
+  the bare tokens), you can still supply a `Docx.Header` / `Docx.Footer` instance manually with
+  `Docx.PageNumber.CURRENT` / `Docx.PageNumber.TOTAL_PAGES`.
 </Callout>
 
 ### What round-trips

--- a/src/content/conversion/content-types/text-and-formatting/font-family-size.mdx
+++ b/src/content/conversion/content-types/text-and-formatting/font-family-size.mdx
@@ -24,16 +24,18 @@ new Editor({ extensions: [ConvertKit] })
 ```
 
 <Callout title="Don't use the deprecated standalone font-size package" variant="warning">
-  Do not install `@tiptap/extension-font-size` separately, and don't pull `@tiptap/extension-font-family` and `@tiptap/extension-font-size` à la carte — everything lives inside `TextStyleKit`, which ConvertKit registers automatically.
+  Do not install `@tiptap/extension-font-size` separately, and don't pull
+  `@tiptap/extension-font-family` and `@tiptap/extension-font-size` à la carte — everything lives
+  inside `TextStyleKit`, which ConvertKit registers automatically.
 </Callout>
 
 ## Support overview
 
-| | Import | Editor | Export |
-| --- | --- | --- | --- |
-| Font family | Supported (`textStyle.fontFamily`) | Supported (FontFamily) | Supported (first font only) |
-| Font size | Supported (`textStyle.fontSize` in px) | Supported (FontSize) | Supported (converted to half-points) |
-| Letter spacing | Supported (`textStyle.letterSpacing` in px) | Requires extending TextStyle (not bundled in ConvertKit / TextStyleKit) | Not supported |
+|                | Import                                      | Editor                                                                  | Export                               |
+| -------------- | ------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------ |
+| Font family    | Supported (`textStyle.fontFamily`)          | Supported (FontFamily)                                                  | Supported (first font only)          |
+| Font size      | Supported (`textStyle.fontSize` in px)      | Supported (FontSize)                                                    | Supported (converted to half-points) |
+| Letter spacing | Supported (`textStyle.letterSpacing` in px) | Requires extending TextStyle (not bundled in ConvertKit / TextStyleKit) | Not supported                        |
 
 ## Import
 
@@ -53,7 +55,7 @@ Letter spacing is also extracted from `<w:spacing>` on text runs (converted from
 
 ## Editor rendering
 
-[`FontFamily`](/editor/extensions/marks/font-family) and [`FontSize`](/editor/extensions/marks/font-size) both depend on [`TextStyle`](/editor/extensions/marks/text-style). All three are bundled inside `TextStyleKit`, which ConvertKit registers automatically:
+[`FontFamily`](/editor/extensions/functionality/fontfamily) and [`FontSize`](/editor/extensions/functionality/fontsize) both depend on [`TextStyle`](/editor/extensions/marks/text-style). All three are bundled inside `TextStyleKit`, which ConvertKit registers automatically:
 
 ```bash
 npm install @tiptap-pro/extension-convert-kit
@@ -68,7 +70,10 @@ Export font family and size using the [editor extension](/conversion/export/docx
 On export, font family values are sanitized: quotes are stripped and only the first font from a comma-separated value is used. Since import produces a single font name, round-tripped values pass through unchanged.
 
 <Callout title="Font fallback lists are collapsed" variant="info">
-  DOCX does not support CSS-style font fallback lists. If your editor content contains a manually set value like `"Arial, Helvetica, sans-serif"`, the exporter picks the first font name (`Arial`) and discards the rest. Values imported from DOCX are already single font names and are not affected.
+  DOCX does not support CSS-style font fallback lists. If your editor content contains a manually
+  set value like `"Arial, Helvetica, sans-serif"`, the exporter picks the first font name (`Arial`)
+  and discards the rest. Values imported from DOCX are already single font names and are not
+  affected.
 </Callout>
 
 Font size converts back from pixels to half-points:

--- a/src/content/conversion/content-types/text-and-formatting/text-alignment.mdx
+++ b/src/content/conversion/content-types/text-and-formatting/text-alignment.mdx
@@ -20,11 +20,11 @@ Text alignment is a paragraph-level attribute that round-trips between DOCX and 
 
 ## Support overview
 
-| | Import | Editor | Export |
-| --- | --- | --- | --- |
-| Left | Supported | Supported | Supported |
-| Center | Supported | Supported | Supported |
-| Right | Supported | Supported | Supported |
+|         | Import    | Editor    | Export    |
+| ------- | --------- | --------- | --------- |
+| Left    | Supported | Supported | Supported |
+| Center  | Supported | Supported | Supported |
+| Right   | Supported | Supported | Supported |
 | Justify | Supported | Supported | Supported |
 
 ## Import
@@ -33,14 +33,14 @@ Import text alignment using the [editor extension](/conversion/import/docx/edito
 
 The conversion service reads the `<w:jc>` element from each DOCX paragraph and maps it to a `textAlign` attribute on the corresponding Tiptap node.
 
-| Word `<w:jc>` value | Tiptap `textAlign` |
-| --- | --- |
-| `left` | `left` |
-| `center` | `center` |
-| `right` | `right` |
-| `both` | `justify` |
-| `start` | `start` (passed through, may not be recognized by TextAlign) |
-| `end` | `end` (passed through, may not be recognized by TextAlign) |
+| Word `<w:jc>` value | Tiptap `textAlign`                                           |
+| ------------------- | ------------------------------------------------------------ |
+| `left`              | `left`                                                       |
+| `center`            | `center`                                                     |
+| `right`             | `right`                                                      |
+| `both`              | `justify`                                                    |
+| `start`             | `start` (passed through, may not be recognized by TextAlign) |
+| `end`               | `end` (passed through, may not be recognized by TextAlign)   |
 
 The `textAlign` attribute is set on both `paragraph` and `heading` nodes.
 
@@ -50,7 +50,7 @@ The `textAlign` attribute is set on both `paragraph` and `heading` nodes.
 
 ## Editor rendering
 
-The [`TextAlign`](/editor/extensions/functionality/text-align) extension adds `textAlign` as a global attribute on the node types you specify. It renders as an inline `style="text-align: ..."` on the HTML element. ConvertKit registers it with `types: ['paragraph', 'heading']` so imported alignment renders out of the box:
+The [`TextAlign`](/editor/extensions/functionality/textalign) extension adds `textAlign` as a global attribute on the node types you specify. It renders as an inline `style="text-align: ..."` on the HTML element. ConvertKit registers it with `types: ['paragraph', 'heading']` so imported alignment renders out of the box:
 
 ```ts
 import { ConvertKit } from '@tiptap-pro/extension-convert-kit'

--- a/src/content/conversion/content-types/text-and-formatting/text-color-highlight.mdx
+++ b/src/content/conversion/content-types/text-and-formatting/text-color-highlight.mdx
@@ -24,17 +24,19 @@ new Editor({ extensions: [ConvertKit] })
 ```
 
 <Callout title="multicolor: true matters" variant="warning">
-  Without `multicolor: true` on `Highlight`, only a single generic highlight is supported and every imported highlight collapses to the default yellow. ConvertKit applies it automatically; if you override the `highlight` slot, keep the flag on.
+  Without `multicolor: true` on `Highlight`, only a single generic highlight is supported and every
+  imported highlight collapses to the default yellow. ConvertKit applies it automatically; if you
+  override the `highlight` slot, keep the flag on.
 </Callout>
 
 ## Support overview
 
-| | Import | Editor | Export |
-| --- | --- | --- | --- |
-| Text color | Supported (`textStyle` mark) | Supported (TextStyle + Color) | Supported (normalized to hex) |
-| Highlight | Supported (`highlight` mark) | Supported (Highlight, multicolor) | Supported (named or hex) |
-| Shading (`<w:shd>`) | Supported (maps to `highlight`) | Supported | Supported (solid shading) |
-| Theme colors | Not supported (not converted) | Not applicable | Not applicable |
+|                     | Import                          | Editor                            | Export                        |
+| ------------------- | ------------------------------- | --------------------------------- | ----------------------------- |
+| Text color          | Supported (`textStyle` mark)    | Supported (TextStyle + Color)     | Supported (normalized to hex) |
+| Highlight           | Supported (`highlight` mark)    | Supported (Highlight, multicolor) | Supported (named or hex)      |
+| Shading (`<w:shd>`) | Supported (maps to `highlight`) | Supported                         | Supported (solid shading)     |
+| Theme colors        | Not supported (not converted)   | Not applicable                    | Not applicable                |
 
 ## Import
 
@@ -42,10 +44,10 @@ Import text color and highlight using the [editor extension](/conversion/import/
 
 The conversion service maps Word color elements to Tiptap marks:
 
-| Word element | Tiptap mark | Attribute |
-| --- | --- | --- |
-| `<w:color val="FF0000">` | `textStyle` | `{ color: "#FF0000" }` |
-| `<w:highlight val="yellow">` | `highlight` | `{ color: "yellow" }` |
+| Word element                        | Tiptap mark | Attribute              |
+| ----------------------------------- | ----------- | ---------------------- |
+| `<w:color val="FF0000">`            | `textStyle` | `{ color: "#FF0000" }` |
+| `<w:highlight val="yellow">`        | `highlight` | `{ color: "yellow" }`  |
 | `<w:shd val="clear" fill="00FFFF">` | `highlight` | `{ color: "#00FFFF" }` |
 
 Both `<w:highlight>` and `<w:shd>` produce the same `highlight` mark. The developer does not need to distinguish between them.
@@ -56,7 +58,7 @@ Both `<w:highlight>` and `<w:shd>` produce the same `highlight` mark. The develo
 
 ## Editor rendering
 
-The [`Color`](/editor/extensions/marks/color) extension adds color support to [`TextStyle`](/editor/extensions/marks/text-style), and the [`Highlight`](/editor/extensions/marks/highlight) extension handles background colors. ConvertKit bundles both: `TextStyleKit` brings `TextStyle` + `Color` + `BackgroundColor`, and `Highlight` is registered with `multicolor: true` preconfigured.
+The [`Color`](/editor/extensions/functionality/color) extension adds color support to [`TextStyle`](/editor/extensions/marks/text-style), and the [`Highlight`](/editor/extensions/marks/highlight) extension handles background colors. ConvertKit bundles both: `TextStyleKit` brings `TextStyle` + `Color` + `BackgroundColor`, and `Highlight` is registered with `multicolor: true` preconfigured.
 
 Text color renders as an inline `style="color: ..."` on a `<span>` element. Highlight renders as a `<mark>` element with a `background-color` style.
 

--- a/src/content/conversion/export/doc/page-layout.mdx
+++ b/src/content/conversion/export/doc/page-layout.mdx
@@ -6,9 +6,9 @@ tags:
   - type: version
     label: v0.3.0
 meta:
-    title: Custom page layouts in DOC | Tiptap Conversion
-    description: Learn how to customize your DOC page and margin sizes using the Export DOC extension.
-    category: Conversion
+  title: Custom page layouts in DOC | Tiptap Conversion
+  description: Learn how to customize your DOC page and margin sizes using the Export DOC extension.
+  category: Conversion
 ---
 
 import { Callout } from '@/components/ui/Callout'
@@ -18,18 +18,22 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 <EnterpriseCalloutAuto variant="doc" renderMode="sidebar" disableWaitlist />
 
 <Requirements>
-    <RequirementItem label="1. Activate trial or subscribe">
-        Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start plan](https://cloud.tiptap.dev/v2/billing) in your account.
-    </RequirementItem>
-    <RequirementItem label="2. Install from private registry">
-        To install this frontend extension, authenticate to Tiptap's private npm registry by following the [setup guide](/guides/pro-extensions).
-    </RequirementItem>
+  <RequirementItem label="1. Activate trial or subscribe">
+    Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start
+    plan](https://cloud.tiptap.dev/v2/billing) in your account.
+  </RequirementItem>
+  <RequirementItem label="2. Install from private registry">
+    To install this frontend extension, authenticate to Tiptap's private npm registry by following
+    the [setup guide](/guides/pro-extensions).
+  </RequirementItem>
 </Requirements>
 
 The DOC Export extension supports custom page sizes and margins, allowing you to create documents with precise layouts that match your requirements. Whether you need A5 pages, custom paper sizes, or specific margin configurations, you can configure these settings directly in the extension.
 
 <Callout title="Consider using DOCX instead" variant="info">
-    The DOC format is a legacy format from Microsoft Word 97-2003. For modern use, we recommend exporting to [DOCX](/conversion/export/docx/page-layout) instead. Use DOC only when compatibility with older systems requires it.
+  The DOC format is a legacy format from Microsoft Word 97-2003. For modern use, we recommend
+  exporting to [DOCX](/conversion/export/docx/page-layout) instead. Use DOC only when compatibility
+  with older systems requires it.
 </Callout>
 
 ## Page size configuration
@@ -40,8 +44,8 @@ Use the `pageSize` option to define custom page dimensions for your exported DOC
 
 All page size and margin measurements support the following units:
 
-| Unit | Description            |
-|------|------------------------|
+| Unit | Description           |
+| ---- | --------------------- |
 | `cm` | Centimeters (default) |
 | `in` | Inches                |
 | `pt` | Points                |
@@ -52,7 +56,7 @@ All page size and margin measurements support the following units:
 ### Configuration options
 
 | Property | Type     | Description                                                                                          | Default    |
-|----------|----------|------------------------------------------------------------------------------------------------------|------------|
+| -------- | -------- | ---------------------------------------------------------------------------------------------------- | ---------- |
 | `width`  | `string` | The width of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px).  | `"21cm"`   |
 | `height` | `string` | The height of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px). | `"29.7cm"` |
 
@@ -63,8 +67,8 @@ ExportDoc.configure({
   token: 'YOUR_TOKEN',
   appId: 'YOUR_APP_ID',
   pageSize: {
-    width: '14.8cm',    // A5 width
-    height: '21cm',     // A5 height
+    width: '14.8cm', // A5 width
+    height: '21cm', // A5 height
   },
 })
 ```
@@ -75,14 +79,14 @@ The `pageMargins` option allows you to set custom margins for all sides of your 
 
 ### Configuration options
 
-| Property | Type     | Description                                                                                                                                  | Default     |
-|----------|----------|----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-| `top`    | `string` | The top margin of the page. Can be negative. Must be a number followed by a valid unit (cm, in, pt, pc, mm, px).                             | `"1cm"`     |
-| `bottom` | `string` | The bottom margin of the page. Can be negative. Must be a number followed by a valid unit (cm, in, pt, pc, mm, px).                          | `"1cm"`     |
-| `left`   | `string` | The left margin of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px).                                    | `"1cm"`     |
-| `right`  | `string` | The right margin of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px).                                   | `"1cm"`     |
-| `header` | `string` | Distance from the top edge of the page to the top of the header. Should be smaller than `top`. Must be a positive number with unit.          | `"1.25cm"`  |
-| `footer` | `string` | Distance from the bottom edge of the page to the bottom of the footer. Should be smaller than `bottom`. Must be a positive number with unit. | `"1.25cm"`  |
+| Property | Type     | Description                                                                                                                                  | Default    |
+| -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `top`    | `string` | The top margin of the page. Can be negative. Must be a number followed by a valid unit (cm, in, pt, pc, mm, px).                             | `"1cm"`    |
+| `bottom` | `string` | The bottom margin of the page. Can be negative. Must be a number followed by a valid unit (cm, in, pt, pc, mm, px).                          | `"1cm"`    |
+| `left`   | `string` | The left margin of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px).                                    | `"1cm"`    |
+| `right`  | `string` | The right margin of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px).                                   | `"1cm"`    |
+| `header` | `string` | Distance from the top edge of the page to the top of the header. Should be smaller than `top`. Must be a positive number with unit.          | `"1.25cm"` |
+| `footer` | `string` | Distance from the bottom edge of the page to the bottom of the footer. Should be smaller than `bottom`. Must be a positive number with unit. | `"1.25cm"` |
 
 ```js
 import { ExportDoc } from '@tiptap-pro/extension-export-doc'
@@ -103,11 +107,17 @@ ExportDoc.configure({
 ```
 
 <Callout title="Auto-derived from the Pages extension" variant="hint">
-    When the [Pages extension](/editor/extensions/pages) is configured alongside `ExportDoc`, the `header` and `footer` offsets are automatically derived from the Pages storage values `headerTopMargin` and `footerBottomMargin`. Values you pass to `pageMargins` always take precedence.
+  When the [Pages extension](/editor/extensions/functionality/pages) is configured alongside
+  `ExportDoc`, the `header` and `footer` offsets are automatically derived from the Pages storage
+  values `headerTopMargin` and `footerBottomMargin`. Values you pass to `pageMargins` always take
+  precedence.
 </Callout>
 
 <Callout title="Convert service requirement" variant="info">
-    End-to-end support for `pageMargins.header` and `pageMargins.footer` requires the Tiptap convert service to be on a version that accepts these fields and ships an updated `@tiptap-pro/extension-export-docx`. On older convert service versions the values are ignored and Word's defaults are used.
+  End-to-end support for `pageMargins.header` and `pageMargins.footer` requires the Tiptap convert
+  service to be on a version that accepts these fields and ships an updated
+  `@tiptap-pro/extension-export-docx`. On older convert service versions the values are ignored and
+  Word's defaults are used.
 </Callout>
 
 ## Complete example
@@ -162,13 +172,13 @@ editor
 
 Here are some common page sizes you can use as reference:
 
-| Format     | Width    | Height   |
-|------------|----------|----------|
-| **A4**     | `21cm`   | `29.7cm` |
-| **A5**     | `14.8cm` | `21cm`   |
-| **Letter** | `8.5in`  | `11in`   |
-| **Legal**  | `8.5in`  | `14in`   |
-| **Tabloid**| `11in`   | `17in`   |
+| Format      | Width    | Height   |
+| ----------- | -------- | -------- |
+| **A4**      | `21cm`   | `29.7cm` |
+| **A5**      | `14.8cm` | `21cm`   |
+| **Letter**  | `8.5in`  | `11in`   |
+| **Legal**   | `8.5in`  | `14in`   |
+| **Tabloid** | `11in`   | `17in`   |
 
 ## Different measurement units
 
@@ -185,14 +195,15 @@ ExportDoc.configure({
   },
   // Margins in different units
   pageMargins: {
-    top: '0.75in',    // Inches
-    bottom: '72pt',   // Points (1 inch = 72 points)
-    left: '2cm',      // Centimeters
-    right: '20mm',    // Millimeters
+    top: '0.75in', // Inches
+    bottom: '72pt', // Points (1 inch = 72 points)
+    left: '2cm', // Centimeters
+    right: '20mm', // Millimeters
   },
 })
 ```
 
 <Callout title="Unit consistency" variant="hint">
-    While you can mix different units, it's generally recommended to use consistent units throughout your configuration for better maintainability and clarity.
+  While you can mix different units, it's generally recommended to use consistent units throughout
+  your configuration for better maintainability and clarity.
 </Callout>

--- a/src/content/conversion/export/docx/page-layout.mdx
+++ b/src/content/conversion/export/docx/page-layout.mdx
@@ -6,9 +6,9 @@ tags:
   - type: version
     label: v0.13.0
 meta:
-    title: Custom page layouts in DOCX | Tiptap Conversion
-    description: Learn how to customize your DOCX (Word) page and margin sizes using the Export extension.
-    category: Conversion
+  title: Custom page layouts in DOCX | Tiptap Conversion
+  description: Learn how to customize your DOCX (Word) page and margin sizes using the Export extension.
+  category: Conversion
 ---
 
 import { Callout } from '@/components/ui/Callout'
@@ -19,12 +19,14 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 <EnterpriseCalloutAuto variant="docx" renderMode="sidebar" disableWaitlist />
 
 <Requirements>
-    <RequirementItem label="1. Activate trial or subscribe">
-        Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start plan](https://cloud.tiptap.dev/v2/billing) in your account.
-    </RequirementItem>
-    <RequirementItem label="2. Install from private registry">
-        To install this frontend extension, authenticate to Tiptap's private npm registry by following the [setup guide](/guides/pro-extensions).
-    </RequirementItem>
+  <RequirementItem label="1. Activate trial or subscribe">
+    Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start
+    plan](https://cloud.tiptap.dev/v2/billing) in your account.
+  </RequirementItem>
+  <RequirementItem label="2. Install from private registry">
+    To install this frontend extension, authenticate to Tiptap's private npm registry by following
+    the [setup guide](/guides/pro-extensions).
+  </RequirementItem>
 </Requirements>
 
 The DOCX Export extension now supports custom page sizes and margins, allowing you to create documents with precise layouts that match your requirements. Whether you need A5 pages, custom paper sizes, or specific margin configurations, you can configure these settings directly in the extension.
@@ -39,8 +41,8 @@ Use the `pageSize` option to define custom page dimensions for your exported DOC
 
 All page size and margin measurements support the following universal units:
 
-| Unit | Description            |
-|------|------------------------|
+| Unit | Description           |
+| ---- | --------------------- |
 | `cm` | Centimeters (default) |
 | `in` | Inches                |
 | `pt` | Points                |
@@ -50,13 +52,17 @@ All page size and margin measurements support the following universal units:
 
 ### Configuration options
 
-| Property | Type | Description | Default |
-|----------|------|-------------|---------|
-| `width` | `PositiveUniversalMeasure` | The width of the page. Must be positive | `"21.0cm"` (A4 width) |
+| Property | Type                       | Description                              | Default                |
+| -------- | -------------------------- | ---------------------------------------- | ---------------------- |
+| `width`  | `PositiveUniversalMeasure` | The width of the page. Must be positive  | `"21.0cm"` (A4 width)  |
 | `height` | `PositiveUniversalMeasure` | The height of the page. Must be positive | `"29.7cm"` (A4 height) |
 
 <Callout title="PositiveUniversalMeasure">
-A `PositiveUniversalMeasure` is a string representing a positive length with a unit, such as `"21cm"`, `"8.5in"`, `"148mm"`, `"595pt"`, `"50pc"`, or `"800px"`. Supported units include centimeters (`cm`), millimeters (`mm`), inches (`in`), points (`pt`), picas (`pc`), and pixels (`px`). The value must be greater than zero. If you provide a value without a unit, centimeters (`cm`) will be used by default.
+  A `PositiveUniversalMeasure` is a string representing a positive length with a unit, such as
+  `"21cm"`, `"8.5in"`, `"148mm"`, `"595pt"`, `"50pc"`, or `"800px"`. Supported units include
+  centimeters (`cm`), millimeters (`mm`), inches (`in`), points (`pt`), picas (`pc`), and pixels
+  (`px`). The value must be greater than zero. If you provide a value without a unit, centimeters
+  (`cm`) will be used by default.
 </Callout>
 
 ```js
@@ -65,8 +71,8 @@ ExportDocx.configure({
     // Handle the exported file
   },
   pageSize: {
-    width: '14.8cm',    // A5 width
-    height: '21cm',     // A5 height
+    width: '14.8cm', // A5 width
+    height: '21cm', // A5 height
   },
 })
 ```
@@ -77,23 +83,30 @@ The `pageMargins` option allows you to set custom margins for all sides of your 
 
 ### Configuration options
 
-| Property | Type | Description | Default |
-|----------|------|-------------|---------|
-| `top` | `UniversalMeasure` | Top margin of the page.<br />Can be negative. | `"1.0cm"` |
-| `bottom` | `UniversalMeasure` | Bottom margin of the page.<br />Can be negative. | `"1.0cm"` |
-| `left` | `PositiveUniversalMeasure` | Left margin of the page. Must be positive. | `"1.0cm"` |
-| `right` | `PositiveUniversalMeasure` | Right margin of the page. Must be positive. | `"1.0cm"` |
-| `header` | `PositiveUniversalMeasure` | Distance from the top edge of the page to the top of the header. Should be less than `top` so the header sits above body content. | Word default `"1.25cm"` |
+| Property | Type                       | Description                                                                                                                                | Default                 |
+| -------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- |
+| `top`    | `UniversalMeasure`         | Top margin of the page.<br />Can be negative.                                                                                              | `"1.0cm"`               |
+| `bottom` | `UniversalMeasure`         | Bottom margin of the page.<br />Can be negative.                                                                                           | `"1.0cm"`               |
+| `left`   | `PositiveUniversalMeasure` | Left margin of the page. Must be positive.                                                                                                 | `"1.0cm"`               |
+| `right`  | `PositiveUniversalMeasure` | Right margin of the page. Must be positive.                                                                                                | `"1.0cm"`               |
+| `header` | `PositiveUniversalMeasure` | Distance from the top edge of the page to the top of the header. Should be less than `top` so the header sits above body content.          | Word default `"1.25cm"` |
 | `footer` | `PositiveUniversalMeasure` | Distance from the bottom edge of the page to the bottom of the footer. Should be less than `bottom` so the footer sits below body content. | Word default `"1.25cm"` |
 
 <Callout title="UniversalMeasure">
-A `UniversalMeasure` is a string representing a length with a unit, such as `"21cm"`, `"8.5in"`, `"148mm"`, `"595pt"`, `"50pc"`, or `"800px"`. Supported units include centimeters (`cm`), millimeters (`mm`), inches (`in`), points (`pt`), picas (`pc`), and pixels (`px`). **The value can be positive or negative**. If you provide a value without a unit, centimeters (`cm`) will be used by default.
+  A `UniversalMeasure` is a string representing a length with a unit, such as `"21cm"`, `"8.5in"`,
+  `"148mm"`, `"595pt"`, `"50pc"`, or `"800px"`. Supported units include centimeters (`cm`),
+  millimeters (`mm`), inches (`in`), points (`pt`), picas (`pc`), and pixels (`px`). **The value can
+  be positive or negative**. If you provide a value without a unit, centimeters (`cm`) will be used
+  by default.
 </Callout>
 
 <Callout title="PositiveUniversalMeasure">
-A `PositiveUniversalMeasure` is a string representing a positive length with a unit, such as `"21cm"`, `"8.5in"`, `"148mm"`, `"595pt"`, `"50pc"`, or `"800px"`. Supported units include centimeters (`cm`), millimeters (`mm`), inches (`in`), points (`pt`), picas (`pc`), and pixels (`px`). The value must be greater than zero. If you provide a value without a unit, centimeters (`cm`) will be used by default.
+  A `PositiveUniversalMeasure` is a string representing a positive length with a unit, such as
+  `"21cm"`, `"8.5in"`, `"148mm"`, `"595pt"`, `"50pc"`, or `"800px"`. Supported units include
+  centimeters (`cm`), millimeters (`mm`), inches (`in`), points (`pt`), picas (`pc`), and pixels
+  (`px`). The value must be greater than zero. If you provide a value without a unit, centimeters
+  (`cm`) will be used by default.
 </Callout>
-
 
 ```js
 ExportDocx.configure({
@@ -102,7 +115,7 @@ ExportDocx.configure({
   },
   pageMargins: {
     top: '2cm',
-    bottom: '2cm', 
+    bottom: '2cm',
     left: '1.5cm',
     right: '1.5cm',
     // Distance from the page edge to the header/footer
@@ -137,7 +150,10 @@ ExportDocx.configure({
 ```
 
 <Callout title="Auto-derived from the Pages extension" variant="hint">
-    When the [Pages extension](/editor/extensions/pages) is configured alongside `ExportDocx`, the `header` and `footer` offsets are automatically derived from the Pages storage values `headerTopMargin` and `footerBottomMargin`. Values you pass to `pageMargins` always take precedence — set `header` or `footer` explicitly to override the auto-derived values.
+  When the [Pages extension](/editor/extensions/functionality/pages) is configured alongside
+  `ExportDocx`, the `header` and `footer` offsets are automatically derived from the Pages storage
+  values `headerTopMargin` and `footerBottomMargin`. Values you pass to `pageMargins` always take
+  precedence — set `header` or `footer` explicitly to override the auto-derived values.
 </Callout>
 
 ## Complete example
@@ -151,14 +167,14 @@ const editor = new Editor({
   extensions: [
     // Other extensions...
     ExportDocx.configure({
-      onCompleteExport: result => {
+      onCompleteExport: (result) => {
         // Create and download the DOCX file
         const blob = new Blob([result], {
           type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
         })
         const url = URL.createObjectURL(blob)
         const a = document.createElement('a')
-        
+
         a.href = url
         a.download = 'custom-layout.docx'
         a.click()
@@ -186,13 +202,13 @@ const editor = new Editor({
 
 Here are some common page sizes you can use as reference:
 
-| Format | Width | Height |
-|--------|-------|--------|
-| **A4** | `21.0cm` | `29.7cm` |
-| **A5** | `14.8cm` | `21.0cm` |
-| **Letter** | `8.5in` | `11in` |
-| **Legal** | `8.5in` | `14in` |
-| **Tabloid** | `11in` | `17in` |
+| Format      | Width    | Height   |
+| ----------- | -------- | -------- |
+| **A4**      | `21.0cm` | `29.7cm` |
+| **A5**      | `14.8cm` | `21.0cm` |
+| **Letter**  | `8.5in`  | `11in`   |
+| **Legal**   | `8.5in`  | `14in`   |
+| **Tabloid** | `11in`   | `17in`   |
 
 ## Different measurement units
 
@@ -210,16 +226,17 @@ ExportDocx.configure({
   },
   // Margins in different units
   pageMargins: {
-    top: '0.75in',    // Inches
-    bottom: '72pt',   // Points (1 inch = 72 points)
-    left: '2cm',      // Centimeters
-    right: '20mm',    // Millimeters
+    top: '0.75in', // Inches
+    bottom: '72pt', // Points (1 inch = 72 points)
+    left: '2cm', // Centimeters
+    right: '20mm', // Millimeters
   },
 })
 ```
 
 <Callout title="Unit consistency" variant="hint">
-    While you can mix different units, it's generally recommended to use consistent units throughout your configuration for better maintainability and clarity.
+  While you can mix different units, it's generally recommended to use consistent units throughout
+  your configuration for better maintainability and clarity.
 </Callout>
 
 ## Runtime configuration
@@ -233,8 +250,8 @@ editor.commands.exportDocx({
     // Handle the exported file
   },
   pageSize: {
-    width: '11in',    // Tabloid width
-    height: '17in',   // Tabloid height
+    width: '11in', // Tabloid width
+    height: '17in', // Tabloid height
   },
   pageMargins: {
     top: '0.5in',

--- a/src/content/conversion/export/odt/page-layout.mdx
+++ b/src/content/conversion/export/odt/page-layout.mdx
@@ -6,9 +6,9 @@ tags:
   - type: version
     label: v0.3.0
 meta:
-    title: Custom page layouts in ODT | Tiptap Conversion
-    description: Learn how to customize your ODT page and margin sizes using the Export ODT extension.
-    category: Conversion
+  title: Custom page layouts in ODT | Tiptap Conversion
+  description: Learn how to customize your ODT page and margin sizes using the Export ODT extension.
+  category: Conversion
 ---
 
 import { Callout } from '@/components/ui/Callout'
@@ -18,12 +18,14 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 <EnterpriseCalloutAuto variant="odt" renderMode="sidebar" disableWaitlist />
 
 <Requirements>
-    <RequirementItem label="1. Activate trial or subscribe">
-        Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start plan](https://cloud.tiptap.dev/v2/billing) in your account.
-    </RequirementItem>
-    <RequirementItem label="2. Install from private registry">
-        To install this frontend extension, authenticate to Tiptap's private npm registry by following the [setup guide](/guides/pro-extensions).
-    </RequirementItem>
+  <RequirementItem label="1. Activate trial or subscribe">
+    Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start
+    plan](https://cloud.tiptap.dev/v2/billing) in your account.
+  </RequirementItem>
+  <RequirementItem label="2. Install from private registry">
+    To install this frontend extension, authenticate to Tiptap's private npm registry by following
+    the [setup guide](/guides/pro-extensions).
+  </RequirementItem>
 </Requirements>
 
 The ODT Export extension supports custom page sizes and margins, allowing you to create documents with precise layouts that match your requirements. Whether you need A5 pages, custom paper sizes, or specific margin configurations, you can configure these settings directly in the extension.
@@ -36,8 +38,8 @@ Use the `pageSize` option to define custom page dimensions for your exported ODT
 
 All page size and margin measurements support the following units:
 
-| Unit | Description            |
-|------|------------------------|
+| Unit | Description           |
+| ---- | --------------------- |
 | `cm` | Centimeters (default) |
 | `in` | Inches                |
 | `pt` | Points                |
@@ -48,7 +50,7 @@ All page size and margin measurements support the following units:
 ### Configuration options
 
 | Property | Type     | Description                                                                                          | Default    |
-|----------|----------|------------------------------------------------------------------------------------------------------|------------|
+| -------- | -------- | ---------------------------------------------------------------------------------------------------- | ---------- |
 | `width`  | `string` | The width of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px).  | `"21cm"`   |
 | `height` | `string` | The height of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px). | `"29.7cm"` |
 
@@ -59,8 +61,8 @@ ExportOdt.configure({
   token: 'YOUR_TOKEN',
   appId: 'YOUR_APP_ID',
   pageSize: {
-    width: '14.8cm',    // A5 width
-    height: '21cm',     // A5 height
+    width: '14.8cm', // A5 width
+    height: '21cm', // A5 height
   },
 })
 ```
@@ -71,14 +73,14 @@ The `pageMargins` option allows you to set custom margins for all sides of your 
 
 ### Configuration options
 
-| Property | Type     | Description                                                                                                                                  | Default     |
-|----------|----------|----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-| `top`    | `string` | The top margin of the page. Can be negative. Must be a number followed by a valid unit (cm, in, pt, pc, mm, px).                             | `"1cm"`     |
-| `bottom` | `string` | The bottom margin of the page. Can be negative. Must be a number followed by a valid unit (cm, in, pt, pc, mm, px).                          | `"1cm"`     |
-| `left`   | `string` | The left margin of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px).                                    | `"1cm"`     |
-| `right`  | `string` | The right margin of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px).                                   | `"1cm"`     |
-| `header` | `string` | Distance from the top edge of the page to the top of the header. Should be smaller than `top`. Must be a positive number with unit.          | `"1.25cm"`  |
-| `footer` | `string` | Distance from the bottom edge of the page to the bottom of the footer. Should be smaller than `bottom`. Must be a positive number with unit. | `"1.25cm"`  |
+| Property | Type     | Description                                                                                                                                  | Default    |
+| -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `top`    | `string` | The top margin of the page. Can be negative. Must be a number followed by a valid unit (cm, in, pt, pc, mm, px).                             | `"1cm"`    |
+| `bottom` | `string` | The bottom margin of the page. Can be negative. Must be a number followed by a valid unit (cm, in, pt, pc, mm, px).                          | `"1cm"`    |
+| `left`   | `string` | The left margin of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px).                                    | `"1cm"`    |
+| `right`  | `string` | The right margin of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px).                                   | `"1cm"`    |
+| `header` | `string` | Distance from the top edge of the page to the top of the header. Should be smaller than `top`. Must be a positive number with unit.          | `"1.25cm"` |
+| `footer` | `string` | Distance from the bottom edge of the page to the bottom of the footer. Should be smaller than `bottom`. Must be a positive number with unit. | `"1.25cm"` |
 
 ```js
 import { ExportOdt } from '@tiptap-pro/extension-export-odt'
@@ -99,11 +101,17 @@ ExportOdt.configure({
 ```
 
 <Callout title="Auto-derived from the Pages extension" variant="hint">
-    When the [Pages extension](/editor/extensions/pages) is configured alongside `ExportOdt`, the `header` and `footer` offsets are automatically derived from the Pages storage values `headerTopMargin` and `footerBottomMargin`. Values you pass to `pageMargins` always take precedence.
+  When the [Pages extension](/editor/extensions/functionality/pages) is configured alongside
+  `ExportOdt`, the `header` and `footer` offsets are automatically derived from the Pages storage
+  values `headerTopMargin` and `footerBottomMargin`. Values you pass to `pageMargins` always take
+  precedence.
 </Callout>
 
 <Callout title="Convert service requirement" variant="info">
-    End-to-end support for `pageMargins.header` and `pageMargins.footer` requires the Tiptap convert service to be on a version that accepts these fields and ships an updated `@tiptap-pro/extension-export-docx`. On older convert service versions the values are ignored and Word's defaults are used.
+  End-to-end support for `pageMargins.header` and `pageMargins.footer` requires the Tiptap convert
+  service to be on a version that accepts these fields and ships an updated
+  `@tiptap-pro/extension-export-docx`. On older convert service versions the values are ignored and
+  Word's defaults are used.
 </Callout>
 
 ## Complete example
@@ -158,13 +166,13 @@ editor
 
 Here are some common page sizes you can use as reference:
 
-| Format     | Width    | Height   |
-|------------|----------|----------|
-| **A4**     | `21cm`   | `29.7cm` |
-| **A5**     | `14.8cm` | `21cm`   |
-| **Letter** | `8.5in`  | `11in`   |
-| **Legal**  | `8.5in`  | `14in`   |
-| **Tabloid**| `11in`   | `17in`   |
+| Format      | Width    | Height   |
+| ----------- | -------- | -------- |
+| **A4**      | `21cm`   | `29.7cm` |
+| **A5**      | `14.8cm` | `21cm`   |
+| **Letter**  | `8.5in`  | `11in`   |
+| **Legal**   | `8.5in`  | `14in`   |
+| **Tabloid** | `11in`   | `17in`   |
 
 ## Different measurement units
 
@@ -181,14 +189,15 @@ ExportOdt.configure({
   },
   // Margins in different units
   pageMargins: {
-    top: '0.75in',    // Inches
-    bottom: '72pt',   // Points (1 inch = 72 points)
-    left: '2cm',      // Centimeters
-    right: '20mm',    // Millimeters
+    top: '0.75in', // Inches
+    bottom: '72pt', // Points (1 inch = 72 points)
+    left: '2cm', // Centimeters
+    right: '20mm', // Millimeters
   },
 })
 ```
 
 <Callout title="Unit consistency" variant="hint">
-    While you can mix different units, it's generally recommended to use consistent units throughout your configuration for better maintainability and clarity.
+  While you can mix different units, it's generally recommended to use consistent units throughout
+  your configuration for better maintainability and clarity.
 </Callout>

--- a/src/content/conversion/export/pdf/page-layout.mdx
+++ b/src/content/conversion/export/pdf/page-layout.mdx
@@ -6,9 +6,9 @@ tags:
   - type: version
     label: v0.3.0
 meta:
-    title: Custom page layouts in PDF | Tiptap Conversion
-    description: Learn how to customize your PDF page and margin sizes using the Export PDF extension.
-    category: Conversion
+  title: Custom page layouts in PDF | Tiptap Conversion
+  description: Learn how to customize your PDF page and margin sizes using the Export PDF extension.
+  category: Conversion
 ---
 
 import { Callout } from '@/components/ui/Callout'
@@ -18,12 +18,14 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 <EnterpriseCalloutAuto variant="pdf" renderMode="sidebar" disableWaitlist />
 
 <Requirements>
-    <RequirementItem label="1. Activate trial or subscribe">
-        Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start plan](https://cloud.tiptap.dev/v2/billing) in your account.
-    </RequirementItem>
-    <RequirementItem label="2. Install from private registry">
-        To install this frontend extension, authenticate to Tiptap's private npm registry by following the [setup guide](/guides/pro-extensions).
-    </RequirementItem>
+  <RequirementItem label="1. Activate trial or subscribe">
+    Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start
+    plan](https://cloud.tiptap.dev/v2/billing) in your account.
+  </RequirementItem>
+  <RequirementItem label="2. Install from private registry">
+    To install this frontend extension, authenticate to Tiptap's private npm registry by following
+    the [setup guide](/guides/pro-extensions).
+  </RequirementItem>
 </Requirements>
 
 The PDF Export extension supports custom page sizes and margins, allowing you to create documents with precise layouts that match your requirements. Whether you need A5 pages, custom paper sizes, or specific margin configurations, you can configure these settings directly in the extension.
@@ -36,8 +38,8 @@ Use the `pageSize` option to define custom page dimensions for your exported PDF
 
 All page size and margin measurements support the following units:
 
-| Unit | Description            |
-|------|------------------------|
+| Unit | Description           |
+| ---- | --------------------- |
 | `cm` | Centimeters (default) |
 | `in` | Inches                |
 | `pt` | Points                |
@@ -48,7 +50,7 @@ All page size and margin measurements support the following units:
 ### Configuration options
 
 | Property | Type     | Description                                                                                          | Default    |
-|----------|----------|------------------------------------------------------------------------------------------------------|------------|
+| -------- | -------- | ---------------------------------------------------------------------------------------------------- | ---------- |
 | `width`  | `string` | The width of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px).  | `"21cm"`   |
 | `height` | `string` | The height of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px). | `"29.7cm"` |
 
@@ -59,8 +61,8 @@ ExportPdf.configure({
   token: 'YOUR_TOKEN',
   appId: 'YOUR_APP_ID',
   pageSize: {
-    width: '14.8cm',    // A5 width
-    height: '21cm',     // A5 height
+    width: '14.8cm', // A5 width
+    height: '21cm', // A5 height
   },
 })
 ```
@@ -71,14 +73,14 @@ The `pageMargins` option allows you to set custom margins for all sides of your 
 
 ### Configuration options
 
-| Property | Type     | Description                                                                                                                        | Default     |
-|----------|----------|------------------------------------------------------------------------------------------------------------------------------------|-------------|
-| `top`    | `string` | The top margin of the page. Can be negative. Must be a number followed by a valid unit (cm, in, pt, pc, mm, px).                   | `"1cm"`     |
-| `bottom` | `string` | The bottom margin of the page. Can be negative. Must be a number followed by a valid unit (cm, in, pt, pc, mm, px).                | `"1cm"`     |
-| `left`   | `string` | The left margin of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px).                          | `"1cm"`     |
-| `right`  | `string` | The right margin of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px).                         | `"1cm"`     |
-| `header` | `string` | Distance from the top edge of the page to the top of the header. Should be smaller than `top`. Must be a positive number with unit.    | `"1.25cm"`  |
-| `footer` | `string` | Distance from the bottom edge of the page to the bottom of the footer. Should be smaller than `bottom`. Must be a positive number with unit. | `"1.25cm"`  |
+| Property | Type     | Description                                                                                                                                  | Default    |
+| -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `top`    | `string` | The top margin of the page. Can be negative. Must be a number followed by a valid unit (cm, in, pt, pc, mm, px).                             | `"1cm"`    |
+| `bottom` | `string` | The bottom margin of the page. Can be negative. Must be a number followed by a valid unit (cm, in, pt, pc, mm, px).                          | `"1cm"`    |
+| `left`   | `string` | The left margin of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px).                                    | `"1cm"`    |
+| `right`  | `string` | The right margin of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px).                                   | `"1cm"`    |
+| `header` | `string` | Distance from the top edge of the page to the top of the header. Should be smaller than `top`. Must be a positive number with unit.          | `"1.25cm"` |
+| `footer` | `string` | Distance from the bottom edge of the page to the bottom of the footer. Should be smaller than `bottom`. Must be a positive number with unit. | `"1.25cm"` |
 
 ```js
 import { ExportPdf } from '@tiptap-pro/extension-export-pdf'
@@ -99,11 +101,17 @@ ExportPdf.configure({
 ```
 
 <Callout title="Auto-derived from the Pages extension" variant="hint">
-    When the [Pages extension](/editor/extensions/pages) is configured alongside `ExportPdf`, the `header` and `footer` offsets are automatically derived from the Pages storage values `headerTopMargin` and `footerBottomMargin`. Values you pass to `pageMargins` always take precedence.
+  When the [Pages extension](/editor/extensions/functionality/pages) is configured alongside
+  `ExportPdf`, the `header` and `footer` offsets are automatically derived from the Pages storage
+  values `headerTopMargin` and `footerBottomMargin`. Values you pass to `pageMargins` always take
+  precedence.
 </Callout>
 
 <Callout title="Convert service requirement" variant="info">
-    End-to-end support for `pageMargins.header` and `pageMargins.footer` requires the Tiptap convert service to be on a version that accepts these fields and ships an updated `@tiptap-pro/extension-export-docx`. On older convert service versions the values are ignored and Word's defaults are used.
+  End-to-end support for `pageMargins.header` and `pageMargins.footer` requires the Tiptap convert
+  service to be on a version that accepts these fields and ships an updated
+  `@tiptap-pro/extension-export-docx`. On older convert service versions the values are ignored and
+  Word's defaults are used.
 </Callout>
 
 ## Complete example
@@ -158,13 +166,13 @@ editor
 
 Here are some common page sizes you can use as reference:
 
-| Format     | Width    | Height   |
-|------------|----------|----------|
-| **A4**     | `21cm`   | `29.7cm` |
-| **A5**     | `14.8cm` | `21cm`   |
-| **Letter** | `8.5in`  | `11in`   |
-| **Legal**  | `8.5in`  | `14in`   |
-| **Tabloid**| `11in`   | `17in`   |
+| Format      | Width    | Height   |
+| ----------- | -------- | -------- |
+| **A4**      | `21cm`   | `29.7cm` |
+| **A5**      | `14.8cm` | `21cm`   |
+| **Letter**  | `8.5in`  | `11in`   |
+| **Legal**   | `8.5in`  | `14in`   |
+| **Tabloid** | `11in`   | `17in`   |
 
 ## Different measurement units
 
@@ -181,14 +189,15 @@ ExportPdf.configure({
   },
   // Margins in different units
   pageMargins: {
-    top: '0.75in',    // Inches
-    bottom: '72pt',   // Points (1 inch = 72 points)
-    left: '2cm',      // Centimeters
-    right: '20mm',    // Millimeters
+    top: '0.75in', // Inches
+    bottom: '72pt', // Points (1 inch = 72 points)
+    left: '2cm', // Centimeters
+    right: '20mm', // Millimeters
   },
 })
 ```
 
 <Callout title="Unit consistency" variant="hint">
-    While you can mix different units, it's generally recommended to use consistent units throughout your configuration for better maintainability and clarity.
+  While you can mix different units, it's generally recommended to use consistent units throughout
+  your configuration for better maintainability and clarity.
 </Callout>


### PR DESCRIPTION
This fixes broken internal links in the Tiptap docs conversion pages by updating MDX references to the current editor extension slugs.

The affected links were pointing at stale routes for TextAlign, Color, FontFamily, FontSize, and Pages, which produced 404s when crawlers followed them from the conversion docs. The updated links now target the current extension pages.

Validation:
- `pnpm prettier --check` on the touched MDX files
- `pnpm lint` is blocked by an existing repository ESLint/plugin compatibility issue in `custom.d.ts` (`react/display-name` rule initialization fails under ESLint 10)
