### PR TITLE
Tag server AI toolkit as alpha

### DIFF
--- a/src/components/SidebarRenderer.tsx
+++ b/src/components/SidebarRenderer.tsx
@@ -108,8 +108,8 @@ export const LinkItem = ({
           >
             <span className="flex-grow flex items-baseline">
               <span>{link.title}</span>
-              {link.beta && (
-                <sup className="inline-block ml-1 text-[10px] text-grayAlpha-600">BETA</sup>
+              {link.releaseTag && (
+                <sup className="inline-block ml-1 text-[10px] text-grayAlpha-600">{link.releaseTag.toUpperCase()}</sup>
               )}
             </span>
             <span className="flex gap-1 items-center">

--- a/src/content/content-ai/capabilities/server-ai-toolkit/overview.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/overview.mdx
@@ -2,7 +2,7 @@
 title: Server AI Toolkit
 tags:
   - type: addon
-  - type: restricted
+  - type: alpha
 meta:
   title: Server AI Toolkit overview | Tiptap Content AI
   description: Overview of the Server AI Toolkit. Build AI agents that read and edit Tiptap documents on the server without a browser-based editor.

--- a/src/content/content-ai/getting-started/overview.mdx
+++ b/src/content/content-ai/getting-started/overview.mdx
@@ -35,7 +35,7 @@ Tiptap offers two frontend extensions that integrate directly into your editor.
   <ProductCard
     title="Server AI Toolkit"
     description="Build AI agents that can read and edit Tiptap documents on the server. Enable background document processing and AI-powered document workflows."
-    tags={['Paid add-on', 'Restricted release']}
+    tags={['Alpha', 'Paid add-on']}
     documentationUrl="/content-ai/capabilities/server-ai-toolkit/overview"
     icon={aiToolkitIcon.src}
     doubleWidth={true}

--- a/src/content/content-ai/sidebar.ts
+++ b/src/content/content-ai/sidebar.ts
@@ -29,7 +29,7 @@ export const sidebarConfig: SidebarConfig = {
           title: 'AI Toolkit',
           href: '/content-ai/capabilities/ai-toolkit',
           tags: ['Add-on'],
-          beta: true,
+          releaseTag: "beta",
           children: [
             {
               title: 'Overview',
@@ -289,7 +289,7 @@ export const sidebarConfig: SidebarConfig = {
           title: 'Server AI Toolkit',
           href: '/content-ai/capabilities/server-ai-toolkit',
           tags: ['Add-on'],
-          beta: true,
+          releaseTag: "alpha",
           children: [
             {
               title: 'Overview',

--- a/src/content/editor/sidebar.ts
+++ b/src/content/editor/sidebar.ts
@@ -262,7 +262,7 @@ export const sidebarConfig: SidebarConfig = {
               href: '/editor/extensions/functionality/ai-toolkit',
               title: 'AI Toolkit',
               tags: ['Add-on'],
-              beta: true,
+              releaseTag: "beta",
             },
             {
               href: '/editor/extensions/functionality/bubble-menu',
@@ -292,7 +292,7 @@ export const sidebarConfig: SidebarConfig = {
               href: '/editor/extensions/functionality/comments',
               title: 'Comments',
               tags: ['Start'],
-              beta: true,
+              releaseTag: "beta",
             },
             {
               href: '/editor/extensions/functionality/drag-handle',
@@ -314,7 +314,7 @@ export const sidebarConfig: SidebarConfig = {
               href: '/editor/extensions/functionality/export',
               title: 'Export',
               tags: ['Start'],
-              beta: true,
+              releaseTag: "beta",
             },
             {
               href: '/editor/extensions/functionality/filehandler',
@@ -360,7 +360,7 @@ export const sidebarConfig: SidebarConfig = {
               href: '/editor/extensions/functionality/import',
               title: 'Import',
               tags: ['Start'],
-              beta: true,
+              releaseTag: "beta",
             },
             {
               href: '/editor/extensions/functionality/pages',

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ export type SidebarLink = {
   title: string
   href: string
   tags?: string[]
-  beta?: boolean
+  releaseTag?: "beta" | "alpha"
   external?: boolean
   disabled?: boolean
   children?: Omit<SidebarLink, 'type'>[]


### PR DESCRIPTION
Changes Server AI Toolkit designation from "beta" and "restricted" to just "alpha".

⚠️ To get that into the sidebar I had to do a teeny tiny refactor. `pnpm build` runs fine. `pnpm lint` crashes but that doesn't seem to be a regression. Similarly, VSCode is displaying an error at `/src/app/page.tsx:31` but it doesn't seem to be a regression.
