### PR TITLE
feat: tpa documentation for convert service

### DIFF
--- a/src/content/conversion/getting-started/install.mdx
+++ b/src/content/conversion/getting-started/install.mdx
@@ -31,6 +31,68 @@ Most conversion extensions and REST API endpoints require a JWT for authenticati
 
 You will pass the JWT and App ID when configuring extensions or making REST API calls. See the format-specific setup guides below for details.
 
+## Tiptap Access Control (preview)
+
+<Callout title="Not generally available" variant="warning">
+  The Tiptap Access Control authentication format is in preview and is not enabled by default. To request access for your environment, email [humans@tiptap.dev](mailto:humans@tiptap.dev). Until it's enabled, keep using the App ID + JWT flow described above — it continues to work unchanged.
+</Callout>
+
+Tiptap Access Control is a new authentication format that replaces the `x-app-id` + per-request `convert/authenticate` round-trip with a single signed JWT carrying explicit permissions. The two formats live side by side: the service routes a request to the new path only when the JWT's audience claim is `"Convert"`, so existing integrations keep working without changes.
+
+### How to enable it
+
+1. Email [humans@tiptap.dev](mailto:humans@tiptap.dev) and ask to enable Tiptap Access Control for your Tiptap Cloud environment. We'll provision the signing key and confirm when your environment is ready.
+2. Generate JWTs with `aud: "Convert"`, your environment id as `iss`, and a `permissions` array listing the actions the token is allowed to perform (see below).
+3. Send the JWT in the `Authorization: Bearer <jwt>` header. The `x-app-id` header is **not** read on this path.
+
+### Per-format, per-direction permissions
+
+Each conversion direction has its own action, so handing out a token scoped to exactly the operations a feature needs never silently widens later when a new direction is added:
+
+| Action                    | Grants                                              |
+| ------------------------- | --------------------------------------------------- |
+| `Convert:Import:Docx`     | Import of DOCX                                      |
+| `Convert:Export:Docx`     | Export of DOCX                                      |
+| `Convert:Import:Markdown` | Import of Markdown                                  |
+| `Convert:Export:Markdown` | Export of Markdown                                  |
+| `Convert:Export:Doc`      | Export of legacy DOC                                |
+| `Convert:Export:Odt`      | Export of ODT                                       |
+| `Convert:Export:Epub`     | Export of EPUB                                      |
+| `Convert:Export:Pdf`      | Export of PDF                                       |
+| `Convert:Fonts`           | Managing the font cache (`/fonts/*`) – on-prem only |
+
+Legacy routes without an explicit format (`POST /v2/import`, `POST /v2/export`) check `Convert:Import:Docx` and `Convert:Export:Docx` respectively.
+
+### Example token payload
+
+```json
+{
+  "iss": "env_abc123",
+  "aud": "Convert",
+  "exp": 1777033105,
+  "permissions": [
+    { "action": "Convert:Import:Docx", "resource": "*" },
+    { "action": "Convert:Export:Docx", "resource": "*" },
+    { "action": "Convert:Export:Pdf",  "resource": "*" }
+  ]
+}
+```
+
+A request to `POST /v2/export/pdf` with this token succeeds. `POST /v2/export/odt` is rejected with a `permission_denied` error naming the missing action.
+
+### Error responses
+
+When the token is missing a required permission, the service responds `403 Forbidden` with:
+
+```json
+{
+  "message": "Token is missing permission Convert:Export:Pdf.",
+  "code": "permission_denied"
+}
+```
+
+If the environment's subscription doesn't include Convert at all, the response is `403` with `code: feature_not_available`. Upstream cloud errors are mapped through cleanly: `429 rate_limited`, `503 service_unavailable`, and `401 token_expired` / `signature_invalid` so your client can distinguish a bad token from a temporary cloud problem.
+
 ## Install packages
 
 Install the extensions you need for the formats you want to support.


### PR DESCRIPTION
This pull request adds documentation for the new Tiptap Access Control authentication format, which is currently in preview. The new format introduces a more granular, permission-based JWT authentication method for conversion extensions and REST API endpoints, while maintaining compatibility with the existing App ID + JWT flow.

**Tiptap Access Control authentication (preview):**

* Introduces Tiptap Access Control, a new JWT-based authentication format with explicit per-action permissions, available by request and not enabled by default.
* Documents how to enable the feature, including steps to request access, generate JWTs with the required claims, and send them in requests.
* Details the permissions model, listing available actions for import/export operations and how to scope tokens for least privilege.
* Provides an example JWT payload and describes expected error responses for missing permissions or unavailable features.