### PR TITLE
Sync AI toolkit changelogs in docs

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 0.8.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.8.0
+
 ## 0.7.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 0.8.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.8.0
+
 ## 0.7.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 0.8.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.8.0
+
 ## 0.7.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,12 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 0.8.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.8.0
+
 ## 0.7.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,16 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 0.8.0
+
+### Minor Changes
+
+- 0d86e00: `acceptAllSuggestions` now returns the range of the last accepted suggestion, or `null` when no suggestions were accepted.
+
+### Patch Changes
+
+- c7785ae: Remove support for the `transaction` property from `acceptSuggestion`, restoring the previous suggestion acceptance behavior.
+
 ## 0.7.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,6 +8,8 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
+## 0.8.0
+
 ## 0.7.0
 
 ## 0.6.1


### PR DESCRIPTION
## Summary\n- Add the latest @tiptap-pro/ai-toolkit 0.8.0 release notes to the AI toolkit changelog page.\n- Add the 0.8.0 version heading to the AI SDK, Anthropic, LangChain.js, OpenAI, and Server AI Toolkit changelog pages so the docs match the current package releases.\n\n## Notes\n- @tiptap-pro/ai-toolkit-tool-definitions was already aligned with the latest package changelog, so it did not need a content change.\n