### PR TITLE
feat: export custom nodes dsl docs

### DIFF
--- a/src/content/conversion/export/docx/custom-nodes-dsl-builder.mdx
+++ b/src/content/conversion/export/docx/custom-nodes-dsl-builder.mdx
@@ -1,0 +1,803 @@
+---
+title: Custom-nodes DSL builder (TypeScript)
+tags:
+  - type: start
+  - type: beta
+  - type: version
+    label: v0.18.0
+meta:
+  title: DSL builder for DOCX custom nodes | Tiptap Conversion
+  description: A typed, fluent TypeScript API for authoring the DOCX custom-nodes DSL. Compile-time containment safety, autocomplete on every prop, and the same wire format the REST API consumes.
+  category: Conversion
+---
+
+import { Callout } from '@/components/ui/Callout'
+import { CodeDemo } from '@/components/CodeDemo'
+import { Requirements, RequirementItem } from '@/components/Requirements'
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="docx" renderMode="sidebar" disableWaitlist />
+
+<Callout variant="hint" title="Beta feature">
+  The builder is part of the same `customNodeDsl` feature surface as the [JSON
+  DSL](/conversion/export/docx/custom-nodes-dsl). Both ship under `dslVersion: "1.0"` and produce
+  identical wire-format output. Pin exact package versions if you depend on this feature.
+</Callout>
+
+<Requirements>
+  <RequirementItem label="1. Activate trial or subscribe">
+    Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start
+    plan](https://cloud.tiptap.dev/v2/billing) in your account.
+  </RequirementItem>
+  <RequirementItem label="2. Install from private registry">
+    Authenticate to Tiptap's private npm registry by following the [setup
+    guide](/guides/pro-extensions).
+  </RequirementItem>
+</Requirements>
+
+The DSL builder is the **TypeScript-ergonomic** way to author the [custom-nodes DSL](/conversion/export/docx/custom-nodes-dsl). It is a small, fluent, immutable API that compiles to the **same JSON** the wire format expects — every chained method returns a fresh builder, and `.toJSON()` on any chain produces the literal payload the DSL compiler accepts.
+
+You get:
+
+- **Autocomplete on every element prop.** `paragraph({ … })` suggests `style`, `alignment`, `spacing`, `border`, `shading`, … — exactly the field set the DSL compiler validates. No more guessing prop names from the docs.
+- **Compile-time containment safety.** `paragraph().children(childrenBlock())` is a TypeScript error: paragraphs only accept inline children. `table().rows(paragraph())` is also an error: `Table.rows` requires `TableRow` builders. The errors fire at edit time, not at runtime.
+- **Required-prop checking.** `externalHyperlink({})` is a TypeScript error: the `link` prop is required by the wire format and the builder type enforces that.
+- **Wire-format compatibility.** The output is identical to hand-written JSON. The same payload works inside the editor, in a Node.js server, or as a `customNodeDsl` field in the [Conversion REST API](/conversion/export/docx/rest-api).
+
+<CodeDemo isPro path="/Extensions/ExportDocxCustomNodeDslBuilder" />
+
+---
+
+## Install and import
+
+The builder ships under a subpath import inside the same package as the rest of the DOCX export pipeline:
+
+```bash
+npm i @tiptap-pro/extension-export-docx@^0.18.0
+```
+
+```ts
+// Main entry — the runtime exporter and the configurable extension.
+import { ExportDocx, exportDocx } from '@tiptap-pro/extension-export-docx'
+
+// Builder subpath — tree-shakeable. Customers who never touch the DSL
+// don't pay for it.
+import {
+  docxNode,
+  paragraph,
+  textRun,
+  externalHyperlink,
+  table,
+  tableRow,
+  tableCell,
+  pageBreak,
+  childrenInline,
+  childrenBlock,
+  childrenTableRow,
+  childrenTableCell,
+  iff,
+  switch_,
+  fragment,
+  textOp,
+  ref,
+  template,
+  op,
+  unit,
+  switchValue,
+  marks,
+} from '@tiptap-pro/extension-export-docx/dsl'
+```
+
+The subpath alias works in **Vite, Next.js, Webpack 5+, esbuild, Rollup, and every modern bundler**. Older toolchains may need an explicit `exports`-field-aware resolver.
+
+---
+
+## When to use the builder
+
+| You are…                                                                   | Use…                                                                                                   |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Authoring DOCX rules in TypeScript with autocomplete and refactor support. | **Builder.**                                                                                           |
+| Sending the DSL as a JSON body to `POST /v2/convert/export/docx`.          | [JSON DSL](/conversion/export/docx/custom-nodes-dsl) — pass `customNodeDsl` straight from a JSON file. |
+| Inside the editor extension, want full JavaScript (closures, IO, etc.).    | The function-based [custom-nodes API](/conversion/export/docx/custom-nodes).                           |
+| Loading rules dynamically from a config service.                           | JSON DSL (deserialise the config and pass it through).                                                 |
+
+The builder produces JSON, so you can mix the two: build at design time, persist `.toJSON()` to disk, ship the JSON to a server. Or read JSON at runtime and pass it straight to `exportDocx`. There is no lock-in either direction.
+
+---
+
+## Quick start
+
+A 12-line `hintbox` rule that renders as a styled DOCX paragraph:
+
+```ts
+import { ExportDocx } from '@tiptap-pro/extension-export-docx'
+import { childrenInline, docxNode, paragraph } from '@tiptap-pro/extension-export-docx/dsl'
+
+ExportDocx.configure({
+  customNodeDsl: {
+    dslVersion: '1.0',
+    nodes: [
+      docxNode('hintbox')
+        .block()
+        .emit(
+          paragraph({ style: 'Hintbox' }) //
+            .children(childrenInline({ marks: 'default' })),
+        )
+        .toJSON(),
+    ],
+  },
+})
+```
+
+This is the same payload as the [JSON DSL quick-start example](/conversion/export/docx/custom-nodes-dsl#a-first-example) — identical bytes go on the wire, only the authoring layer differs.
+
+---
+
+## The top-level builder: `docxNode`
+
+`docxNode(type)` starts a rule for one ProseMirror node type. The chain ends in **exactly one** of `emit(...)`, `emitNothing()`, or `drop()` — calling `toJSON()` before picking a strategy throws.
+
+```ts
+docxNode('hintbox') // ┐
+  .block() //          │  optional — declare nodeKind explicitly
+  .emit(paragraph()) //│  what to render in place of the PM node
+  .toJSON() //         ┘  the literal CustomNodeRule JSON
+```
+
+| Method           | Effect                                                                                                            |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `.block()`       | Mark the rule as block-level (for the validator's containment checks).                                            |
+| `.inline()`      | Mark the rule as inline-level.                                                                                    |
+| `.auto()`        | Let the validator infer kind from the emit shape (the default).                                                   |
+| `.emit(node)`    | Render the matching PM node as `node`. Accepts a single render-node builder, a literal `RenderNode`, or an array. |
+| `.emitNothing()` | `emit: null` — emit nothing for this PM node, but still walk its descendants.                                     |
+| `.drop()`        | `render: null` — drop the matching PM node and **all its descendants**.                                           |
+| `.toJSON()`      | Materialise the chain as the wire-format `CustomNodeRule` JSON.                                                   |
+
+Each method returns a **fresh builder**, so partial chains can be reused without aliasing surprises:
+
+```ts
+const base = docxNode('mention').inline()
+const withColor = base.emit(textRun({ color: '4472C4' }))
+const dropped = base.drop()
+// `base` is unchanged.
+```
+
+---
+
+## Element factories
+
+One factory per element in the v1 catalog. Each returns a chainable builder whose `.toJSON()` produces the wire-format [`ElementNode`](/conversion/export/docx/custom-nodes-dsl#elementnode).
+
+### `paragraph(props?)`
+
+Block element accepting inline children.
+
+```ts
+paragraph({
+  style: 'Hintbox',
+  alignment: 'center',
+  spacing: { before: 240, after: 240, line: 240, lineRule: 'auto' },
+  border: {
+    top: { style: 'single', size: 4, color: 'B8D8FF', space: 5 },
+    bottom: { style: 'single', size: 4, color: 'B8D8FF', space: 5 },
+    left: { style: 'single', size: 4, color: 'B8D8FF', space: 5 },
+    right: { style: 'single', size: 4, color: 'B8D8FF', space: 5 },
+  },
+  shading: { type: 'clear', fill: 'E6F3FF' },
+}).children(childrenInline({ marks: 'default' }))
+```
+
+| Method                     | Use                                                                                                                                |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `.children(spec)`          | Set the inline children (`ChildrenInlineBuilder`, a single render-node builder, or an array). Block children fail at compile time. |
+| `.inheritOverrides(value)` | When `false`, skip the global `paragraphOverrides` bundle for this paragraph. Default `true`.                                      |
+| `.toJSON()`                | Wire-format `ElementNode`.                                                                                                         |
+
+Spec mirror: [Paragraph element prop schema](/conversion/export/docx/custom-nodes-dsl#paragraph).
+
+The `border` and `shading` props let custom nodes carry decorative chrome (boxes, callouts, hintboxes) inline on the DSL element, with no named `styleOverrides` style required. See [Express decoration inline](#express-decoration-inline) below.
+
+### `textRun(props?)`
+
+Inline leaf — no `children`. Use `applyMarks` to inherit the rule's PM-node marks.
+
+```ts
+textRun({
+  text: template('@{node.attrs.label}'),
+  color: '4472C4',
+  size: 24, // half-points
+  highlight: 'cyan',
+  style: 'Hyperlink', // round-trip identity marker
+}).applyMarks('node')
+```
+
+| Method                     | Use                                                                                                                                                                                                  |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.applyMarks(policy)`      | `'node'` (inherit the rule's PM-node marks) or a `marks('node')...` builder for fine-grained control. `'default'` and `'none'` are deliberately rejected here — see [Mark policies](#mark-policies). |
+| `.inheritOverrides(value)` | When `false`, skip `textRunOverrides` for this run. Default `true`.                                                                                                                                  |
+| `.toJSON()`                | Wire-format `ElementNode`.                                                                                                                                                                           |
+
+Spec mirror: [TextRun element prop schema](/conversion/export/docx/custom-nodes-dsl#textrun).
+
+### `externalHyperlink(props)`
+
+Inline element wrapping one or more `TextRun` children. The `link` prop is **required** at the type level — `externalHyperlink({})` is a TypeScript error.
+
+```ts
+externalHyperlink({ link: ref('node.attrs.href') }).children([
+  textRun({ text: ref('node.attrs.label'), style: 'Hyperlink' }) //
+    .applyMarks('node'),
+])
+```
+
+The link value is also runtime-validated to start with `http`, `https`, `mailto`, or `tel` (capped at 2048 characters). Other protocols reject at compile time with `DOCX_DSL_INVALID_PROP`.
+
+### `table(props?)` / `tableRow(props?)` / `tableCell(props?)`
+
+`table()` accepts `TableRow` builders via `.rows(...)` (or the equivalent `.children([row, row, ...])`). `tableRow()` accepts `TableCell` builders via `.children([cell, cell, ...])`. `tableCell()` accepts block content (paragraphs, nested tables) or `childrenBlock()`.
+
+```ts
+table({
+  width: { size: 100, type: 'pct' },
+  borders: {
+    top: { style: 'single', size: 4, color: 'B8D8FF' },
+    bottom: { style: 'single', size: 4, color: 'B8D8FF' },
+    left: { style: 'single', size: 4, color: 'B8D8FF' },
+    right: { style: 'single', size: 4, color: 'B8D8FF' },
+  },
+}).rows(
+  tableRow().children([
+    tableCell({
+      shading: { type: 'clear', fill: 'FFF1CC' },
+      verticalAlign: 'top',
+    }).children([paragraph().children(childrenInline({ marks: 'default' }))]),
+  ]),
+)
+```
+
+The wire format maps `Table` children to docx's `rows` constructor argument internally — you don't write `rows: ...` yourself.
+
+### `pageBreak()`
+
+Leaf factory — emits a block-level paragraph containing a docx page-break run. For an inline page break inside a paragraph, use `textRun({ break: 1 })` instead.
+
+```ts
+docxNode('explicitPageBreak').block().emit(pageBreak()).toJSON()
+```
+
+---
+
+## Children helpers
+
+Inside an element's `.children(...)` you can either pass:
+
+- An **explicit array of render-node builders** (`[paragraph(), table(), ...]`).
+- A **`childrenX()` delegation** that asks the runtime to walk the PM node's `content` array and dispatch each child through the standard converter.
+
+| Helper                  | Goes inside                                                      | Wire form                                                            |
+| ----------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `childrenInline(opts?)` | `paragraph().children(...)`, `externalHyperlink().children(...)` | `{ "$children": { "as": "inline", "marks"?: ... } }`                 |
+| `childrenBlock(opts?)`  | `tableCell().children(...)`                                      | `{ "$children": { "as": "block", "wrapInlineInParagraph"?: bool } }` |
+| `childrenTableRow()`    | `table().children(...)` (synonym for `.rows(...)`)               | `{ "$children": { "as": "table-row" } }`                             |
+| `childrenTableCell()`   | `tableRow().children(...)`                                       | `{ "$children": { "as": "table-cell" } }`                            |
+
+```ts
+// Inline mark policy — runs the standard mark pipeline on every text child.
+paragraph({ style: 'Body' }).children(childrenInline({ marks: 'default' }))
+
+// Block delegation with inline-wrap — buffers loose inline children into
+// default paragraphs so the table cell is always block-only.
+tableCell().children(childrenBlock({ wrapInlineInParagraph: true }))
+```
+
+`childrenInline()` accepts a `marks` option that takes a `MarkPolicy` (`'default'`, `'none'`, `'node'`) or a `marks(...)` builder chain — see [Mark policies](#mark-policies).
+
+---
+
+## Render-tree primitives
+
+Beyond elements, four render-tree shapes let you compose dynamic output.
+
+### `iff({ test, then, else? })`
+
+Structural conditional. `else` defaults to `null` (emit nothing).
+
+```ts
+iff({
+  test: ref('node.attrs.featured'),
+  then: paragraph({ style: 'Featured' }).children(childrenInline({ marks: 'default' })),
+  else: paragraph().children(childrenInline({ marks: 'default' })),
+})
+```
+
+`test` is coerced to boolean using v1 truthiness rules — `false`, `null`, `undefined`, `0`, `""` are falsy, everything else truthy.
+
+### `switch_({ on, cases, default? })`
+
+Multi-way conditional. Lookup is exact-match against the `cases` keys. `on` must resolve to a string at runtime.
+
+```ts
+switch_({
+  on: ref('node.attrs.variant'),
+  cases: {
+    warning: paragraph({ style: 'CalloutWarning' }),
+    info: paragraph({ style: 'CalloutInfo' }),
+  },
+  default: paragraph({ style: 'Callout' }),
+})
+```
+
+The trailing underscore is because `switch` is a reserved word in JavaScript. There is also a **value-form** `switchValue(...)` for picking prop values — see [Value expressions](#value-expressions) below.
+
+### `fragment(...children)`
+
+Emit several sibling render nodes. A bare array passed to an element's `.children([...])` does the same job; `fragment` is for when fragmentation is the whole emit.
+
+```ts
+docxNode('keyValue')
+  .block()
+  .emit(
+    fragment(
+      paragraph({ style: 'Key' }).children([textRun({ text: ref('node.attrs.key') })]),
+      paragraph({ style: 'Value' }).children(childrenInline({ marks: 'default' })),
+    ),
+  )
+  .toJSON()
+```
+
+### `textOp(value, opts?)`
+
+Convenience for emitting a single text run from a value expression. Equivalent in v1 to `{ element: 'TextRun', props: { text: value } }` with the mark policy applied — but shorter to write.
+
+```ts
+textOp(template('@{node.attrs.label}'))
+textOp(ref('node.attrs.title'), { default: '(untitled)', marks: 'none' })
+```
+
+---
+
+## Value expressions
+
+Anywhere a prop value (or `$text`, `$if.test`, `$switch.on`, `$op.args`) is accepted, you can pass a literal **or** one of these typed expressions.
+
+### `ref(path, opts?)`
+
+Read a value from the source PM node. Allowed paths: `node`, `node.type`, `node.attrs`, `node.attrs.<key>`, `node.text`, `node.textContent`. Other paths reject with [`DOCX_DSL_INVALID_REF`](/conversion/export/docx/custom-nodes-dsl#error-codes).
+
+```ts
+ref('node.attrs.color')
+ref('node.attrs.color', { default: '4472C4', transform: 'hexNoHash' })
+ref('node.textContent')
+```
+
+The `transform` option accepts a single `TransformName` or an array. See the [transform table](/conversion/export/docx/custom-nodes-dsl#transforms) on the JSON DSL reference page.
+
+### `template(s)`
+
+String interpolation — always returns a string. Substitutions use `{path}` (same path grammar as `ref`); `{{` and `}}` escape literal braces.
+
+```ts
+template('@{node.attrs.label}') //        →  '@alice'
+template('size: {node.attrs.size}px') //  →  'size: 24px'
+template('{{escaped}} braces') //          →  '{escaped} braces'
+```
+
+The resolved length is capped at `maxTemplateLength` (default 2 000). Exceeding it rejects with `DOCX_DSL_RESOURCE_LIMIT` at runtime.
+
+### `op(name, ...args)`
+
+Typed compute. Closed list of operations with strict arities — see the [op arity table](/conversion/export/docx/custom-nodes-dsl#op---typed-compute).
+
+```ts
+op('mul', ref('node.attrs.size'), 2)
+op('coalesce', ref('node.attrs.color'), ref('node.attrs.fallbackColor'), '000000')
+op('and', ref('node.attrs.visible'), op('not', ref('node.attrs.hidden')))
+```
+
+There is no `concat` — use `template(...)` for strings. There is no implicit numeric coercion — `op('add', '3', 1)` rejects.
+
+### `unit(name, value)`
+
+Bridge to a closed-list unit / coercion helper backed by the same functions the converter uses internally. The result type matches the helper's signature.
+
+```ts
+unit('pixelsToHalfPoints', 16) //                          →  24 (half-points)
+unit('pointsToTwips', 12) //                               →  240 (twips)
+unit('normalizeColor', ref('node.attrs.backgroundColor')) //→  '4F46E5'
+```
+
+Full list: [unit dispatch table](/conversion/export/docx/custom-nodes-dsl#unit---unit--coercion-helper).
+
+### `switchValue({ on, cases, default? })`
+
+Value-form `$switch` — picks a prop value (not a render node) by string match.
+
+```ts
+paragraph({
+  style: switchValue({
+    on: ref('node.attrs.variant'),
+    cases: { warning: 'CalloutWarning', info: 'CalloutInfo' },
+    default: 'Callout',
+  }),
+})
+```
+
+The validator chooses the value form vs. the render-tree form by surrounding context: `switchValue` is only valid inside a prop value, while `switch_` is only valid in a `RenderNode` slot.
+
+---
+
+## Mark policies
+
+The `marks(mode)` builder constructs a chainable [`MarkPolicy`](/conversion/export/docx/custom-nodes-dsl#marks-system) object. Useful when you need fine-grained control beyond the string shorthands.
+
+```ts
+import { childrenInline, marks } from '@tiptap-pro/extension-export-docx/dsl'
+
+childrenInline({
+  marks: marks('default') //
+    .disable('bold', 'italic')
+    .overrides({
+      underline: { props: { color: 'EA580C' } },
+      highlight: { replace: true, props: { color: 'FFE066' } },
+    }),
+})
+```
+
+| Method                                           | Use                                                                                                                                          |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `marks(mode)`                                    | Start a builder. `mode` is `'default'` (use the standard pipeline against the child's own marks) or `'node'` (use the rule's PM-node marks). |
+| `.disable(...marks)`                             | Skip these marks entirely. Their standard mappings don't run and any matching `overrides` entry is ignored.                                  |
+| `.overrides({ markType: { props?, replace? } })` | Per-mark adjustments. `replace: true` suppresses the standard mapping for that mark; `props` is merged on top.                               |
+| `.toJSON()`                                      | Materialise as the wire-format `MarkPolicyObject`. Container helpers call this for you.                                                      |
+
+### `applyMarks` is a narrower surface
+
+`textRun().applyMarks(...)` and `externalHyperlink().applyMarks(...)` accept **only** `'node'` or a `marks('node')...` builder — the wire format rejects `'default'` and `'none'` here because they only make sense for child marks.
+
+The builder enforces that at runtime: passing `marks('default')` to `applyMarks` throws with a helpful message instead of producing a payload that would later fail the DSL compiler.
+
+```ts
+textRun().applyMarks('node') //                       ✓
+textRun().applyMarks(marks('node').disable('code')) // ✓
+textRun().applyMarks(marks('default')) //              ✗ throws at build time
+```
+
+---
+
+## Type-system guarantees
+
+The builder's TypeScript surface enforces every containment rule the runtime would have caught — but at edit time. These are all compile errors:
+
+```ts
+// Paragraphs accept inline children only.
+paragraph().children(childrenBlock())
+//                  ^^^^^^^^^^^^^^^^
+// Type 'ChildrenBlockBuilder' is not assignable to type 'ParagraphChildSpec'.
+
+// Table.rows requires TableRow builders.
+table().rows(paragraph())
+//           ^^^^^^^^^^^
+// Type 'ParagraphBuilder' is not assignable to type 'TableRowBuilder'.
+
+// TableRow children must be TableCell builders.
+tableRow().children([tableRow()])
+//                   ^^^^^^^^^^
+// Type 'TableRowBuilder' is not assignable to type 'TableCellBuilder'.
+
+// TableCell children are block-level; inline-children delegation is rejected.
+tableCell().children(childrenInline())
+//                   ^^^^^^^^^^^^^^^^
+
+// TextRun is a leaf — no children.
+textRun({ text: 'hi' }).children
+//                       ^^^^^^^^
+// Property 'children' does not exist on type 'TextRunBuilder'.
+
+// externalHyperlink.link is required.
+externalHyperlink({})
+//                ^^
+// Property 'link' is missing in type '{}' but required in type 'ExternalHyperlinkProps'.
+
+// applyMarks rejects 'default' / 'none'.
+textRun().applyMarks('default')
+//                   ^^^^^^^^^
+// Argument of type '"default"' is not assignable to parameter of type 'ApplyMarksPolicy | MarkPolicyBuilder'.
+```
+
+These mirror the runtime's [`DOCX_DSL_INVALID_CONTEXT`](/conversion/export/docx/custom-nodes-dsl#error-codes) rules — same constraints, surfaced earlier.
+
+---
+
+## Express decoration inline
+
+A common pattern with `styleOverrides` was: declare a named `Hintbox` paragraph style with border and shading, then reference it from a DSL rule via `style: 'Hintbox'`. The `paragraph()` builder now exposes `border` and `shading` props directly, so the decoration can ride inline on the element — no `styleOverrides` block needed.
+
+The named-style label still has a job: **round-trip identity**. The DOCX writer emits `<w:pStyle w:val="Hintbox"/>` whether or not `Hintbox` is declared in `styles.xml`. The import side reads that pStyle to reconstruct the matching custom node.
+
+```ts
+docxNode('hintbox')
+  .block()
+  .emit(
+    paragraph({
+      // Round-trip identity marker.
+      style: 'Hintbox',
+      // Decoration travels here — no styleOverrides required.
+      spacing: { before: 240, after: 240 },
+      border: {
+        top: { style: 'single', size: 1, color: 'B8D8FF', space: 5 },
+        bottom: { style: 'single', size: 1, color: 'B8D8FF', space: 5 },
+        left: { style: 'single', size: 1, color: 'B8D8FF', space: 5 },
+        right: { style: 'single', size: 1, color: 'B8D8FF', space: 5 },
+      },
+      // `clear` shading lets `fill` show through as the background.
+      // `solid` would render a 100% foreground (default `auto` → black)
+      // and hide the fill entirely. See the OOXML pitfall below.
+      shading: { type: 'clear', fill: 'E6F3FF' },
+    }).children(childrenInline({ marks: 'default' })),
+  )
+  .toJSON()
+```
+
+This pairs naturally with [`cssStyles.extractFromDocument`](/conversion/export/docx/css-to-docx) — let CSS handle headings, body fonts, lists, and other generic selectors; let the DSL handle anything tied to a custom node type.
+
+<Callout variant="warning" title="OOXML pitfall — `solid` shading paints a foreground">
+  In OOXML, `<w:shd>` with `w:val="solid"` paints the **foreground** at 100% coverage. The
+  `fill` attribute is the *background* (sits behind the foreground). When `color` is
+  unset, the foreground defaults to `auto`, which Word renders as **black** — completely
+  hiding the `fill`. For a paragraph background tint use **`type: 'clear'`** (empty pattern,
+  `fill` shows through). The same trap exists in the JSON DSL — it's an OOXML semantics
+  thing, not a builder bug.
+</Callout>
+
+---
+
+## Worked examples
+
+The same five examples that appear on the [JSON DSL reference page](/conversion/export/docx/custom-nodes-dsl#putting-it-together--worked-examples), authored here through the builder.
+
+### Hintbox — block paragraph with inline decoration
+
+```ts
+docxNode('hintbox')
+  .block()
+  .emit(
+    paragraph({
+      style: 'Hintbox',
+      spacing: { before: 240, after: 240 },
+      border: {
+        top: { style: 'single', size: 1, color: 'B8D8FF', space: 5 },
+        bottom: { style: 'single', size: 1, color: 'B8D8FF', space: 5 },
+        left: { style: 'single', size: 1, color: 'B8D8FF', space: 5 },
+        right: { style: 'single', size: 1, color: 'B8D8FF', space: 5 },
+      },
+      shading: { type: 'clear', fill: 'E6F3FF' },
+    }).children(childrenInline({ marks: 'default' })),
+  )
+  .toJSON()
+```
+
+### Mention — inline TextRun with templated text and inherited marks
+
+```ts
+docxNode('mention')
+  .inline()
+  .emit(
+    textRun({
+      text: template('@{node.attrs.label}'),
+      color: ref('node.attrs.color', { default: '4472C4', transform: 'hexNoHash' }),
+    }).applyMarks('node'),
+  )
+  .toJSON()
+```
+
+A bold mention renders as `new TextRun({ text: '@alice', color: '4472C4', bold: true })`.
+
+### Callout — single-cell table with attribute-driven shading and switched style
+
+```ts
+docxNode('calloutBox')
+  .block()
+  .emit(
+    table({
+      width: { size: 100, type: 'pct' },
+      borders: {
+        top: { style: 'single', size: 4, color: 'B8D8FF' },
+        bottom: { style: 'single', size: 4, color: 'B8D8FF' },
+        left: { style: 'single', size: 4, color: 'B8D8FF' },
+        right: { style: 'single', size: 4, color: 'B8D8FF' },
+      },
+    }).rows(
+      tableRow().children([
+        tableCell({
+          shading: {
+            type: 'clear',
+            fill: unit('normalizeColor', ref('node.attrs.backgroundColor', { default: 'E6F3FF' })),
+          },
+          margins: {
+            top: unit('pointsToTwips', 8),
+            bottom: unit('pointsToTwips', 8),
+            left: unit('pointsToTwips', 10),
+            right: unit('pointsToTwips', 10),
+          },
+        }).children([
+          paragraph({
+            style: switchValue({
+              on: ref('node.attrs.variant'),
+              cases: { warning: 'CalloutWarning', info: 'CalloutInfo' },
+              default: 'Callout',
+            }),
+          }).children(childrenInline({ marks: 'default' })),
+        ]),
+      ]),
+    ),
+  )
+  .toJSON()
+```
+
+### Code block — paragraph that suppresses conflicting child marks
+
+```ts
+docxNode('codeBlock')
+  .block()
+  .emit(
+    paragraph({ style: 'Code' }).children(
+      childrenInline({ marks: marks('default').disable('bold', 'italic') }),
+    ),
+  )
+  .toJSON()
+```
+
+### Custom link — inline ExternalHyperlink wrapping a TextRun
+
+```ts
+docxNode('customLink')
+  .inline()
+  .emit(
+    externalHyperlink({ link: ref('node.attrs.href') }).children([
+      textRun({ text: ref('node.attrs.label'), style: 'Hyperlink' }) //
+        .applyMarks('node'),
+    ]),
+  )
+  .toJSON()
+```
+
+---
+
+## Side-by-side: builder vs hand-written JSON
+
+The builder produces wire-equivalent JSON. Here's the same hintbox rule both ways:
+
+**Builder**
+
+```ts
+docxNode('hintbox')
+  .block()
+  .emit(
+    paragraph({ style: 'Hintbox' }) //
+      .children(childrenInline({ marks: 'default' })),
+  )
+  .toJSON()
+```
+
+**JSON**
+
+```jsonc
+{
+  "type": "hintbox",
+  "nodeKind": "block",
+  "render": {
+    "emit": {
+      "element": "Paragraph",
+      "props": { "style": "Hintbox" },
+      "children": { "$children": { "as": "inline", "marks": "default" } },
+    },
+  },
+}
+```
+
+`builder.toJSON()` and the hand-written object are deep-equal — verified by the package's own parity tests. Pick whichever fits your authoring environment; the wire format is the same.
+
+---
+
+## Composition with `cssStyles`
+
+The builder pairs well with [`cssStyles`](/conversion/export/docx/css-to-docx) for a clean separation of concerns:
+
+- **CSS** describes generic-selector styling — headings, paragraphs, lists, blockquotes — that already lives in the editor's stylesheet.
+- **The DSL** describes custom-node rendering — anything that needs a Tiptap node type and can't be expressed by a generic CSS selector.
+
+```ts
+ExportDocx.configure({
+  cssStyles: {
+    extractFromDocument: true, // pulls .tiptap rules from the live stylesheets
+    baseFontSize: 16,
+  },
+  customNodeDsl: {
+    dslVersion: '1.0',
+    nodes: [
+      docxNode('hintbox')
+        .block()
+        .emit(
+          paragraph({
+            style: 'Hintbox', // round-trip identity
+            border: { top: { style: 'single', size: 1, color: 'B8D8FF', space: 5 } /* ... */ },
+            shading: { type: 'clear', fill: 'E6F3FF' },
+          }).children(childrenInline({ marks: 'default' })),
+        )
+        .toJSON(),
+    ],
+  },
+})
+```
+
+You can drop the `styleOverrides` block entirely with this approach. The bundled `ExportDocxCustomNodeDslBuilder` demo uses exactly this pattern.
+
+---
+
+## Conflict policy and runtime errors
+
+The builder is a thin authoring layer — every runtime constraint described on the [JSON DSL reference page](/conversion/export/docx/custom-nodes-dsl#errors) applies identically:
+
+- Function-based [`customNodes`](/conversion/export/docx/custom-nodes) win when the same `type` appears in both APIs (warning logged once per export call per conflicting type).
+- DSL errors return the [structured envelope](/conversion/export/docx/custom-nodes-dsl#error-responses-rest) with `code` + `dslPath` + (for runtime errors) `nodePath` + `nodeType`.
+- [Resource caps](/conversion/export/docx/custom-nodes-dsl#resource-limits) are enforced at compile and runtime — tunable on `exportDocx` via `customNodeDslLimits` and on the REST surface via `DOCX_DSL_MAX_*` env vars.
+
+The builder adds **one** runtime check of its own: passing a `marks('default')` builder to `applyMarks` throws a clear error rather than emitting a payload that would later fail with `DOCX_DSL_INVALID_SHAPE`. Everything else flows straight through to the standard DSL compiler.
+
+---
+
+## TypeScript reference
+
+Every builder, helper, and prop-shape interface is exported from `@tiptap-pro/extension-export-docx/dsl` for direct re-use:
+
+```ts
+import type {
+  // Top-level rule
+  CustomNodeRuleBuilder,
+
+  // Element builders
+  ParagraphBuilder,
+  TextRunBuilder,
+  ExternalHyperlinkBuilder,
+  TableBuilder,
+  TableRowBuilder,
+  TableCellBuilder,
+
+  // Children helpers
+  ChildrenInlineBuilder,
+  ChildrenBlockBuilder,
+  ChildrenTableRowBuilder,
+  ChildrenTableCellBuilder,
+
+  // Render-node abstraction
+  RenderNodeBuilder,
+
+  // Mark-policy chain
+  MarkPolicyBuilder,
+
+  // Per-element prop interfaces
+  ParagraphProps,
+  TextRunProps,
+  ExternalHyperlinkProps,
+  TableProps,
+  TableRowProps,
+  TableCellProps,
+
+  // Shared shape
+  BorderSide,
+  Prop,
+} from '@tiptap-pro/extension-export-docx/dsl'
+```
+
+`Prop<T>` is the helper that lets every leaf accept either the literal value (`number`, `string`, etc.) or a `ValueExpr` (`ref(...)`, `template(...)`, `op(...)`, etc.).
+
+---
+
+## Related
+
+- [Custom-nodes DSL (JSON reference)](/conversion/export/docx/custom-nodes-dsl) — full normative description of the wire format. The builder is sugar over this; consult the reference for runtime semantics, error codes, and resource limits.
+- [Function-based custom nodes](/conversion/export/docx/custom-nodes) — the JavaScript-callback variant for in-browser customisation only.
+- [CSS to DOCX](/conversion/export/docx/css-to-docx) — pairs naturally with the builder for a generic-vs-custom split.
+- [Style overrides](/conversion/export/docx/styles) — manual named-style declarations. Still useful for character / paragraph styles a customer wants to expose to Word's style picker; not needed just to decorate a custom node anymore.
+- [DOCX REST API](/conversion/export/docx/rest-api) — same `customNodeDsl` payload, sent over HTTP.

--- a/src/content/conversion/export/docx/custom-nodes-dsl.mdx
+++ b/src/content/conversion/export/docx/custom-nodes-dsl.mdx
@@ -893,7 +893,6 @@ Every error carries a stable `code` and a `dslPath` pointing into the offending 
 | `DOCX_DSL_RUNTIME_TYPE_MISMATCH` | A value-expression result didn't match the expected type at runtime (e.g. `$switch.on` resolved to a number).                |
 | `DOCX_DSL_RESOURCE_LIMIT`        | A configurable cap was exceeded (depth, node count, string length, …).                                                       |
 | `DOCX_DSL_RENDER_FAILED`         | The adapter `instantiate` step threw — generally indicates a docx.js incompatibility, surfaced with the offending `dslPath`. |
-| `DOCX_DSL_DISABLED`              | (REST only) `DOCX_DSL_ENABLED=false` was set and the request included a `customNodeDsl` field.                               |
 
 ### HTTP status mapping (REST)
 
@@ -903,7 +902,6 @@ Every error carries a stable `code` and a `dslPath` pointing into the offending 
 | Runtime errors (caught while rendering)  | `422`                                              |
 | Resource caps exceeded at compile        | `400`                                              |
 | Resource caps exceeded at runtime        | `422`                                              |
-| `DOCX_DSL_DISABLED` rollback flag        | `503`                                              |
 | docx.js itself fails (rare)              | `422` (existing `FAILED_TO_EXPORT_DOCX_FILE` path) |
 
 ### Behavior matrix (REST)
@@ -921,7 +919,6 @@ Every error carries a stable `code` and a `dslPath` pointing into the offending 
 | Invalid `$ref` path                                             | `400` | `DOCX_DSL_INVALID_REF`     |
 | Required attribute resolves to `undefined`, prop schema rejects | `422` | `DOCX_DSL_INVALID_PROP`    |
 | Depth cap exceeded at runtime                                   | `422` | `DOCX_DSL_RESOURCE_LIMIT`  |
-| Rollback flag set with DSL present                              | `503` | `DOCX_DSL_DISABLED`        |
 
 The DSL is **fail-fast**: any error aborts the export with no partial output. Silent partial output produces invalid DOCX that is harder to debug than an explicit error.
 

--- a/src/content/conversion/export/docx/custom-nodes-dsl.mdx
+++ b/src/content/conversion/export/docx/custom-nodes-dsl.mdx
@@ -58,6 +58,14 @@ The **`customNodeDsl`** option closes that gap. It is a small, serializable JSON
 
 Both APIs can coexist on the editor extension. When the same node type appears in both `customNodes` and `customNodeDsl`, the function definition wins and a single `console.warn` is emitted per export call. Existing function-based customers see no behavior change.
 
+<Callout variant="hint" title="Authoring in TypeScript? Use the builder">
+  This page documents the **JSON wire format** — the canonical reference for what travels over the
+  convert REST surface. If you're authoring rules in a TypeScript codebase, consider the [DSL
+  builder](/conversion/export/docx/custom-nodes-dsl-builder) — a fluent, typed API that produces the
+  exact same JSON, with autocomplete on every prop and compile-time containment safety. The builder
+  ships under the `@tiptap-pro/extension-export-docx/dsl` subpath import.
+</Callout>
+
 ---
 
 ## A first example

--- a/src/content/conversion/export/docx/custom-nodes-dsl.mdx
+++ b/src/content/conversion/export/docx/custom-nodes-dsl.mdx
@@ -1,0 +1,980 @@
+---
+title: Export custom nodes with the JSON DSL
+tags:
+  - type: start
+  - type: beta
+  - type: version
+    label: v0.17.0
+meta:
+  title: Custom-node DSL for DOCX | Tiptap Conversion
+  description: A serializable JSON description of how Tiptap custom nodes should render into DOCX. Works in both the editor extension and the Conversion REST API.
+  category: Conversion
+---
+
+import { Callout } from '@/components/ui/Callout'
+import { CodeDemo } from '@/components/CodeDemo'
+import { Requirements, RequirementItem } from '@/components/Requirements'
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<EnterpriseCalloutAuto variant="docx" renderMode="sidebar" disableWaitlist />
+
+<Callout variant="hint" title="Beta feature">
+  The DSL is stabilising but may still see additive refinements before general availability. Pin
+  exact package versions if you depend on it. The wire format is versioned (`dslVersion: "1.0"`);
+  future versions will not change this document's shape silently.
+</Callout>
+
+<Requirements>
+  <RequirementItem label="1. Activate trial or subscribe">
+    Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start
+    plan](https://cloud.tiptap.dev/v2/billing) in your account.
+  </RequirementItem>
+  <RequirementItem label="2. Install from private registry">
+    To install this frontend extension, authenticate to Tiptap's private npm registry by following
+    the [setup guide](/guides/pro-extensions).
+  </RequirementItem>
+  <RequirementItem label="3. (REST only) Configure Convert app">
+    To use the Convert REST API retrieve your App ID and Convert secret from [your
+    dashboard](https://cloud.tiptap.dev/v2/cloud/convert).
+  </RequirementItem>
+</Requirements>
+
+The [function-based custom-node API](/conversion/export/docx/custom-nodes) lets you render any custom Tiptap node into DOCX by writing a small JavaScript function. That works great inside the editor extension, but functions cannot be sent over HTTP — so the [DOCX REST API](/conversion/export/docx/rest-api) historically had no way to render custom nodes at all.
+
+The **`customNodeDsl`** option closes that gap. It is a small, serializable JSON language for describing how a custom node should render into DOCX. The same JSON works in both surfaces: pass it to `ExportDocx.configure({ customNodeDsl })` in the browser, or as the `customNodeDsl` field in the REST request body.
+
+<CodeDemo isPro path="/Extensions/ExportDocxCustomNodeDsl" />
+
+---
+
+## When to use it
+
+| You want to…                                                                                              | Use                                                                       |
+| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Render a custom node when calling `editor.exportDocx()` in the browser, with full JavaScript flexibility. | The [function API](/conversion/export/docx/custom-nodes) (`customNodes`). |
+| Render a custom node when calling `POST /v2/convert/export/docx`.                                         | **`customNodeDsl`** (this page).                                          |
+| Share the same custom-node export logic between your browser app and a server-side render.                | **`customNodeDsl`** (this page).                                          |
+| Render the same custom node from both surfaces, with one source of truth.                                 | **`customNodeDsl`** (this page).                                          |
+
+Both APIs can coexist on the editor extension. When the same node type appears in both `customNodes` and `customNodeDsl`, the function definition wins and a single `console.warn` is emitted per export call. Existing function-based customers see no behavior change.
+
+---
+
+## A first example
+
+A custom `hintbox` block node that should render as a styled paragraph in DOCX:
+
+```ts
+import { ExportDocx } from '@tiptap-pro/extension-export-docx'
+
+ExportDocx.configure({
+  customNodeDsl: {
+    dslVersion: '1.0',
+    nodes: [
+      {
+        type: 'hintbox',
+        nodeKind: 'block',
+        render: {
+          emit: {
+            element: 'Paragraph',
+            props: { style: 'Hintbox' },
+            children: { $children: { as: 'inline', marks: 'default' } },
+          },
+        },
+      },
+    ],
+  },
+})
+```
+
+The same JSON over REST:
+
+```bash
+curl --output example.docx -X POST "https://api.tiptap.dev/v2/convert/export/docx" \
+    -H "Authorization: Bearer YOUR_TOKEN" \
+    -H "X-App-Id: YOUR_APP_ID" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "doc": "{\"type\":\"doc\",\"content\":[{\"type\":\"hintbox\",\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}]}",
+      "exportType": "blob",
+      "customNodeDsl": {
+        "dslVersion": "1.0",
+        "nodes": [
+          {
+            "type": "hintbox",
+            "nodeKind": "block",
+            "render": {
+              "emit": {
+                "element": "Paragraph",
+                "props": { "style": "Hintbox" },
+                "children": { "$children": { "as": "inline", "marks": "default" } }
+              }
+            }
+          }
+        ]
+      }
+    }'
+```
+
+The `Hintbox` paragraph style itself is declared via [styleOverrides](/conversion/export/docx/styles), exactly the same way you would declare it for the function API.
+
+---
+
+## Top-level document
+
+```jsonc
+{
+  "dslVersion": "1.0",
+  "nodes": [
+    /* CustomNodeRule, … */
+  ],
+}
+```
+
+| Field        | Type               | Description                                                                                                                            |
+| ------------ | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `dslVersion` | `"1.0"`            | Required exact literal. Any other value rejects with `DOCX_DSL_UNKNOWN_VERSION`.                                                       |
+| `nodes`      | `CustomNodeRule[]` | Required. One rule per ProseMirror node type. Maximum 128 entries. Duplicate `type` values reject with `DOCX_DSL_DUPLICATE_NODE_TYPE`. |
+
+The following root keys are **reserved for future versions** and reject today with `DOCX_DSL_RESERVED_SHAPE` instead of being silently ignored: `requiresStyles`, `contributedStyles`, `externalRefs`, `limits`. This makes future activations safe — payloads that compile today will keep compiling exactly the same way tomorrow.
+
+---
+
+## CustomNodeRule
+
+A single rule describes one ProseMirror node type:
+
+```jsonc
+{
+  "type": "hintbox",
+  "nodeKind": "block",
+  "render": {
+    /* RenderProgram */
+  },
+}
+```
+
+| Field      | Type                            | Default  | Description                                                                                        |
+| ---------- | ------------------------------- | -------- | -------------------------------------------------------------------------------------------------- |
+| `type`     | `string`                        | required | The PM node type this rule matches (e.g. `"hintbox"`, `"mention"`).                                |
+| `nodeKind` | `"block" \| "inline" \| "auto"` | `"auto"` | Declared kind of the source PM node. `"auto"` lets the validator infer from the rule's emit shape. |
+| `render`   | `RenderProgram \| null`         | required | What to render. `null` drops the matching PM node and **all its descendants**.                     |
+
+To emit nothing for the wrapping node while letting children render normally, use `render: { emit: { "$children": { "as": "block" } } }` instead of `render: null`.
+
+---
+
+## RenderProgram
+
+```jsonc
+{
+  "emit": /* RenderNode | RenderNode[] | null */
+}
+```
+
+A `RenderProgram` must declare at least an `emit`. A program with neither `emit` nor a (reserved) `contribute` field rejects with `DOCX_DSL_INVALID_SHAPE`.
+
+`emit: null` renders nothing for this PM node, but does **not** drop descendants. To drop descendants entirely, set `render: null` on the rule itself.
+
+---
+
+## RenderNodes
+
+Every entry under `emit` (and the children of `ElementNode`) is a `RenderNode`. There are seven shapes, all discriminated structurally — there is no `kind` tag on the wire:
+
+| Shape                    | Discriminator   | Meaning                                                   |
+| ------------------------ | --------------- | --------------------------------------------------------- |
+| `null`                   | literal         | Render nothing here.                                      |
+| array                    | bare JS array   | Implicit fragment — render each item in order.            |
+| `{ "element": …, … }`    | `element` key   | Build a docx.js element via the adapter registry.         |
+| `{ "$children": { … } }` | `$children` key | Walk the PM node's child content and dispatch each child. |
+| `{ "$text": …, … }`      | `$text` key     | Convenience for emitting a single text run.               |
+| `{ "$fragment": [ … ] }` | `$fragment` key | Explicit fragment of sibling render nodes.                |
+| `{ "$if": { … } }`       | `$if` key       | Structural conditional.                                   |
+| `{ "$switch": { … } }`   | `$switch` key   | Structural multi-way conditional.                         |
+
+An object that mixes two `$`-prefixed keys (for example `{ "$text": …, "$children": … }`) rejects with `DOCX_DSL_INVALID_SHAPE`. Pick one.
+
+### ElementNode
+
+The most common shape — instantiate a docx.js element:
+
+```jsonc
+{
+  "element": "Paragraph",
+  "props": { "style": "Hintbox" },
+  "children": { "$children": { "as": "inline", "marks": "default" } },
+  "applyMarks": "node",
+  "inheritOverrides": true,
+}
+```
+
+| Field              | Type                         | Default     | Description                                                                                                                                                |
+| ------------------ | ---------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `element`          | `ElementName`                | required    | One of the allowed elements (see the [Element catalog](#element-catalog)).                                                                                 |
+| `props`            | `Record<string, ValueExpr>`  | `{}`        | Element properties. Each value can be a literal or any [value expression](#value-expressions). Unknown prop keys reject against the element's prop schema. |
+| `children`         | `RenderNode \| RenderNode[]` | `undefined` | Child render nodes. The element's adapter dictates what is allowed (see [Containment](#containment)).                                                      |
+| `applyMarks`       | `ApplyMarksPolicy`           | `undefined` | Valid only on inline elements. Merges the rule's own PM-node marks onto the run. See [Marks](#marks-system).                                               |
+| `inheritOverrides` | `boolean`                    | `true`      | When `false`, skip the global `*Overrides` bundle (e.g. `paragraphOverrides`) for this element only.                                                       |
+
+### `$children`
+
+Walks `node.content` and dispatches each child through the standard converter:
+
+```jsonc
+{ "$children": { "as": "inline", "marks": "default" } }
+```
+
+| Field                   | Type                                                 | Default     | Description                                                                                                                                                                                  |
+| ----------------------- | ---------------------------------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `as`                    | `"block" \| "inline" \| "table-row" \| "table-cell"` | required    | Expected child kind. Validated against the parent element's `childKind`. Mismatches reject with `DOCX_DSL_INVALID_CONTEXT`.                                                                  |
+| `marks`                 | `MarkPolicy`                                         | `"default"` | Valid only when `as: "inline"`. How to map marks on text children. See [Marks](#marks-system).                                                                                               |
+| `wrapInlineInParagraph` | `boolean`                                            | `false`     | Valid only when `as: "block"`. When `true`, consecutive inline children are buffered into a default `Paragraph` rather than rejecting. Useful for table cells consuming inline-only content. |
+
+### `$text`
+
+Convenience for emitting a single text run:
+
+```jsonc
+{ "$text": { "$ref": "node.attrs.label" }, "marks": "default", "default": "(unnamed)" }
+```
+
+| Field     | Type                  | Default     | Description                                                                |
+| --------- | --------------------- | ----------- | -------------------------------------------------------------------------- |
+| `$text`   | `ValueExpr`           | required    | Resolves to a string. Non-strings are coerced via `String()`.              |
+| `marks`   | `"default" \| "none"` | `"default"` | `"default"` runs the standard mark pipeline; `"none"` skips it.            |
+| `default` | `string`              | `undefined` | Substitute string when the resolved value is `""`, `null`, or `undefined`. |
+
+`{ "$text": e }` with `marks: "default"` is equivalent to `{ "element": "TextRun", "props": { "text": e } }` with the standard mark pipeline applied — but shorter to write.
+
+### `$fragment`
+
+Explicit fragment of sibling render nodes. A bare array does the same job:
+
+```jsonc
+{ "$fragment": [ /* RenderNode, … */ ] }
+// — or, equivalently —
+[ /* RenderNode, … */ ]
+```
+
+### `$if`
+
+Structural conditional:
+
+```jsonc
+{
+  "$if": {
+    "test": { "$ref": "node.attrs.featured" },
+    "then": { "element": "Paragraph", "props": { "style": "Featured" } },
+    "else": null,
+  },
+}
+```
+
+| Field  | Type         | Default  | Description                                                                                    |
+| ------ | ------------ | -------- | ---------------------------------------------------------------------------------------------- |
+| `test` | `ValueExpr`  | required | Coerced to boolean. `false`, `null`, `undefined`, `0`, `""` are falsy; everything else truthy. |
+| `then` | `RenderNode` | required | Branch rendered when `test` is truthy.                                                         |
+| `else` | `RenderNode` | `null`   | Branch rendered when `test` is falsy.                                                          |
+
+### `$switch`
+
+Multi-way conditional. Lookup is exact-match against `cases` keys — there is no regex or glob matching:
+
+```jsonc
+{
+  "$switch": {
+    "on": { "$ref": "node.attrs.variant" },
+    "cases": {
+      "warning": { "element": "Paragraph", "props": { "style": "CalloutWarning" } },
+      "info": { "element": "Paragraph", "props": { "style": "CalloutInfo" } },
+    },
+    "default": { "element": "Paragraph", "props": { "style": "Callout" } },
+  },
+}
+```
+
+`on` must resolve to a string at runtime; non-strings reject with `DOCX_DSL_RUNTIME_TYPE_MISMATCH`. `default` is the fallback when no case matches; if omitted, the default is `null` (render nothing).
+
+`$switch` is **also valid as a value expression** — see [Value-form `$switch`](#value-form-switch).
+
+---
+
+## Element catalog
+
+The DSL ships with a closed set of supported elements. Adding new elements is a versioned change. Unknown names reject with `DOCX_DSL_UNKNOWN_ELEMENT`.
+
+| Element             | Kind         | Allowed in      | Children kind           | Notes                                                                                                                                                    |
+| ------------------- | ------------ | --------------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Paragraph`         | `block`      | document, block | `inline`                | Standard text block.                                                                                                                                     |
+| `TextRun`           | `inline`     | inline          | (leaf)                  | Standard text run.                                                                                                                                       |
+| `ExternalHyperlink` | `inline`     | inline          | `inline` (TextRun-only) | Wraps one or more `TextRun`s in a hyperlink.                                                                                                             |
+| `Table`             | `block`      | document, block | `table-row`             | Children populate `rows`, not `children`.                                                                                                                |
+| `TableRow`          | `table-row`  | table-row       | `table-cell`            | One row of a table.                                                                                                                                      |
+| `TableCell`         | `table-cell` | table-cell      | `block`                 | One cell of a row; contains block content.                                                                                                               |
+| `PageBreak`         | `block`      | document, block | (leaf)                  | Emits a paragraph containing a docx page-break run. For an inline page break inside a paragraph use `{ "element": "TextRun", "props": { "break": 1 } }`. |
+
+`ImageRun` is **not** part of v1. Image data flows through the built-in `image` PM node only — your DSL rule can `$children` into it, but the DSL itself never originates image bytes. This is a security guarantee on the REST surface.
+
+### Containment
+
+The validator rejects every illegal parent/child combination at compile time, with the exact `dslPath` of the offending node.
+
+| Parent slot ↓ \ child kind → | block |               inline                | table-row | table-cell |
+| ---------------------------- | :---: | :---------------------------------: | :-------: | :--------: |
+| Document body                |   ✓   |                                     |           |            |
+| `Paragraph.children`         |       |                  ✓                  |           |            |
+| `ExternalHyperlink.children` |       |          ✓ (TextRun only)           |           |            |
+| `Table.rows`                 |       |                                     |     ✓     |            |
+| `TableRow.children`          |       |                                     |           |     ✓      |
+| `TableCell.children`         |   ✓   | (only with `wrapInlineInParagraph`) |           |            |
+
+Mismatch example:
+
+```jsonc
+{
+  "error": "Element \"Paragraph\" cannot appear in \"inline\" slot.",
+  "code": "DOCX_DSL_INVALID_CONTEXT",
+  "dslPath": "nodes[1].render.emit.children[0]",
+}
+```
+
+### Element properties
+
+Every element validates its `props` against a strict schema. Unknown keys reject with `DOCX_DSL_INVALID_PROP`.
+
+#### Paragraph
+
+```jsonc
+{
+  "style": "Hintbox",
+  "alignment": "left" | "center" | "right" | "justified" | "justify" | "both",
+  "heading": "heading1" | "heading2" | "heading3" | "heading4" | "heading5" | "heading6",
+  "spacing":  { "before": 120, "after": 120, "line": 240, "lineRule": "auto" | "exact" | "atLeast" },
+  "numbering":{ "reference": "bullet-list" | "ordered-list", "level": 0, "instance": 1 },
+  "indent":   { "left": 360, "right": 0, "firstLine": 360, "hanging": 0 },
+  "pageBreakBefore": false
+}
+```
+
+Spacing and indent values are in **twips** (1 twip = 1/20 of a point). Use the `$unit` helpers — `pointsToTwips`, `inchesToTwips`, etc. — if you'd rather express them in friendlier units.
+
+#### TextRun
+
+```jsonc
+{
+  "text": "hello",
+  "bold": true,
+  "italics": true,
+  "underline": true,
+  "underline": { "type": "single" | "double" | "thick" | "dotted" | "dash" | "wave", "color": "4F46E5" },
+  "strike": true,
+  "doubleStrike": true,
+  "superScript": true,
+  "subScript": true,
+  "size": 24,
+  "color": "1F2937",
+  "font": "Inter",
+  "highlight": "yellow",
+  "shading": { "type": "solid" | "clear", "fill": "F3F4F6", "color": "1F2937" },
+  "break": 1,
+  "style": "InlineCode"
+}
+```
+
+`size` is in **half-points** (so a 12pt run is `size: 24`). `color`, shading `fill` and `color`, and underline `color` are **6-character hex strings without `#`** (use the `hexNoHash` transform or the `normalizeColor` unit if your data has a `#` prefix).
+
+#### ExternalHyperlink
+
+```jsonc
+{ "link": "https://tiptap.dev" }
+```
+
+The `link` value is required and validated to start with one of `http`, `https`, `mailto`, `tel`. Any other protocol is rejected at compile time. The link is capped at 2048 characters.
+
+`ExternalHyperlink` requires at least one `TextRun` child; an empty hyperlink rejects at runtime with `DOCX_DSL_INVALID_CONTEXT`.
+
+#### Table
+
+```jsonc
+{
+  "width":   { "size": 100, "type": "pct" | "auto" | "dxa" | "nil" },
+  "layout":  "fixed" | "autofit",
+  "columnWidths": [2400, 2400, 2400],
+  "margins": { "top": 100, "bottom": 100, "left": 120, "right": 120 },
+  "borders": {
+    "top":              { "style": "single", "size": 4, "color": "B8D8FF" },
+    "bottom":           { "style": "single", "size": 4, "color": "B8D8FF" },
+    "left":             { "style": "single", "size": 4, "color": "B8D8FF" },
+    "right":            { "style": "single", "size": 4, "color": "B8D8FF" },
+    "insideHorizontal": { "style": "single", "size": 4, "color": "B8D8FF" },
+    "insideVertical":   { "style": "single", "size": 4, "color": "B8D8FF" }
+  }
+}
+```
+
+`Table` children populate the docx.js `rows` argument — you don't need to write `rows` yourself. A table requires at least one row (an empty table rejects at runtime).
+
+#### TableRow
+
+```jsonc
+{
+  "tableHeader": false,
+  "cantSplit":   false,
+  "height":      { "value": 480, "rule": "auto" | "exact" | "atLeast" }
+}
+```
+
+A row requires at least one cell.
+
+#### TableCell
+
+```jsonc
+{
+  "width":         { "size": 50, "type": "pct" | "auto" | "dxa" | "nil" },
+  "columnSpan":    1,
+  "rowSpan":       1,
+  "shading":       { "type": "solid" | "clear", "fill": "FFF1CC", "color": "1F2937" },
+  "borders":       { "top": …, "bottom": …, "left": …, "right": … },
+  "margins":       { "top": 100, "bottom": 100, "left": 120, "right": 120 },
+  "verticalAlign": "top" | "center" | "bottom"
+}
+```
+
+#### PageBreak
+
+```jsonc
+{}
+```
+
+`PageBreak` takes no props. It emits a block-level paragraph containing a docx page-break run.
+
+---
+
+## Value expressions
+
+Anywhere a prop value (or a `$text` value, `$if.test`, `$switch.on`, etc.) is accepted, you can pass a literal **or** one of the typed value expressions below. Values that aren't expressions — strings, numbers, booleans, `null`, arrays, plain objects — pass through verbatim. Plain objects are walked recursively, so nested structures like `spacing` can carry expressions in any leaf.
+
+The expression language is **deliberately small**. There is no string concatenation operator (use `$template`), no array indexing (use exact attribute paths), no `eval`, no general computation. The five primitives below cover what real custom-node renderers need.
+
+### `$ref` — read a PM-node attribute
+
+```jsonc
+{
+  "$ref": "node.attrs.color",
+  "default": "4F46E5",
+  "transform": "hexNoHash",
+}
+```
+
+| Field       | Type                               | Default     | Description                                                                                            |
+| ----------- | ---------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------ |
+| `$ref`      | `string`                           | required    | Dotted path. Identifier segments only (`/^[a-zA-Z_][a-zA-Z0-9_]*$/`); no array indexing, no wildcards. |
+| `default`   | `ValueExpr`                        | `undefined` | Substitute when the path resolves to `null` or `undefined`.                                            |
+| `transform` | `TransformName \| TransformName[]` | `undefined` | One or more whitelisted post-processors applied after resolution.                                      |
+
+Allowed paths:
+
+| Path               | Returns                                                                                        |
+| ------------------ | ---------------------------------------------------------------------------------------------- |
+| `node`             | The whole PM node object.                                                                      |
+| `node.type`        | The PM node type name.                                                                         |
+| `node.attrs`       | The whole attrs object.                                                                        |
+| `node.attrs.<key>` | The named attribute (only one level deep — `node.attrs.style.color` is **not** allowed in v1). |
+| `node.text`        | The PM node's `text` field (only meaningful for text nodes).                                   |
+| `node.textContent` | Concatenation of all descendant text nodes — equivalent to ProseMirror's `node.textContent`.   |
+
+Other paths reject:
+
+- `node.content`, `node.marks` → `DOCX_DSL_INVALID_REF` (no traversal model in v1).
+- `loop.*`, `$parent`, `$siblings`, `$depth`, `$root` → `DOCX_DSL_RESERVED_SHAPE` (reserved for future versions).
+- `__proto__`, `prototype`, `constructor` segments anywhere in the path → `DOCX_DSL_INVALID_REF` (prototype-pollution guard).
+- Function-valued resolutions → `DOCX_DSL_INVALID_REF`.
+
+### `$template` — string interpolation
+
+```jsonc
+{ "$template": "@{node.attrs.label}" }
+```
+
+Always returns a string. Substitutions use `{path}` (same path grammar as `$ref`). `{{` and `}}` escape literal braces. The resolved length is capped at `maxTemplateLength` (default 2000); exceeding it rejects with `DOCX_DSL_RESOURCE_LIMIT` at runtime.
+
+### `$op` — typed compute
+
+```jsonc
+{ "$op": "mul", "args": [{ "$ref": "node.attrs.size" }, 2] }
+```
+
+| Op                                 | Arity          | Notes                                                            |
+| ---------------------------------- | -------------- | ---------------------------------------------------------------- |
+| `add`, `mul`                       | ≥ 2 (variadic) | Numeric. Mixing types rejects.                                   |
+| `sub`, `div`                       | exactly 2      | Numeric.                                                         |
+| `eq`, `ne`, `lt`, `le`, `gt`, `ge` | exactly 2      | Both sides must be the same primitive type (numbers or strings). |
+| `and`, `or`                        | ≥ 2            | Short-circuiting on truthiness.                                  |
+| `not`                              | exactly 1      | Boolean.                                                         |
+| `coalesce`                         | ≥ 2            | Returns the first non-`null`, non-`undefined` argument.          |
+
+There is no `concat` op — use `$template` for strings. There is no implicit numeric coercion — `{ "$op": "add", "args": ["3", 1] }` rejects with `DOCX_DSL_RUNTIME_TYPE_MISMATCH`.
+
+### `$unit` — unit / coercion helper
+
+```jsonc
+{ "$unit": "pointsToTwips", "value": 12 }
+```
+
+Bridges to a closed list of helpers. The result type matches the helper's signature.
+
+| Unit                      | Input                                 | Output                                   |
+| ------------------------- | ------------------------------------- | ---------------------------------------- |
+| `pixelsToHalfPoints`      | number (px)                           | number (half-points)                     |
+| `pixelsToPoints`          | number (px)                           | number (points)                          |
+| `pointsToHalfPoints`      | number (pt)                           | number (half-points)                     |
+| `pointsToTwips`           | number (pt)                           | number (twips)                           |
+| `lineHeightToDocx`        | number (multiplier)                   | number (docx line value)                 |
+| `universalMeasureToTwips` | string `"1.5cm"`/`"10pt"`/… or number | number (twips)                           |
+| `normalizeColor`          | string (any CSS color)                | 6-char hex string without `#`, or `null` |
+| `inchesToTwips`           | number (in)                           | number (twips)                           |
+| `cmToTwips`               | number (cm)                           | number (twips)                           |
+| `mmToTwips`               | number (mm)                           | number (twips)                           |
+
+These are the same helpers used by the function-based `customNodes` API, exposed for DSL authors so the wire format matches the editor extension's runtime semantics exactly.
+
+### Value-form `$switch`
+
+`$switch` is **also legal as a value expression** — useful for choosing a prop value from an attribute:
+
+```jsonc
+{
+  "color": {
+    "$switch": {
+      "on": { "$ref": "node.attrs.variant" },
+      "cases": { "warning": "F59E0B", "info": "0EA5E9" },
+      "default": "1F2937",
+    },
+  },
+}
+```
+
+The validator picks the value form vs the structural render-tree form by surrounding context. Inside `props` you get a value expression; in a `RenderNode` slot you get the structural form.
+
+### Transforms
+
+Applied after `$ref` resolution (or to `default` when the path was missing):
+
+| Transform                | Behavior                                                                                              |
+| ------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `hexNoHash`              | Strip leading `#`; the remainder must match `/^[0-9A-Fa-f]{6}$/`. Rejects non-strings or invalid hex. |
+| `lower`, `upper`, `trim` | Standard string ops. Reject non-strings.                                                              |
+| `parseIntStrict`         | `parseInt(value, 10)`; rejects `NaN`.                                                                 |
+| `parseFloatStrict`       | `parseFloat(value)`; rejects `NaN`.                                                                   |
+| `boolean`                | Strict: accepts `true`/`false`, `"true"`/`"false"` (case-insensitive). Rejects everything else.       |
+| `nullableString`         | Empty/whitespace string → `null`; otherwise trimmed string.                                           |
+
+`hexNoHash` is **not** a CSS-color normalizer (it does not understand `rgb()`, named colors, `#abc` shorthand, etc.). Use `{ "$unit": "normalizeColor", "value": … }` if you need that.
+
+### Truthiness rules
+
+For `$if.test` and the boolean ops `and` / `or` / `not` / `coalesce`:
+
+| Falsy                                   | Truthy          |
+| --------------------------------------- | --------------- |
+| `false`, `null`, `undefined`, `0`, `""` | everything else |
+
+There is no implicit type coercion outside of these explicit rules.
+
+---
+
+## Marks system
+
+Marks (`bold`, `italic`, `underline`, `strike`, `code`, `subscript`, `superscript`, `textStyle`, `highlight`, `link`) are the source of much of DOCX's run-level formatting. The DSL gives you two mark hooks:
+
+1. **`MarkPolicy`** on `$children` and `$text` — controls how the standard pipeline maps marks on **text children**.
+2. **`applyMarks`** on inline elements (`TextRun`, `ExternalHyperlink`) — controls how the **rule's own** PM-node marks merge onto the emitted run.
+
+### `MarkPolicy` (on `$children` / `$text`)
+
+```jsonc
+"marks": "default"           // standard Tiptap mark mapping (the default)
+"marks": "none"              // ignore all marks
+"marks": "node"              // use the rule's own PM node's marks instead of each child's
+"marks": {
+  "mode": "default" | "node",
+  "overrides": {
+    "bold":   { "props": { "color": "DC2626" }, "replace": false },
+    "italic": { "replace": true }
+  },
+  "disable": ["highlight"]
+}
+```
+
+| Field                       | Default                   | Description                                                                                               |
+| --------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `mode`                      | required (in object form) | `"default"` runs the standard mark pipeline; `"node"` runs it against the rule's own PM-node marks.       |
+| `overrides[<mark>].props`   | `{}`                      | Extra `TextRun` props to apply when this mark is present.                                                 |
+| `overrides[<mark>].replace` | `false`                   | When `true`, suppress the standard mapping for this mark and apply only the override `props`.             |
+| `disable`                   | `[]`                      | Marks to skip entirely. Their standard mappings do not run and any matching `overrides` entry is ignored. |
+
+`MarkPolicy: "default"` is the default for `$children: { as: "inline" }` and `$text` — the same standard pipeline a normal text run would receive.
+
+### `applyMarks` (on inline elements)
+
+`applyMarks` is distinct from `MarkPolicy`: it always uses the **rule's own** PM-node marks (the marks on the custom node itself), not the children's marks. Because there's no other choice, the only valid `mode` is `"node"`:
+
+```jsonc
+"applyMarks": "node"
+"applyMarks": {
+  "mode": "node",
+  "overrides": { "underline": { "props": { "color": "EA580C" } } },
+  "disable": ["highlight"]
+}
+```
+
+`'default'` and `'none'` are deliberately rejected on `applyMarks` — they only have meaning for child marks.
+
+When `applyMarks` is omitted, the rule's PM-node marks are **ignored**. Most explicitly styled inline custom nodes want this default — you set the colors and font yourself, and let the wrapping marks fall away.
+
+### Override precedence
+
+When several layers want to set the same property, the last one in this ordered ladder wins:
+
+```
+1. base docx defaults
+2. cssStyles-derived styles               (the experimental cssStyles option)
+3. styleOverrides                         (named DOCX styles)
+4. global *Overrides options              (paragraphOverrides, textRunOverrides, …)
+5. built-in Tiptap node/mark mapping      (the standard pipeline)
+6. DSL child-pipeline mark overrides      (MarkPolicy.overrides[<mark>])
+7. DSL applyMarks props on inline elements
+8. explicit DSL element props
+```
+
+`inheritOverrides: false` on an `ElementNode` skips layer 4 for that element only — useful when you want a single hint-box paragraph to opt out of `paragraphOverrides` without affecting any other paragraph.
+
+Nested objects (`spacing`, `borders`, `shading`) are **replaced** at each layer, not deep-merged. If you set `spacing: { before: 120 }` and the underlying `paragraphOverrides` has `spacing: { line: 240 }`, the result is just `{ before: 120 }`. Same convention as the existing extension options.
+
+---
+
+## Putting it together — worked examples
+
+### Hintbox (block, custom style, standard children)
+
+```jsonc
+{
+  "type": "hintbox",
+  "nodeKind": "block",
+  "render": {
+    "emit": {
+      "element": "Paragraph",
+      "props": { "style": "Hintbox" },
+      "children": { "$children": { "as": "inline", "marks": "default" } },
+    },
+  },
+}
+```
+
+Pair with a `Hintbox` paragraph entry under [`styleOverrides.paragraphStyles`](/conversion/export/docx/styles).
+
+### Mention (inline, templated text, mark inheritance)
+
+```jsonc
+{
+  "type": "mention",
+  "nodeKind": "inline",
+  "render": {
+    "emit": {
+      "element": "TextRun",
+      "props": {
+        "text": { "$template": "@{node.attrs.label}" },
+        "color": { "$ref": "node.attrs.color", "default": "4472C4", "transform": "hexNoHash" },
+      },
+      "applyMarks": "node",
+    },
+  },
+}
+```
+
+A bold mention renders as `new TextRun({ text: '@alice', color: '4472C4', bold: true })`.
+
+### Callout box (table, conditional style, attribute-driven shading)
+
+```jsonc
+{
+  "type": "calloutBox",
+  "nodeKind": "block",
+  "render": {
+    "emit": {
+      "element": "Table",
+      "props": {
+        "width": { "size": 100, "type": "pct" },
+        "borders": {
+          "top": { "style": "single", "size": 4, "color": "B8D8FF" },
+          "bottom": { "style": "single", "size": 4, "color": "B8D8FF" },
+          "left": { "style": "single", "size": 4, "color": "B8D8FF" },
+          "right": { "style": "single", "size": 4, "color": "B8D8FF" },
+        },
+      },
+      "children": [
+        {
+          "element": "TableRow",
+          "children": [
+            {
+              "element": "TableCell",
+              "props": {
+                "shading": {
+                  "type": "clear",
+                  "fill": {
+                    "$unit": "normalizeColor",
+                    "value": { "$ref": "node.attrs.backgroundColor", "default": "E6F3FF" },
+                  },
+                },
+                "margins": {
+                  "top": { "$unit": "pointsToTwips", "value": 8 },
+                  "bottom": { "$unit": "pointsToTwips", "value": 8 },
+                  "left": { "$unit": "pointsToTwips", "value": 10 },
+                  "right": { "$unit": "pointsToTwips", "value": 10 },
+                },
+              },
+              "children": [
+                {
+                  "element": "Paragraph",
+                  "props": {
+                    "style": {
+                      "$switch": {
+                        "on": { "$ref": "node.attrs.variant" },
+                        "cases": { "warning": "CalloutWarning", "info": "CalloutInfo" },
+                        "default": "Callout",
+                      },
+                    },
+                  },
+                  "children": { "$children": { "as": "inline", "marks": "default" } },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
+}
+```
+
+### Code block (suppress conflicting child marks)
+
+```jsonc
+{
+  "type": "codeBlock",
+  "nodeKind": "block",
+  "render": {
+    "emit": {
+      "element": "Paragraph",
+      "props": { "style": "Code" },
+      "children": {
+        "$children": {
+          "as": "inline",
+          "marks": { "mode": "default", "disable": ["bold", "italic"] },
+        },
+      },
+    },
+  },
+}
+```
+
+### Custom link (inline hyperlink with mark inheritance)
+
+```jsonc
+{
+  "type": "customLink",
+  "nodeKind": "inline",
+  "render": {
+    "emit": {
+      "element": "ExternalHyperlink",
+      "props": { "link": { "$ref": "node.attrs.href" } },
+      "children": [
+        {
+          "element": "TextRun",
+          "props": {
+            "text": { "$ref": "node.attrs.label" },
+            "style": "Hyperlink",
+          },
+          "applyMarks": "node",
+        },
+      ],
+    },
+  },
+}
+```
+
+---
+
+## Conflict policy with the function API
+
+When the editor extension is configured with both `customNodes` and `customNodeDsl`:
+
+| Scenario                                          | Outcome                                                                            |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Same `type` in both                               | Function wins. One `console.warn` is emitted per export call per conflicting type. |
+| Type only in `customNodes`                        | Function renders.                                                                  |
+| Type only in `customNodeDsl.nodes`                | DSL renders.                                                                       |
+| Type in neither                                   | Existing "Custom node not found" behaviour; node is dropped with a console error.  |
+| Duplicate `type` **within** `customNodeDsl.nodes` | Compile error: `DOCX_DSL_DUPLICATE_NODE_TYPE`.                                     |
+
+This is the contract: a customer with no DSL knowledge upgrades the package version with no code changes and observes identical output. Adding `customNodeDsl` only **adds** rules; it never overrides existing function-based custom nodes.
+
+The REST surface does not accept the function API at all — only `customNodeDsl`.
+
+---
+
+## Resource limits
+
+The DSL is untrusted JSON over the public REST surface. Resource caps are enforced at compile and runtime. Legitimate custom-node programs should never hit them.
+
+| Limit                 | Default | Description                                                                           |
+| --------------------- | ------- | ------------------------------------------------------------------------------------- |
+| `maxRules`            | 128     | Maximum number of node rules in a single DSL document.                                |
+| `maxRenderDepth`      | 32      | Maximum recursion depth during render-tree compile and runtime traversal.             |
+| `maxRenderNodes`      | 1024    | Maximum compiled render-node count in a single program.                               |
+| `maxValueDepth`       | 16      | Maximum recursion depth inside value expressions (`$ref` defaults, `$op` args, etc.). |
+| `maxStringLength`     | 10 000  | Maximum length of a string prop after evaluation.                                     |
+| `maxTemplateLength`   | 2 000   | Maximum length of a `$template` result after substitution.                            |
+| `maxOpArgs`           | 32      | Maximum argument count for any single `$op`.                                          |
+| `maxTableRows`        | 1 024   | Maximum number of `TableRow` children a `Table` may emit.                             |
+| `maxTableCellsPerRow` | 64      | Maximum number of `TableCell` children a single `TableRow` may emit.                  |
+
+### Tuning limits in the editor extension
+
+Pass `customNodeDslLimits?: Partial<CustomNodeDslLimits>` alongside `customNodeDsl`:
+
+```ts
+ExportDocx.configure({
+  customNodeDsl,
+  customNodeDslLimits: {
+    maxRules: 256,
+    maxRenderDepth: 48,
+  },
+})
+```
+
+The wire format itself has **no** `limits` field. The reserved root key `limits` rejects with `DOCX_DSL_RESERVED_SHAPE` so server-administered limits cannot be subverted by the client payload.
+
+---
+
+## Errors
+
+Every error carries a stable `code` and a `dslPath` pointing into the offending JSON. Runtime errors additionally carry `nodePath` (path into the PM document) and `nodeType`.
+
+```jsonc
+{
+  "error": "Expected TextRun.size to be number, got string.",
+  "code": "DOCX_DSL_INVALID_PROP",
+  "dslPath": "nodes[2].render.emit.props.size",
+  "nodePath": "doc.content[4].content[2]",
+  "nodeType": "mention",
+}
+```
+
+### Error codes
+
+| Code                             | When                                                                                                                         |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `DOCX_DSL_UNKNOWN_VERSION`       | `dslVersion` is present but not `"1.0"`.                                                                                     |
+| `DOCX_DSL_INVALID_SHAPE`         | The JSON does not match the expected shape (missing required field, wrong type).                                             |
+| `DOCX_DSL_DUPLICATE_NODE_TYPE`   | Two rules in `nodes` declare the same `type`.                                                                                |
+| `DOCX_DSL_UNKNOWN_ELEMENT`       | `element` is not in the v1 catalog.                                                                                          |
+| `DOCX_DSL_UNKNOWN_OPERATION`     | `$op` is not in the closed list.                                                                                             |
+| `DOCX_DSL_RESERVED_SHAPE`        | A key reserved for future versions appeared in the payload.                                                                  |
+| `DOCX_DSL_INVALID_PROP`          | An element prop fails its schema (unknown key, wrong type).                                                                  |
+| `DOCX_DSL_INVALID_ENUM`          | An enum prop received a value outside the closed list.                                                                       |
+| `DOCX_DSL_INVALID_REF`           | `$ref` path is malformed, points outside the allowed roots, or hits a forbidden segment.                                     |
+| `DOCX_DSL_INVALID_TEMPLATE`      | `$template` malformed (e.g. unbalanced braces).                                                                              |
+| `DOCX_DSL_INVALID_UNIT`          | `$unit` name is not in the closed list.                                                                                      |
+| `DOCX_DSL_INVALID_TRANSFORM`     | `transform` name is not in the closed list.                                                                                  |
+| `DOCX_DSL_INVALID_CONTEXT`       | A render node is in a slot its element kind isn't allowed in (containment violation).                                        |
+| `DOCX_DSL_INVALID_OP_ARITY`      | An `$op` was passed the wrong number of arguments.                                                                           |
+| `DOCX_DSL_RUNTIME_TYPE_MISMATCH` | A value-expression result didn't match the expected type at runtime (e.g. `$switch.on` resolved to a number).                |
+| `DOCX_DSL_RESOURCE_LIMIT`        | A configurable cap was exceeded (depth, node count, string length, …).                                                       |
+| `DOCX_DSL_RENDER_FAILED`         | The adapter `instantiate` step threw — generally indicates a docx.js incompatibility, surfaced with the offending `dslPath`. |
+| `DOCX_DSL_DISABLED`              | (REST only) `DOCX_DSL_ENABLED=false` was set and the request included a `customNodeDsl` field.                               |
+
+### HTTP status mapping (REST)
+
+| Class                                    | Status                                             |
+| ---------------------------------------- | -------------------------------------------------- |
+| Compile errors (caught by the validator) | `400`                                              |
+| Runtime errors (caught while rendering)  | `422`                                              |
+| Resource caps exceeded at compile        | `400`                                              |
+| Resource caps exceeded at runtime        | `422`                                              |
+| `DOCX_DSL_DISABLED` rollback flag        | `503`                                              |
+| docx.js itself fails (rare)              | `422` (existing `FAILED_TO_EXPORT_DOCX_FILE` path) |
+
+### Behavior matrix (REST)
+
+| Scenario                                                        | HTTP  | Body code                  |
+| --------------------------------------------------------------- | ----- | -------------------------- |
+| No `customNodeDsl` field                                        | `200` | unchanged DOCX response    |
+| Valid `customNodeDsl`, all rules render                         | `200` | DOCX                       |
+| Missing `dslVersion`                                            | `400` | `DOCX_DSL_INVALID_SHAPE`   |
+| Wrong `dslVersion`                                              | `400` | `DOCX_DSL_UNKNOWN_VERSION` |
+| `customNodeDsl.nodes` exceeds `maxRules`                        | `400` | `DOCX_DSL_RESOURCE_LIMIT`  |
+| Reserved root key (`requiresStyles`, etc.)                      | `400` | `DOCX_DSL_RESERVED_SHAPE`  |
+| Invalid containment                                             | `400` | `DOCX_DSL_INVALID_CONTEXT` |
+| Unknown element name                                            | `400` | `DOCX_DSL_UNKNOWN_ELEMENT` |
+| Invalid `$ref` path                                             | `400` | `DOCX_DSL_INVALID_REF`     |
+| Required attribute resolves to `undefined`, prop schema rejects | `422` | `DOCX_DSL_INVALID_PROP`    |
+| Depth cap exceeded at runtime                                   | `422` | `DOCX_DSL_RESOURCE_LIMIT`  |
+| Rollback flag set with DSL present                              | `503` | `DOCX_DSL_DISABLED`        |
+
+The DSL is **fail-fast**: any error aborts the export with no partial output. Silent partial output produces invalid DOCX that is harder to debug than an explicit error.
+
+---
+
+## Security model
+
+The REST surface accepts arbitrary `customNodeDsl` from authenticated clients. The DSL is designed so no combination of valid inputs can reach docx.js internals, the host filesystem, or the network.
+
+| Threat                                                                     | Mitigation                                                                                                              |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Arbitrary code execution                                                   | No `eval`, no `Function`, no dynamic imports. Closed adapter / op / unit / transform whitelists.                        |
+| Property access outside PM node                                            | `$ref` resolver walks `node.*` only; no array indexing, no prototype walk.                                              |
+| Prototype pollution via `__proto__` / `prototype` / `constructor` segments | Path-segment guard rejects them with `DOCX_DSL_INVALID_REF`.                                                            |
+| OOM via deep nesting                                                       | `maxRenderDepth: 32` enforced at compile and per recursive call.                                                        |
+| OOM via large payloads                                                     | `maxRules`, `maxRenderNodes`, `maxStringLength`, `maxTemplateLength` caps.                                              |
+| OOM via tables                                                             | `maxTableRows: 1024`, `maxTableCellsPerRow: 64`.                                                                        |
+| Quadratic time on `$template` resolution                                   | `maxTemplateLength` cap on resolved length; `maxOpArgs: 32` on op argument lists.                                       |
+| Malformed docx output                                                      | Per-element Zod prop schemas catch most issues at compile; runtime values are type-checked before docx.js constructors. |
+| Unauthorized media fetches                                                 | The DSL has no `ImageRun.data` field; image data flows only through the built-in `image` PM node.                       |
+| Malicious URLs                                                             | `ExternalHyperlink.link` is whitelisted to `http`, `https`, `mailto`, `tel`.                                            |
+
+---
+
+## REST API addendum
+
+The DSL travels on the existing `POST /v2/convert/export/docx` endpoint as a sibling of the existing `styleOverrides`, `pageSize`, `pageMargins`, `headers`, and `footers` fields. See the [REST API reference](/conversion/export/docx/rest-api) for headers, response shape, and the rest of the body schema.
+
+| Body field      | Type                                              | Default     | Description               |
+| --------------- | ------------------------------------------------- | ----------- | ------------------------- |
+| `customNodeDsl` | `Object` ([`CustomNodeDsl`](#top-level-document)) | `undefined` | Custom-node render rules. |
+
+When the request comes in `multipart/form-data` (the form variant of the endpoint), `customNodeDsl` is sent as a **JSON-stringified value** in the form field of the same name, exactly like `styleOverrides`. The service parses it and forwards the result to the export pipeline.
+
+---
+
+## What's intentionally not here
+
+These are **explicit boundaries**, not bugs:
+
+- **Loops over array attributes.** There is no `$each` in v1. The shape is reserved (`DOCX_DSL_RESERVED_SHAPE`) so it can be added without breaking any payloads compiled today. Until then, model variable-length collections by emitting them from the parent (block) and using `$children` to dispatch their items.
+- **Cross-rule attribute access.** A child rule cannot read its parent rule's PM node. The escape hatch is `$children: { as: "inline", marks: "node" }` on the parent rule, which forwards the parent's marks to the child run.
+- **Free-form expressions.** The DSL is not Turing-complete and does not embed Jexl / JSONata / `eval`. All operations are typed and capped.
+- **Image data origination.** Image bytes never come from the DSL; they come from the built-in `image` PM node.
+- **Document-level style contributions.** The DSL describes how _nodes_ render. Named styles still live in [`styleOverrides`](/conversion/export/docx/styles). The reserved `requiresStyles` and `contributedStyles` root keys mark the future surface.
+- **Editing a `dslVersion` payload between versions.** `dslVersion: "1.0"` is an exact literal. Future minor versions will be additive (new optional fields, new operations) and will accept v1.0 payloads unchanged. Major version bumps will require explicit migration.
+
+---
+
+## Related
+
+- [Editor-extension custom nodes (function API)](/conversion/export/docx/custom-nodes) — the JavaScript-function variant for in-browser customisation.
+- [Style overrides](/conversion/export/docx/styles) — declare named DOCX styles like `Hintbox`, `CalloutWarning`, that DSL rules reference by id.
+- [CSS to DOCX](/conversion/export/docx/css-to-docx) — compose with the DSL: the `cssStyles` layer feeds heading and paragraph styles, while DSL rules cover your custom-node types.
+- [DOCX REST API](/conversion/export/docx/rest-api) — request shape, headers, response, and error envelope for the underlying endpoint.
+- [Editor extension overview](/conversion/export/docx/editor-extension) — full configuration surface for `ExportDocx.configure`.

--- a/src/content/conversion/export/docx/custom-nodes.mdx
+++ b/src/content/conversion/export/docx/custom-nodes.mdx
@@ -6,11 +6,12 @@ tags:
   - type: version
     label: v0.13.0
 meta:
-    title: Export custom nodes to DOCX | Tiptap Conversion
-    description: Learn how to export custom nodes to DOCX (Word) files using the Export extension.
-    category: Conversion
+  title: Export custom nodes to DOCX | Tiptap Conversion
+  description: Learn how to export custom nodes to DOCX (Word) files using the Export extension.
+  category: Conversion
 ---
 
+import { Callout } from '@/components/ui/Callout'
 import { CodeDemo } from '@/components/CodeDemo'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
@@ -19,17 +20,25 @@ import CustomNodeConversionGuide from '../_shared/_custom-node-conversion-guide.
 <EnterpriseCalloutAuto variant="docx" renderMode="sidebar" disableWaitlist />
 
 <Requirements>
-    <RequirementItem label="1. Activate trial or subscribe">
-        Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start plan](https://cloud.tiptap.dev/v2/billing) in your account.
-    </RequirementItem>
-    <RequirementItem label="2. Install from private registry">
-        To install this frontend extensions, authenticate to Tiptap's private npm registry by following the [setup guide](/guides/pro-extensions).
-    </RequirementItem>
+  <RequirementItem label="1. Activate trial or subscribe">
+    Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start
+    plan](https://cloud.tiptap.dev/v2/billing) in your account.
+  </RequirementItem>
+  <RequirementItem label="2. Install from private registry">
+    To install this frontend extensions, authenticate to Tiptap's private npm registry by following
+    the [setup guide](/guides/pro-extensions).
+  </RequirementItem>
 </Requirements>
 
 One of the biggest advantages of the `@tiptap-pro/extension-export-docx` extension is the ability to define how custom nodes in your Tiptap schema should be rendered in DOCX.
 
 This allows you to preserve application-specific content in the exported Word file.
+
+<Callout variant="hint" title="Looking for the REST-compatible variant?">
+  Functions can't be serialized over HTTP, so the function API on this page only works inside the
+  editor extension. For a JSON-based equivalent that travels over REST and runs in both surfaces,
+  see the [Custom-nodes DSL](/conversion/export/docx/custom-nodes-dsl).
+</Callout>
 
 ## Export custom nodes to .docx
 
@@ -58,7 +67,7 @@ const editor = new Editor({
   extensions: [
     // Other extensions ...
     ExportDocx.configure({
-      onCompleteExport: result => {
+      onCompleteExport: (result) => {
         setIsLoading(false)
         const blob = new Blob([result], {
           type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
@@ -74,15 +83,15 @@ const editor = new Editor({
       customNodes: [
         {
           type: 'hintbox',
-          render: node => {
+          render: (node) => {
             // Here we define how our custom Hintbox node should be rendered in the DOCX.
             // Per the documentation, we should return a Docx node
             // that's either a Paragraph, an array of Paragraphs, a Table, a TextRun, an ExternalHyperlink, or null.
             return new Docx.Paragraph({
-              children: node.content.map(content => convertTextNode(content)),
+              children: node.content.map((content) => convertTextNode(content)),
               style: 'Hintbox', // Here we apply our custom style to the Paragraph node.
             })
-            },
+          },
         },
       ], // Custom nodes
       styleOverrides: {
@@ -129,10 +138,7 @@ const editor = new Editor({
 Then, at a later point in your application, you can export the editor content to a `DOCX` file:
 
 ```ts
-editor
-  .chain()
-  .exportDocx()
-  .run()
+editor.chain().exportDocx().run()
 ```
 
 You can construct any supported `DOCX` elements in the `render` function using the `Docx` library classes (`Paragraph`, `TextRun`, `Table`, etc.) that are provided via the `Docx` import from the `@tiptap-pro/extension-export-docx` package.

--- a/src/content/conversion/export/docx/rest-api.mdx
+++ b/src/content/conversion/export/docx/rest-api.mdx
@@ -6,9 +6,9 @@ tags:
   - type: version
     label: v2.12.0
 meta:
-    title: Export DOCX REST API | Tiptap Conversion
-    description: Learn how to export Tiptap JSON documents to DOCX format via the Conversion REST API.
-    category: Conversion
+  title: Export DOCX REST API | Tiptap Conversion
+  description: Learn how to export Tiptap JSON documents to DOCX format via the Conversion REST API.
+  category: Conversion
 ---
 
 import { Callout } from '@/components/ui/Callout'
@@ -19,23 +19,24 @@ import ElementOverridesRestApi from '../_shared/_element-overrides-rest-api.mdx'
 <EnterpriseCalloutAuto variant="docx" renderMode="sidebar" disableWaitlist />
 
 <Requirements>
-    <RequirementItem label="1. Activate trial or subscribe">
-        Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start plan](https://cloud.tiptap.dev/v2/billing) in your account.
-    </RequirementItem>
-    <RequirementItem label="2. Configure Convert app">
-       To use the Convert REST API retrieve your App ID and Convert secret from [your dashboard](https://cloud.tiptap.dev/v2/cloud/convert).
-    </RequirementItem>
+  <RequirementItem label="1. Activate trial or subscribe">
+    Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start
+    plan](https://cloud.tiptap.dev/v2/billing) in your account.
+  </RequirementItem>
+  <RequirementItem label="2. Configure Convert app">
+    To use the Convert REST API retrieve your App ID and Convert secret from [your
+    dashboard](https://cloud.tiptap.dev/v2/cloud/convert).
+  </RequirementItem>
 </Requirements>
 
 The DOCX export API converts Tiptap JSON documents into `.docx` (Microsoft Word) files. It uses the same conversion library as the [editor extension](/conversion/export/docx/editor-extension) and produces equivalent DOCX output for standard content.
 
-The REST API supports [style overrides](/conversion/export/docx/styles), page size and margins, headers/footers, and element-level overrides (`tableOverrides`, `paragraphOverrides`, `textRunOverrides`, `tableCellOverrides`, `imageOverrides`). It does not support custom node rendering or any option that requires JavaScript functions. If you need those capabilities, use the [editor extension](/conversion/export/docx/editor-extension), which also works server-side.
+The REST API supports [style overrides](/conversion/export/docx/styles), [custom-node rendering via the DSL](/conversion/export/docx/custom-nodes-dsl), page size and margins, headers/footers, and element-level overrides (`tableOverrides`, `paragraphOverrides`, `textRunOverrides`, `tableCellOverrides`, `imageOverrides`). It does not accept JavaScript-function options. For the function-based custom-node API, use the [editor extension](/conversion/export/docx/editor-extension), which also works server-side.
 
 <Callout title="Review the postman collection" variant="hint">
-    You can also experiment with the Document Conversion API by heading over to our [Postman
-    Collection](https://www.postman.com/tiptap-platform/workspace/tiptap-workspace/collection/33042171-bcc93ecb-8bad-4484-8cb0-d995ee23ae60).
+  You can also experiment with the Document Conversion API by heading over to our [Postman
+  Collection](https://www.postman.com/tiptap-platform/workspace/tiptap-workspace/collection/33042171-bcc93ecb-8bad-4484-8cb0-d995ee23ae60).
 </Callout>
-
 
 ## Export DOCX
 
@@ -43,12 +44,18 @@ The REST API supports [style overrides](/conversion/export/docx/styles), page si
 
 The `/v2/convert/export/docx` endpoint converts Tiptap documents into `DOCX` format. Users can `POST` documents to this endpoint and use various parameters to customize how different document elements are handled during the conversion process.
 
-
 <Callout title="Export customization support" variant="info">
-    The `/v2/convert/export/docx` endpoint accepts [style overrides](/conversion/export/docx/styles), page size/margins, headers/footers, and the five element-level overrides (`tableOverrides`, `paragraphOverrides`, `textRunOverrides`, `tableCellOverrides`, `imageOverrides`). It does not support custom node conversions, since those require JavaScript functions that cannot be serialized. For custom node conversions, use the [editor extension](/conversion/export/docx/editor-extension) or the [server side export guide](/conversion/export/docx/editor-extension#server-side-export).
+  The `/v2/convert/export/docx` endpoint accepts [style overrides](/conversion/export/docx/styles),
+  page size/margins, headers/footers, the five element-level overrides (`tableOverrides`,
+  `paragraphOverrides`, `textRunOverrides`, `tableCellOverrides`, `imageOverrides`), and
+  [custom-node rendering via the JSON DSL](/conversion/export/docx/custom-nodes-dsl). It does not
+  accept JavaScript-function options. For the function-based custom-node API, use the [editor
+  extension](/conversion/export/docx/editor-extension) or the [server side export
+  guide](/conversion/export/docx/editor-extension#server-side-export).
 </Callout>
 
 ### Example (cURL)
+
 ```bash
 curl --output example.docx -X POST "https://api.tiptap.dev/v2/convert/export/docx" \
     -H "Authorization: Bearer YOUR_TOKEN" \
@@ -61,7 +68,8 @@ curl --output example.docx -X POST "https://api.tiptap.dev/v2/convert/export/doc
 ```
 
 <Callout title="Subscription required" variant="warning">
-    This endpoint requires a valid Tiptap subscription. For more details review our [pricing page](https://tiptap.dev/pricing).
+  This endpoint requires a valid Tiptap subscription. For more details review our [pricing
+  page](https://tiptap.dev/pricing).
 </Callout>
 
 ### Required headers
@@ -74,31 +82,33 @@ curl --output example.docx -X POST "https://api.tiptap.dev/v2/convert/export/doc
 
 ### Body
 
-| Name                     | Type     | Description                                                        | Default     |
-| ------------------------ | -------- | ------------------------------------------------------------------ | ----------- |
-| `doc`                    | `String` | Tiptap's JSON                                                      | `N/A`       |
-| `exportType`             | `string` | The expected export type                                           | `blob`      |
-| `styleOverrides`         | `Object` | Style overrides                                                    | `{}`        |
-| `pageSize`               | `Object` | Page size configuration                                            | `undefined` |
-| `pageMargins`            | `Object` | Page margins configuration                                         | `undefined` |
-| `headers`                | `Object` | Page header configuration                                          | `undefined` |
-| `footers`                | `Object` | Page footer configuration                                          | `undefined` |
-| `tableOverrides`         | `Object` | Table-level rendering overrides                                    | `undefined` |
-| `paragraphOverrides`     | `Object` | Paragraph-level rendering overrides                                | `undefined` |
-| `textRunOverrides`       | `Object` | Text run rendering overrides                                       | `undefined` |
-| `tableCellOverrides`     | `Object` | Table cell rendering overrides                                     | `undefined` |
-| `imageOverrides`         | `Object` | Image rendering overrides                                          | `undefined` |
+| Name                 | Type     | Description                                                       | Default     |
+| -------------------- | -------- | ----------------------------------------------------------------- | ----------- |
+| `doc`                | `String` | Tiptap's JSON                                                     | `N/A`       |
+| `exportType`         | `string` | The expected export type                                          | `blob`      |
+| `styleOverrides`     | `Object` | Style overrides                                                   | `{}`        |
+| `pageSize`           | `Object` | Page size configuration                                           | `undefined` |
+| `pageMargins`        | `Object` | Page margins configuration                                        | `undefined` |
+| `headers`            | `Object` | Page header configuration                                         | `undefined` |
+| `footers`            | `Object` | Page footer configuration                                         | `undefined` |
+| `tableOverrides`     | `Object` | Table-level rendering overrides                                   | `undefined` |
+| `paragraphOverrides` | `Object` | Paragraph-level rendering overrides                               | `undefined` |
+| `textRunOverrides`   | `Object` | Text run rendering overrides                                      | `undefined` |
+| `tableCellOverrides` | `Object` | Table cell rendering overrides                                    | `undefined` |
+| `imageOverrides`     | `Object` | Image rendering overrides                                         | `undefined` |
+| `customNodeDsl`      | `Object` | [Custom-node DSL](/conversion/export/docx/custom-nodes-dsl) rules | `undefined` |
 
 #### Page Size Configuration
 
 The `pageSize` object allows you to customize the dimensions of your exported DOCX document:
 
-| Property | Type | Description | Default |
-| --- | --- | --- | --- |
-| `width` | `string` | The width of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px). | `"21.0cm"` |
+| Property | Type     | Description                                                                                          | Default    |
+| -------- | -------- | ---------------------------------------------------------------------------------------------------- | ---------- |
+| `width`  | `string` | The width of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px).  | `"21.0cm"` |
 | `height` | `string` | The height of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px). | `"29.7cm"` |
 
 **Example cURL with custom page size:**
+
 ```bash
 curl --output example.docx -X POST "https://api.tiptap.dev/v2/convert/export/docx" \
     -H "Authorization: Bearer YOUR_TOKEN" \
@@ -115,15 +125,15 @@ curl --output example.docx -X POST "https://api.tiptap.dev/v2/convert/export/doc
 
 The `pageMargins` object allows you to customize the margins of your exported DOCX document:
 
-| Property | Type | Description | Default |
-| --- | --- | --- | --- |
-| `top` | `string` | The top margin of the page. Can be negative. Must be a number followed by a valid unit (cm, in, pt, pc, mm, px). | `"1.0cm"` |
+| Property | Type     | Description                                                                                                         | Default   |
+| -------- | -------- | ------------------------------------------------------------------------------------------------------------------- | --------- |
+| `top`    | `string` | The top margin of the page. Can be negative. Must be a number followed by a valid unit (cm, in, pt, pc, mm, px).    | `"1.0cm"` |
 | `bottom` | `string` | The bottom margin of the page. Can be negative. Must be a number followed by a valid unit (cm, in, pt, pc, mm, px). | `"1.0cm"` |
-| `left` | `string` | The left margin of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px). | `"1.0cm"` |
-| `right` | `string` | The right margin of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px). | `"1.0cm"` |
-
+| `left`   | `string` | The left margin of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px).           | `"1.0cm"` |
+| `right`  | `string` | The right margin of the page. Must be a positive number followed by a valid unit (cm, in, pt, pc, mm, px).          | `"1.0cm"` |
 
 **Example cURL with custom page margins:**
+
 ```bash
 curl --output example.docx -X POST "https://api.tiptap.dev/v2/convert/export/docx" \
     -H "Authorization: Bearer YOUR_TOKEN" \
@@ -144,19 +154,23 @@ The headers and footers objects allows you to configure a set of headers and foo
 
 The `headers` object allows you to customize the headers of your exported DOCX document:
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `evenAndOddHeaders` | `boolean` | Whether to use different headers for odd and even pages |
-| `differentFirstPage` | `boolean` | Whether to use a different header on the first page. When `true`, the `first` value is used on page one instead of `default`. |
-| `default` | `string` | The standard default header on every page, or header on odd pages when the `evenAndOddHeaders` option is activated. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
-| `first` | `string` | The header on the first page. Only used when `differentFirstPage` is set to `true`. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
-| `even` | `string` | The header on even pages when the `evenAndOddHeaders` option is activated. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
+| Property             | Type      | Description                                                                                                                                                                                            |
+| -------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `evenAndOddHeaders`  | `boolean` | Whether to use different headers for odd and even pages                                                                                                                                                |
+| `differentFirstPage` | `boolean` | Whether to use a different header on the first page. When `true`, the `first` value is used on page one instead of `default`.                                                                          |
+| `default`            | `string`  | The standard default header on every page, or header on odd pages when the `evenAndOddHeaders` option is activated. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
+| `first`              | `string`  | The header on the first page. Only used when `differentFirstPage` is set to `true`. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting.                                 |
+| `even`               | `string`  | The header on even pages when the `evenAndOddHeaders` option is activated. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting.                                          |
 
 <Callout title="Plain text vs. Tiptap JSONContent">
-    Each header value can be either a **plain text string** (produces a simple unstyled header) or a **stringified Tiptap JSONContent** object (enables rich formatting such as bold, italic, links, etc.). When passing JSONContent, stringify the object with `JSON.stringify()` before sending it in the request body.
+  Each header value can be either a **plain text string** (produces a simple unstyled header) or a
+  **stringified Tiptap JSONContent** object (enables rich formatting such as bold, italic, links,
+  etc.). When passing JSONContent, stringify the object with `JSON.stringify()` before sending it in
+  the request body.
 </Callout>
 
 **Example cURL with custom headers:**
+
 ```bash
 curl --output example.docx -X POST "https://api.tiptap.dev/v2/convert/export/docx" \
     -H "Authorization: Bearer YOUR_TOKEN" \
@@ -173,19 +187,23 @@ curl --output example.docx -X POST "https://api.tiptap.dev/v2/convert/export/doc
 
 The `footers` object allows you to customize the footers of your exported DOCX document:
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `evenAndOddFooters` | `boolean` | Whether to use different footers for odd and even pages |
-| `differentFirstPage` | `boolean` | Whether to use a different footer on the first page. When `true`, the `first` value is used on page one instead of `default`. |
-| `default` | `string` | The standard default footer on every page, or footer on odd pages when the `evenAndOddFooters` option is activated. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
-| `first` | `string` | The footer on the first page. Only used when `differentFirstPage` is set to `true`. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
-| `even` | `string` | The footer on even pages when the `evenAndOddFooters` option is activated. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
+| Property             | Type      | Description                                                                                                                                                                                            |
+| -------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `evenAndOddFooters`  | `boolean` | Whether to use different footers for odd and even pages                                                                                                                                                |
+| `differentFirstPage` | `boolean` | Whether to use a different footer on the first page. When `true`, the `first` value is used on page one instead of `default`.                                                                          |
+| `default`            | `string`  | The standard default footer on every page, or footer on odd pages when the `evenAndOddFooters` option is activated. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting. |
+| `first`              | `string`  | The footer on the first page. Only used when `differentFirstPage` is set to `true`. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting.                                 |
+| `even`               | `string`  | The footer on even pages when the `evenAndOddFooters` option is activated. Accepts a plain text string or stringified Tiptap JSONContent for rich formatting.                                          |
 
 <Callout title="Plain text vs. Tiptap JSONContent">
-    Each footer value can be either a **plain text string** (produces a simple unstyled footer) or a **stringified Tiptap JSONContent** object (enables rich formatting such as bold, italic, links, etc.). When passing JSONContent, stringify the object with `JSON.stringify()` before sending it in the request body.
+  Each footer value can be either a **plain text string** (produces a simple unstyled footer) or a
+  **stringified Tiptap JSONContent** object (enables rich formatting such as bold, italic, links,
+  etc.). When passing JSONContent, stringify the object with `JSON.stringify()` before sending it in
+  the request body.
 </Callout>
 
 **Example cURL with custom footers:**
+
 ```bash
 curl --output example.docx -X POST "https://api.tiptap.dev/v2/convert/export/docx" \
     -H "Authorization: Bearer YOUR_TOKEN" \
@@ -251,6 +269,6 @@ On success the API returns the DOCX file as a binary download:
 | Status | Code                             | Description                          |
 | ------ | -------------------------------- | ------------------------------------ |
 | 400    | `NO_DOCUMENT_PROVIDED`           | No document was provided in the body |
-| 422    | `FAILED_TO_PARSE_DOCX_FILE`     | Failed to parse JSON inputs          |
-| 422    | `FAILED_TO_EXPORT_DOCX_FILE`    | Failed to export DOCX                |
-| 422    | `FAILED_TO_CONVERT_DOCX_TO_BLOB`| Failed to convert result type        |
+| 422    | `FAILED_TO_PARSE_DOCX_FILE`      | Failed to parse JSON inputs          |
+| 422    | `FAILED_TO_EXPORT_DOCX_FILE`     | Failed to export DOCX                |
+| 422    | `FAILED_TO_CONVERT_DOCX_TO_BLOB` | Failed to convert result type        |

--- a/src/content/conversion/sidebar.ts
+++ b/src/content/conversion/sidebar.ts
@@ -122,6 +122,11 @@ export const sidebarConfig: SidebarConfig = {
                   href: '/conversion/export/docx/custom-nodes',
                 },
                 {
+                  title: 'Custom nodes DSL',
+                  href: '/conversion/export/docx/custom-nodes-dsl',
+                  tags: ['Beta'],
+                },
+                {
                   title: 'Styles',
                   href: '/conversion/export/docx/styles',
                 },

--- a/src/content/conversion/sidebar.ts
+++ b/src/content/conversion/sidebar.ts
@@ -127,6 +127,11 @@ export const sidebarConfig: SidebarConfig = {
                   tags: ['Beta'],
                 },
                 {
+                  title: 'Custom nodes DSL builder',
+                  href: '/conversion/export/docx/custom-nodes-dsl-builder',
+                  tags: ['Beta'],
+                },
+                {
                   title: 'Styles',
                   href: '/conversion/export/docx/styles',
                 },


### PR DESCRIPTION
This pull request updates the DOCX export documentation and navigation to clarify and highlight support for custom node rendering via a new JSON-based DSL, in addition to the existing function-based API. It also improves the formatting and readability of the documentation, and adds a new sidebar entry for the custom nodes DSL.

**Custom Node Rendering & API Documentation:**

* The REST API documentation now clearly states support for custom-node rendering via a new JSON-based DSL (`customNodeDsl`), and distinguishes between the function-based API (editor extension only) and the REST-compatible DSL. The body parameter table and relevant callouts are updated accordingly. [[1]](diffhunk://#diff-ecd33df1d0541a5766bc2e04147dd045b5010851ed4413332fd67abb88bb6fbbL23-R58) [[2]](diffhunk://#diff-ecd33df1d0541a5766bc2e04147dd045b5010851ed4413332fd67abb88bb6fbbR99-R111)
* In the editor extension documentation, a new callout explains that the function-based custom node API is not available over REST, and directs users to the DSL documentation for REST-compatible custom node rendering.

**Navigation & Structure:**

* A new sidebar entry for "Custom nodes DSL" is added, marked as Beta, to help users discover the new feature.

**Formatting and Consistency:**

* Improved formatting of requirements, callouts, and tables for better readability and consistency across the documentation. [[1]](diffhunk://#diff-ecd33df1d0541a5766bc2e04147dd045b5010851ed4413332fd67abb88bb6fbbL64-R72) [[2]](diffhunk://#diff-ecd33df1d0541a5766bc2e04147dd045b5010851ed4413332fd67abb88bb6fbbL78-R86) [[3]](diffhunk://#diff-ecd33df1d0541a5766bc2e04147dd045b5010851ed4413332fd67abb88bb6fbbL119-R136) [[4]](diffhunk://#diff-ecd33df1d0541a5766bc2e04147dd045b5010851ed4413332fd67abb88bb6fbbL148-R173) [[5]](diffhunk://#diff-ecd33df1d0541a5766bc2e04147dd045b5010851ed4413332fd67abb88bb6fbbL177-R206)
* Minor code and style fixes in code examples for clarity (e.g., arrow function parentheses, code block formatting). [[1]](diffhunk://#diff-45c88c79e0a7628f70f605346b6de079c2e9a195c13626cfb708629ec9ce4a48L61-R70) [[2]](diffhunk://#diff-45c88c79e0a7628f70f605346b6de079c2e9a195c13626cfb708629ec9ce4a48L77-R91) [[3]](diffhunk://#diff-45c88c79e0a7628f70f605346b6de079c2e9a195c13626cfb708629ec9ce4a48L132-R141)

These changes ensure that users understand the distinction between the function-based and DSL-based approaches for custom node export, and make it easier to find and use the new DSL feature.