### PR TITLE
Sync AI Toolkit changelogs

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-ai-sdk.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-ai-sdk
 
+## 0.9.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.9.0
+
+## 0.8.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.8.0
+
 ## 0.7.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-anthropic.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-anthropic
 
+## 0.9.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.9.0
+
+## 0.8.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.8.0
+
 ## 0.7.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-langchain.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-langchain
 
+## 0.9.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.9.0
+
+## 0.8.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.8.0
+
 ## 0.7.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-openai.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit-openai
 
+## 0.9.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.9.0
+
+## 0.8.0
+
+### Patch Changes
+
+- @tiptap-pro/ai-toolkit-tool-definitions@0.8.0
+
 ## 0.7.0
 
 ### Patch Changes

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit-tool-definitions.mdx
@@ -8,6 +8,10 @@ meta:
 
 # @tiptap-pro/ai-toolkit-tool-definitions
 
+## 0.9.0
+
+## 0.8.0
+
 ## 0.7.0
 
 ## 0.6.1

--- a/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/changelog/ai-toolkit.mdx
@@ -8,6 +8,18 @@ meta:
 
 # @tiptap-pro/ai-toolkit
 
+## 0.9.0
+
+## 0.8.0
+
+### Minor Changes
+
+- 0d86e00: `acceptAllSuggestions` now returns the range of the last accepted suggestion, or `null` when no suggestions were accepted.
+
+### Patch Changes
+
+- c7785ae: Remove support for the `transaction` property from `acceptSuggestion`, restoring the previous suggestion acceptance behavior.
+
 ## 0.7.0
 
 ### Minor Changes

--- a/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/changelog/server-ai-toolkit.mdx
@@ -8,6 +8,16 @@ meta:
 
 # @tiptap-pro/server-ai-toolkit
 
+## 0.9.0
+
+### Minor Changes
+
+- dfa6fec: Rename `getSchemaAwarenessData` to `getEditorContext`.
+
+  The `getSchemaAwarenessData` export is still available for backwards compatibility.
+
+## 0.8.0
+
 ## 0.7.0
 
 ## 0.6.1


### PR DESCRIPTION
## Summary\n- Sync the AI Toolkit and Server AI Toolkit changelog pages in the docs with the latest releases from tiptap-pro.\n- Add the new 0.9.0 entries and the missing 0.8.0 release history where applicable.\n\n## Notes\n- Updated package pages: ai-toolkit, ai-toolkit-ai-sdk, ai-toolkit-anthropic, ai-toolkit-langchain, ai-toolkit-openai, ai-toolkit-tool-definitions, and server-ai-toolkit.