### PR TITLE
Document the tabindex editor option

### DIFF
--- a/src/content/editor/api/editor.mdx
+++ b/src/content/editor/api/editor.mdx
@@ -94,6 +94,28 @@ new Editor({
 })
 ```
 
+### coreExtensionOptions
+
+The `coreExtensionOptions` property configures Tiptap's built-in core extensions.
+
+Use `tabindex.value` to set the `tabindex` attribute on the editor element. When `value` is undefined, editable editors default to `tabindex="0"` and non-editable editors do not get a `tabindex` attribute.
+
+```js
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+
+new Editor({
+  content: `<p>Example Text</p>`,
+  extensions: [StarterKit],
+  editable: false,
+  coreExtensionOptions: {
+    tabindex: {
+      value: '-1',
+    },
+  },
+})
+```
+
 ### textDirection
 
 The `textDirection` property sets the text direction for all content in the editor. This is useful for right-to-left (RTL) languages like Arabic and Hebrew, or for bidirectional text content.


### PR DESCRIPTION
## Summary
- Document the new `tabindex` core extension option in the Editor Instance API settings.
- Show how to use `coreExtensionOptions.tabindex.value` on a non-editable editor, such as `value: '-1'` for programmatic focus.

## Context
This documents the change introduced in https://github.com/ueberdosis/tiptap/pull/7804.

## Notes
- No code changes were required.
