### PR TITLE
Add GitHub token to build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,8 @@ ARG GIT_COMMIT_REF_NAME
 ENV GIT_COMMIT_SHA=$GIT_COMMIT_SHA
 ENV GIT_COMMIT_REF_NAME=$GIT_COMMIT_REF_NAME
 
-RUN pnpm run build
+RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN \
+  pnpm run build
 
 # 2.5 ;) Dev runner
 FROM base AS dev_runner


### PR DESCRIPTION
This change adds the `GITHUB_TOKEN` to the Docker build environment in the most secure way so that it's available during build time, but not at runtime. If not set, the Docker build still works, but the changelog files are not generated for private repositories.