### PR TITLE
Document trackedChangesIntegration option

### DIFF
--- a/src/content/comments/core-concepts/configure.mdx
+++ b/src/content/comments/core-concepts/configure.mdx
@@ -86,6 +86,21 @@ Comments.configure({
 })
 ```
 
+## trackedChangesIntegration
+
+A boolean option that controls whether to enable the automatic [Track Changes](/editor/extensions/functionality/tracked-changes) integration. When enabled, threads are automatically created, updated, resolved, or deleted in response to Track Changes suggestion lifecycle events.
+
+Set this to `false` if you do not use the Track Changes extension and want to prevent any related event listeners and ProseMirror plugins from being registered.
+
+**Default:** `true`
+
+```js
+Comments.configure({
+  // disable Track Changes integration if you don't use that extension
+  trackedChangesIntegration: false,
+})
+```
+
 ## useLegacyWrapping
 
 <Callout title="Warning" variant="warning">


### PR DESCRIPTION
Describe the boolean option that toggles automatic Track Changes integration, note the default is true, and include an example to disable it to avoid registering related listeners and plugins