### PR TITLE
Omit selected Pro packages from generated changelogs

### DIFF
--- a/scripts/generate-changelogs.ts
+++ b/scripts/generate-changelogs.ts
@@ -33,6 +33,13 @@ const REPO_CONFIGS: RepoConfig[] = [OSS_CONFIG, PRO_CONFIG]
 const CONCURRENCY_LIMIT = 5
 const OUTPUT_DIR = path.join(process.cwd(), 'src/content/resources/changelog/_data')
 const CACHE_PATH = path.join(OUTPUT_DIR, 'cache.json')
+const OMITTED_PACKAGE_NAMES = new Set([
+  '@tiptap-pro/extension-ai-advanced',
+  '@tiptap-pro/extension-annotation',
+  '@tiptap-pro/extension-iframely',
+  '@tiptap-pro/extension-document-colors',
+  '@tiptap-pro/server-ai-toolkit',
+])
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN
 
@@ -256,6 +263,13 @@ async function discoverAndFetchPackages(
       `Found ${dirNames.length} directories in ${config.owner}/${config.repo}/${packageDir}`,
     )
     for (const dirName of dirNames) {
+      const packageName = `${config.packageScope}/${dirName}`
+
+      if (OMITTED_PACKAGE_NAMES.has(packageName)) {
+        console.log(`Skipped ${packageName} (omitted from changelog generation)`)
+        continue
+      }
+
       allDirNames.push({ dirName, packageDir })
     }
   }


### PR DESCRIPTION
The package changelog generator discovers every package directory in the upstream repositories. That caused changelog pages to be generated for Pro packages that should not appear in the docs changelog navigation.

This change adds an explicit omission list for the selected Pro packages and skips them during package discovery, before fetching versions or CHANGELOG files. The rest of the generation pipeline is unchanged, so generated pages, the index, and sidebar data continue to be built from the remaining packages.

Verification:
- `pnpm exec prettier --check scripts/generate-changelogs.ts`
- `SKIP_CHANGELOGS=1 pnpm run generate:changelogs`

Notes:
- `pnpm exec tsc --noEmit --pretty false` currently fails on missing `@/assets/noise-light.png` and `@/assets/noise-dark.png` module declarations.
- `pnpm exec eslint scripts/generate-changelogs.ts` currently errors while loading `react/display-name` with ESLint 10.