### PR TITLE
Document selective suggestion acceptance

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/suggestions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/suggestions.mdx
@@ -177,11 +177,12 @@ result.aiFeedback.events
 
 Accepts all active suggestions at once.
 
-This method accepts all suggestions by replacing the content at each suggestion's range with the first replacement option. After accepting all suggestions, the list of active suggestions is cleared.
+This method accepts all suggestions by replacing the content at each suggestion's range with the first replacement option. You can optionally filter which suggestions are accepted.
 
 ### Parameters
 
-None
+- `options?` (`AcceptAllSuggestionsOptions`): Options for the `acceptAllSuggestions` method
+  - `filter?` (`(suggestion: Suggestion) => boolean`): A predicate that determines which suggestions are accepted
 
 ### Returns
 
@@ -203,6 +204,29 @@ This feedback can be used to inform the AI about what changes were accepted by t
 // Accept all suggestions at once and get feedback
 const result = toolkit.acceptAllSuggestions()
 result.aiFeedback.events
+```
+
+## `acceptSuggestions`
+
+Accepts multiple suggestions by id.
+
+This is a convenience wrapper around `acceptAllSuggestions` for accepting a specific set of active suggestions.
+
+### Parameters
+
+- `ids` (`string[]`): The suggestion ids to accept
+
+### Returns
+
+`AcceptSuggestionsResult`
+
+Returns the same result as `acceptAllSuggestions`, including `aiFeedback` and the range of the last accepted suggestion.
+
+### Example
+
+```ts
+// Accept a specific set of suggestions
+const result = toolkit.acceptSuggestions(['suggestion-1', 'suggestion-2'])
 ```
 
 ## `rejectSuggestion`


### PR DESCRIPTION
Updates the AI Toolkit suggestions API reference for [PR 792](https://github.com/ueberdosis/tiptap-pro/pull/792).

- documents `acceptAllSuggestions(options?)` with the new `filter` option
- adds `acceptSuggestions(ids)` to the API reference
- updates the behavior text to reflect partial acceptance