### PR TITLE
fix: correct broken combobox usage example (closes #379)

### DIFF
--- a/src/content/ui-components/primitives/combobox.mdx
+++ b/src/content/ui-components/primitives/combobox.mdx
@@ -32,6 +32,7 @@ npx @tiptap/cli@latest add combobox
 ## Usage
 
 ```tsx
+import React from 'react'
 import {
   ComboboxProvider,
   Combobox,
@@ -40,23 +41,25 @@ import {
   ComboboxItem,
 } from '@/components/tiptap-ui-primitive/combobox'
 
+const ALL_OPTIONS = ['Apple', 'Banana', 'Cherry', 'Date']
+
 export default function MyComponent() {
   const [value, setValue] = React.useState('')
-  const [selectedValue, setSelectedValue] = React.useState('')
+
+  const matches = ALL_OPTIONS.filter((opt) =>
+    opt.toLowerCase().startsWith(value.toLowerCase())
+  )
 
   return (
-    <ComboboxProvider value={selectedValue} setValue={setSelectedValue}>
-      <Combobox
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        placeholder="Search options..."
-      />
+    <ComboboxProvider value={value} setValue={setValue}>
+      <Combobox placeholder="Search options..." />
       <ComboboxPopover>
         <ComboboxList>
-          <ComboboxItem value="apple">Apple</ComboboxItem>
-          <ComboboxItem value="banana">Banana</ComboboxItem>
-          <ComboboxItem value="cherry">Cherry</ComboboxItem>
-          <ComboboxItem value="date">Date</ComboboxItem>
+          {matches.map((opt) => (
+            <ComboboxItem key={opt} value={opt}>
+              {opt}
+            </ComboboxItem>
+          ))}
         </ComboboxList>
       </ComboboxPopover>
     </ComboboxProvider>


### PR DESCRIPTION
Fixes #379

The combobox example in the docs was using two separate state variables
(`value` and `selectedValue`) wired incorrectly to `ComboboxProvider`.
This caused clicking an item to clear the input instead of selecting it.

Changes:
- Use a single `value` state passed to `ComboboxProvider` which handles
  both typing and item selection via `setValue`
- Remove the manual `onChange` on `<Combobox>` (provider handles it)
- Add filtering logic to demonstrate real combobox behaviour
- Add missing `React` import