### PR TITLE
feat: add docs for the new disable header and footer feature

### DIFF
--- a/src/content/pages/core-concepts/limitations.mdx
+++ b/src/content/pages/core-concepts/limitations.mdx
@@ -64,10 +64,6 @@ Every page uses the same structure. Multi-column layouts, alternating page templ
 
 Pages does not implement the browser print dialog. For print-ready output, use the Tiptap Conversion extensions and REST endpoints — see the [Conversion overview](/conversion/getting-started/overview), or for end-to-end setup, [From zero to print-ready](/pages/guides/zero-to-print-ready).
 
-## Header and footer editing cannot be disabled
-
-Double-clicking a header or footer always opens the inline editor. You can intercept the _closing_ behaviour with the `onDblClickHeaderPreventClose` / `onDblClickFooterPreventClose` callbacks, but you cannot prevent the editor from opening in the first place.
-
 <Callout title="Help us prioritise" variant="info">
   If you need a feature that's not supported yet, let us know. Your feedback helps us prioritise.
   <a href="https://tiptap-suite.notion.site/1b601ffa3ebc80a281a8ea0b03b19bdd">

--- a/src/content/pages/core-concepts/options.mdx
+++ b/src/content/pages/core-concepts/options.mdx
@@ -96,6 +96,16 @@ interface PagesOptions {
   /** Even-pages footer content. Default: ''. */
   footerEven?: PagesHeaderFooter
 
+  /** Whether double-clicking the header opens the inline editor overlay.
+   *  When false, the overlay cannot be opened by users or by `openHeaderEditor`.
+   *  Default: true. */
+  editableHeader?: boolean
+
+  /** Whether double-clicking the footer opens the inline editor overlay.
+   *  When false, the overlay cannot be opened by users or by `openFooterEditor`.
+   *  Default: true. */
+  editableFooter?: boolean
+
   /** Enable a different first-page footer independently of `differentFirstPage`.
    *  Set automatically when `setDifferentFirstPage(true)` is called. */
   differentFirstPageFooter?: boolean
@@ -161,6 +171,8 @@ The full reference for header/footer options lives on [Page header and footer](/
 | `headerEven`                         | `PagesHeaderFooter`              | `''`                 | Even-pages header content                                 |
 | `footerOdd`                          | `PagesHeaderFooter`              | `''`                 | Odd-pages footer content                                  |
 | `footerEven`                         | `PagesHeaderFooter`              | `''`                 | Even-pages footer content                                 |
+| `editableHeader`                     | `boolean`                        | `true`               | Allow opening the header overlay on double-click          |
+| `editableFooter`                     | `boolean`                        | `true`               | Allow opening the footer overlay on double-click          |
 | `headerFooterExtensions`             | `Extensions`                     | `StarterKit`         | Extensions for the inner header/footer editors            |
 | `onDblClickHeaderFooterPreventClose` | `(event: MouseEvent) => boolean` | `undefined`          | Prevent closing on double-click outside (header + footer) |
 | `onDblClickHeaderPreventClose`       | `(event: MouseEvent) => boolean` | `undefined`          | Prevent closing on double-click outside (header only)     |
@@ -210,6 +222,8 @@ The full reference also lives on [Page header and footer](/pages/core-concepts/p
 | `setHeaderEven`               | `header: PagesHeaderFooter` | Set even-pages header content                       |
 | `setFooterOdd`                | `footer: PagesHeaderFooter` | Set odd-pages footer content                        |
 | `setFooterEven`               | `footer: PagesHeaderFooter` | Set even-pages footer content                       |
+| `setHeaderEditable`           | `enabled: boolean`          | Lock or unlock the header overlay (controls `editableHeader`). |
+| `setFooterEditable`           | `enabled: boolean`          | Lock or unlock the footer overlay (controls `editableFooter`). |
 | `openHeaderEditor`            | `{ pageNumber: number }`    | Open header editor for a specific page (1-indexed). |
 | `openFooterEditor`            | `{ pageNumber: number }`    | Open footer editor for a specific page (1-indexed). |
 | `closeHeaderFooterEditors`    | none                        | Close whichever header/footer editor is open        |
@@ -262,6 +276,8 @@ After a user edits a header or footer through its overlay, both the rendered HTM
 | `differentOddEven`         | `boolean`             | Whether odd/even pages differ                |
 | `differentFirstPageFooter` | `boolean`             | First-page footer differs (independent flag) |
 | `differentOddEvenFooter`   | `boolean`             | Odd/even footers differ (independent flag)   |
+| `editableHeader`           | `boolean`             | Whether the header overlay can be opened (read-only — use `setHeaderEditable`) |
+| `editableFooter`           | `boolean`             | Whether the footer overlay can be opened (read-only — use `setFooterEditable`) |
 | `accentColor`              | `string`              | Current accent color (both)                  |
 | `headerAccentColor`        | `string`              | Current header accent color                  |
 | `footerAccentColor`        | `string`              | Current footer accent color                  |

--- a/src/content/pages/core-concepts/page-header-footer.mdx
+++ b/src/content/pages/core-concepts/page-header-footer.mdx
@@ -13,10 +13,6 @@ import { CodeDemo } from '@/components/CodeDemo'
 
 Headers and footers allow you to display consistent content at the top and bottom of each page. The Pages extension supports static text, HTML markup, dynamic page numbering with placeholders, rich formatting via JSONContent, different headers/footers for first page or odd/even pages, and interactive editing through double-click in the header or footer area.
 
-<Callout title="Note" variant="info">
-  Headers and footers are always editable via double-click. This behavior cannot be disabled.
-</Callout>
-
 <Callout title="Imported from DOCX" variant="hint">
   When you import a `.docx` file with the [DOCX import
   extension](/conversion/import/docx/editor-extension#headers--footers), headers and footers from
@@ -373,6 +369,31 @@ When a user double-clicks a header or footer to edit it, the extension exposes t
 - `footerEditorOn` / `footerEditorOff` – Subscribe/unsubscribe to events on the footer overlay's inner Tiptap editor
 
 The extension also listens to `focus` events from the header and footer inner editors. When the user focuses an open header or footer editor, `activeEditor`, `activeEditorType`, and `activePageNumber` are refreshed from the active overlay.
+
+### Locking the header or footer
+
+Set `editableHeader` or `editableFooter` to `false` to render headers/footers without the double-click editing affordance. When locked, the overlay can't be opened by users or by code — the `cursor: pointer` hint is dropped, the `openHeaderEditor` / `openFooterEditor` commands return `false`, and any overlay already open is closed (which restores the main editor's `editable` state).
+
+```ts
+Pages.configure({
+  header: 'Page {page} of {total}',
+  editableHeader: false, // locked at editor creation
+})
+```
+
+Toggle at runtime with `setHeaderEditable` / `setFooterEditable`:
+
+```ts
+editor.commands.setHeaderEditable(false) // lock
+editor.commands.setHeaderEditable(true) // unlock
+
+editor.commands.setFooterEditable(false)
+editor.commands.setFooterEditable(true)
+```
+
+<Callout title="Locking does not hide content" variant="info">
+  Headers and footers still render normally when locked — only the inline editing affordance is removed. Use `setHeader('')` / `setFooter('')` if you want to clear the content.
+</Callout>
 
 ### Listening to header/footer editor events
 
@@ -753,10 +774,6 @@ editor.commands.setFooterAccentColor('#ef4444')
 
 ## Limitations
 
-### Editing cannot be disabled
-
-The double-click editing behavior is built into the extension and cannot be disabled. All users with access to the editor can edit headers and footers.
-
 ### Header & Footer editor styling
 
 The header/footer editor uses built-in styles. However, you can customize the accent color using the `accentColor`, `headerAccentColor`, and `footerAccentColor` options.
@@ -781,6 +798,8 @@ Header and footer editors participate in collaboration alongside the main docume
 | `headerEven`                         | `PagesHeaderFooter`              | `''`                 | Even pages header content                                                 |
 | `footerOdd`                          | `PagesHeaderFooter`              | `''`                 | Odd pages footer content                                                  |
 | `footerEven`                         | `PagesHeaderFooter`              | `''`                 | Even pages footer content                                                 |
+| `editableHeader`                     | `boolean`                        | `true`               | Whether double-clicking the header opens the inline editor               |
+| `editableFooter`                     | `boolean`                        | `true`               | Whether double-clicking the footer opens the inline editor               |
 | `headerFooterExtensions`             | `Extension[]`                    | `StarterKit`         | Extensions for header/footer editor                                       |
 | `onDblClickHeaderFooterPreventClose` | `(event: MouseEvent) => boolean` | `undefined`          | Callback to prevent closing header/footer editors on double-click outside |
 | `onDblClickHeaderPreventClose`       | `(event: MouseEvent) => boolean` | `undefined`          | Callback to prevent closing header editor on double-click outside         |
@@ -808,6 +827,8 @@ Header and footer editors participate in collaboration alongside the main docume
 | `setHeaderEven`            | `header: PagesHeaderFooter` | Set even pages header content                      |
 | `setFooterOdd`             | `footer: PagesHeaderFooter` | Set odd pages footer content                       |
 | `setFooterEven`            | `footer: PagesHeaderFooter` | Set even pages footer content                      |
+| `setHeaderEditable`        | `enabled: boolean`          | Lock or unlock the header overlay. When `false`, double-click is inert, `openHeaderEditor` returns `false`, and any open header overlay is closed. |
+| `setFooterEditable`        | `enabled: boolean`          | Lock or unlock the footer overlay. When `false`, double-click is inert, `openFooterEditor` returns `false`, and any open footer overlay is closed. |
 | `openHeaderEditor`         | `{ pageNumber: number }`    | Open header editor for a specific page (1-indexed) |
 | `openFooterEditor`         | `{ pageNumber: number }`    | Open footer editor for a specific page (1-indexed) |
 | `closeHeaderFooterEditors` | none                        | Close whichever header/footer editor is open       |

--- a/src/content/pages/getting-started/overview.mdx
+++ b/src/content/pages/getting-started/overview.mdx
@@ -73,6 +73,7 @@ See the [install guide](/pages/getting-started/install) for the full walkthrough
 - Different headers and footers for the first page and for odd/even pages, like Word.
 - Live editing of headers and footers in dedicated overlays. They participate in collaboration alongside the main document — see [Adding collaboration to Pages](/pages/guides/collaboration-with-pages).
 - Programmatic control: open or close a header/footer editor for a specific page, react to page format changes, react to zoom changes.
+- Lock or unlock header/footer editing per overlay, at config-time or runtime via `editableHeader` / `editableFooter` options and `setHeaderEditable` / `setFooterEditable` commands.
 - Pagination-safe tables via [PagesTableKit](/pages/guides/pages-tablekit). Tables shrink proportionally to fit the page, exact-height rows clip, declared widths are preserved.
 - Round-trip with Tiptap Conversion: imported DOCX headers and footers are auto-applied; exported DOCX, PDF, ODT, EPUB carry headers, footers, and pagination through.
 
@@ -83,7 +84,6 @@ These are real, documented limits — not bugs. If your workflow depends on any 
 - **Non-splittable blocks larger than a page cause an infinite layout loop.** This is the single most important limitation to know about before adopting Pages. Table rows, figures, positioned containers, and most other Block Formatting Context (BFC) elements cannot be split across pages — the layout can only move the whole block to the next page. If the block is taller than the page itself, it can't fit there either, and the layout keeps trying to move it forward and never stabilises. The result is an unresponsive editor. This is a hard limit of the current approach to splitting content between pages, not a near-term roadmap item. See [Limitations](/pages/core-concepts/limitations#oversized-non-splittable-blocks-cause-an-infinite-layout-loop) for the full treatment, including how to detect and prevent it. The table-specific case lives in [PagesTableKit's Known issues](/pages/guides/pages-tablekit#known-issues).
 - **No per-page styling, no page templates.** Every page uses the same layout and visual styling.
 - **No browser-print integration.** Use the [Conversion extensions and REST endpoints](/conversion/getting-started/overview) for print-ready output.
-- **Header and footer editing cannot be disabled** (only its closing-on-double-click behaviour can be intercepted via callbacks).
 
 ## What to expect
 


### PR DESCRIPTION
This pull request updates the documentation for the Pages extension to introduce new options that allow locking or unlocking header and footer editing overlays, both at configuration time and at runtime. Previously, header and footer editing via double-click was always enabled and could not be disabled. The documentation now explains how to use the new `editableHeader` and `editableFooter` options and the corresponding commands, and removes outdated statements about the inability to disable editing.

Key documentation updates:

**New header/footer editing controls:**

* Documented the new `editableHeader` and `editableFooter` options in the Pages configuration, allowing you to control whether the header/footer editing overlays can be opened by users or code. [[1]](diffhunk://#diff-77a3815d1bd0033256ee2002db3ab22714f0c0e224fe37377db6ed83c238246cR99-R108) [[2]](diffhunk://#diff-16b7384fd455252d2aea308f912791827e088c60aed3c9141a6d733fc8718c18R373-R397) [[3]](diffhunk://#diff-16b7384fd455252d2aea308f912791827e088c60aed3c9141a6d733fc8718c18R801-R802)
* Added documentation for the new `setHeaderEditable` and `setFooterEditable` commands, which allow toggling the editability of headers and footers at runtime. [[1]](diffhunk://#diff-77a3815d1bd0033256ee2002db3ab22714f0c0e224fe37377db6ed83c238246cR225-R226) [[2]](diffhunk://#diff-16b7384fd455252d2aea308f912791827e088c60aed3c9141a6d733fc8718c18R830-R831)
* Updated the options tables and API references throughout the relevant pages to include these new properties and commands. [[1]](diffhunk://#diff-77a3815d1bd0033256ee2002db3ab22714f0c0e224fe37377db6ed83c238246cR174-R175) [[2]](diffhunk://#diff-77a3815d1bd0033256ee2002db3ab22714f0c0e224fe37377db6ed83c238246cR279-R280) [[3]](diffhunk://#diff-16b7384fd455252d2aea308f912791827e088c60aed3c9141a6d733fc8718c18R801-R802) [[4]](diffhunk://#diff-16b7384fd455252d2aea308f912791827e088c60aed3c9141a6d733fc8718c18R830-R831)

**Removal of outdated limitations:**

* Removed prior documentation and callouts stating that header and footer editing could not be disabled, reflecting the new functionality. [[1]](diffhunk://#diff-444368d0ab919865516fbe4a5c80cf8aed6f4d33793360ee37aaab98ff34e2f1L67-L70) [[2]](diffhunk://#diff-16b7384fd455252d2aea308f912791827e088c60aed3c9141a6d733fc8718c18L16-L19) [[3]](diffhunk://#diff-16b7384fd455252d2aea308f912791827e088c60aed3c9141a6d733fc8718c18L756-L759) [[4]](diffhunk://#diff-c5fe9181a0ceb4f4eaf2ae5f58a7b55b8370d69378d2fb887a3ddb3cd174522dL86)

**Feature highlights:**

* Updated the feature overview to mention the new ability to lock or unlock header/footer editing overlays via configuration or commands.

These changes make it clear to users how to control header/footer editability and bring the documentation in line with the latest capabilities of the Pages extension.