### PR TITLE
docs: document trackNodeViewPosition option for React and Vue node views

### DIFF
--- a/src/content/editor/extensions/custom-extensions/node-views/react.mdx
+++ b/src/content/editor/extensions/custom-extensions/node-views/react.mdx
@@ -140,6 +140,18 @@ return ReactNodeViewRenderer(Component, { selectedOnTextSelection: true })
 
 With this option turned on, `selected` will also be `true` whenever a `TextSelection` is fully contained within the node’s range — for example, when the cursor is placed somewhere inside the node’s content. Selections that only partially overlap the node are not considered selected.
 
+## Tracking node position
+
+Node views do not re-render when decorations or position change without content changes. ProseMirror handles decorations natively on the contentDOM, and the `getPos()` closure always returns the current position when called — even without a re-render.
+
+If your component needs `getPos()` to stay reactive in render output (e.g. a drag handle that displays `pos: 42`), enable `trackNodeViewPosition`:
+
+```js
+return ReactNodeViewRenderer(Component, { trackNodeViewPosition: true })
+```
+
+When enabled, the component re-renders on every position shift. Use with caution — frequent re-renders can impact performance.
+
 ## All available props
 
 Here is the full list of what props you can expect:

--- a/src/content/editor/extensions/custom-extensions/node-views/vue.mdx
+++ b/src/content/editor/extensions/custom-extensions/node-views/vue.mdx
@@ -133,6 +133,18 @@ return VueNodeViewRenderer(Component, { selectedOnTextSelection: true })
 
 With this option turned on, `selected` will also be `true` whenever a `TextSelection` is fully contained within the node’s range — for example, when the cursor is placed somewhere inside the node’s content. Selections that only partially overlap the node are not considered selected.
 
+## Tracking node position
+
+Node views do not re-render when decorations or position change without content changes. ProseMirror handles decorations natively on the contentDOM, and the `getPos()` closure always returns the current position when called — even without a re-render.
+
+If your component needs `getPos()` to stay reactive in render output (e.g. a drag handle that displays `pos: 42`), enable `trackNodeViewPosition`:
+
+```js
+return VueNodeViewRenderer(Component, { trackNodeViewPosition: true })
+```
+
+When enabled, the component re-renders on every position shift. Use with caution — frequent re-renders can impact performance.
+
 ## All available props
 
 For advanced use cases, we pass a few more props to the component.


### PR DESCRIPTION
Documents the `trackNodeViewPosition` option added in [PR #7828](https://github.com/ueberdosis/tiptap/pull/7828).

## Changes

- **react.mdx** — Added "Tracking node position" section explaining the new `trackNodeViewPosition` option with usage example and performance warning
- **vue.mdx** — Same section added for Vue 2/3

The option enables opt-in re-rendering on position shifts, which is useful for node views that display the current position in render output (e.g. drag handle labels).