### PR TITLE
Add Vanilla JS examples for bubble menu, floating menu, and mention extensions

### DIFF
--- a/src/content/editor/extensions/functionality/bubble-menu.mdx
+++ b/src/content/editor/extensions/functionality/bubble-menu.mdx
@@ -137,13 +137,28 @@ import { Editor } from '@tiptap/core'
 import BubbleMenu from '@tiptap/extension-bubble-menu'
 
 new Editor({
+  element: document.querySelector('#editor'),
   extensions: [
+    StarterKit,
     BubbleMenu.configure({
-      element: document.querySelector('.menu'),
+      element: document.querySelector('#bubble-menu'),
     }),
   ],
+  content: '<p>Select some text to see the bubble menu.</p>',
 })
 ```
+
+Add a menu element to your HTML:
+
+```html
+<div id="bubble-menu" style="display: none; position: absolute;">
+  <button onclick="editor.chain().focus().toggleBold().run()">Bold</button>
+  <button onclick="editor.chain().focus().toggleItalic().run()">Italic</button>
+</div>
+<div id="editor"></div>
+```
+
+Tiptap will automatically show and position the menu element when text is selected.
 
 ## Usage with frameworks
 

--- a/src/content/editor/extensions/functionality/floatingmenu.mdx
+++ b/src/content/editor/extensions/functionality/floatingmenu.mdx
@@ -125,13 +125,28 @@ import { Editor } from '@tiptap/core'
 import FloatingMenu from '@tiptap/extension-floating-menu'
 
 new Editor({
+  element: document.querySelector('#editor'),
   extensions: [
+    StarterKit,
     FloatingMenu.configure({
-      element: document.querySelector('.menu'),
+      element: document.querySelector('#floating-menu'),
     }),
   ],
+  content: '<p>Click on an empty line to see the floating menu.</p>',
 })
 ```
+
+Add a menu element to your HTML:
+
+```html
+<div id="floating-menu" style="display: none; position: absolute;">
+  <button onclick="editor.chain().focus().toggleHeading({ level: 1 }).run()">H1</button>
+  <button onclick="editor.chain().focus().toggleBulletList().run()">List</button>
+</div>
+<div id="editor"></div>
+```
+
+Tiptap will automatically show and position the menu element when the cursor is on an empty line.
 
 ## Usage with frameworks
 

--- a/src/content/editor/extensions/nodes/mention.mdx
+++ b/src/content/editor/extensions/nodes/mention.mdx
@@ -151,6 +151,67 @@ const Editor = new Editor({
 
 This ensures that the suggestion menu only opens for the user who actually typed the trigger character.
 
+## Use in Vanilla JavaScript
+
+Here is a complete example that sets up a mention with a suggestion list:
+
+```js
+import { Editor } from '@tiptap/core'
+import Mention from '@tiptap/extension-mention'
+
+new Editor({
+  element: document.querySelector('#editor'),
+  extensions: [
+    StarterKit,
+    Mention.configure({
+      HTMLAttributes: {
+        class: 'mention',
+      },
+      suggestion: {
+        char: '@',
+        items: ({ query }) => {
+          return ['Alice', 'Bob', 'Carol'].filter((name) =>
+            name.toLowerCase().includes(query.toLowerCase())
+          )
+        },
+        render: () => {
+          let popup
+
+          return {
+            onStart: (props) => {
+              popup = document.createElement('div')
+              popup.classList.add('suggestion-popup')
+              props.items.forEach((item) => {
+                const button = document.createElement('button')
+                button.textContent = item
+                button.addEventListener('click', () => props.command({ id: item }))
+                popup.appendChild(button)
+              })
+              document.body.appendChild(popup)
+            },
+            onUpdate: (props) => {
+              popup.innerHTML = ''
+              props.items.forEach((item) => {
+                const button = document.createElement('button')
+                button.textContent = item
+                button.addEventListener('click', () => props.command({ id: item }))
+                popup.appendChild(button)
+              })
+            },
+            onHide: () => {
+              popup?.remove()
+            },
+          }
+        },
+      },
+    }),
+  ],
+  content: '<p>Type @ to mention someone.</p>',
+})
+```
+
+You can also pass a custom React or Vue component for rendering. See the [Suggestion utility](/editor/api/utilities/suggestion) for details.
+
 ## Source code
 
 [packages/extension-mention/](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-mention/)

--- a/src/content/editor/getting-started/install/index.mdx
+++ b/src/content/editor/getting-started/install/index.mdx
@@ -20,7 +20,6 @@ import alpineIcon from '@/assets/alpine.png'
 import phpIcon from '@/assets/php.png'
 import angularIcon from '@/assets/angular.png'
 import solidIcon from '@/assets/solid.png'
-import cdnIcon from '@/assets/cdn.png'
 
 <CardGrid.Wrapper className="grid-cols-1 sm:grid-cols-3">
   <CardGrid.Item asChild>
@@ -75,12 +74,6 @@ import cdnIcon from '@/assets/cdn.png'
     <Link href="/editor/getting-started/install/php">
       <CardGrid.ItemImageIcon src={phpIcon.src} alt="PHP logo" />
       <CardGrid.ItemTitle className="text-[1.125rem]">PHP</CardGrid.ItemTitle>
-    </Link>
-  </CardGrid.Item>
-  <CardGrid.Item asChild>
-    <Link href="/editor/getting-started/install/cdn">
-      <CardGrid.ItemImageIcon src={cdnIcon.src} alt="CDN logo" />
-      <CardGrid.ItemTitle className="text-[1.125rem]">CDN</CardGrid.ItemTitle>
     </Link>
   </CardGrid.Item>
 </CardGrid.Wrapper>

--- a/src/content/editor/getting-started/install/vanilla-javascript.mdx
+++ b/src/content/editor/getting-started/install/vanilla-javascript.mdx
@@ -12,18 +12,22 @@ Are you building without a frontend framework like React or Vue? No problem, you
 
 <Callout title="Hint" variant="hint">
 
-"Vanilla JavaScript" here means **no frontend framework**, but still using **modern JavaScript with ES module imports** (e.g. through Vite, Rollup, or Webpack).
+"Vanilla JavaScript" here means **no frontend framework**, but you are still using **modern JavaScript with ES module imports** (e.g. through Vite, Rollup, or Webpack).
 
-If you’re not using a build tool, check out the [CDN example below](#using-a-cdn-no-build-step) for an example that runs directly in the browser.
+If you'd rather skip build tools entirely, check the [CDN section below](#without-a-build-tool-cdn) for a setup that runs directly in the browser.
 
 </Callout>
 
-## Install dependencies
+## With a build tool (Vite, Webpack, Rollup)
 
-You’ll need the core Tiptap packages to get started:
+This approach is recommended if you're already using a bundler or just want the standard npm workflow.
 
-- `@tiptap/core` – the main editor API  
-- `@tiptap/pm` – ProseMirror, the engine behind Tiptap  
+### Install dependencies
+
+You'll need the core Tiptap packages to get started:
+
+- `@tiptap/core` – the main editor API
+- `@tiptap/pm` – ProseMirror, the engine behind Tiptap
 - `@tiptap/starter-kit` – a convenient bundle of common extensions
 
 ```bash
@@ -38,7 +42,7 @@ Add a simple container in your HTML where you want the editor to appear:
 <div class="element"></div>
 ```
 
-## Initialize the editor
+### Initialize the editor
 
 Create a JavaScript file (for example `src/main.js`) and add the following code:
 
@@ -55,16 +59,19 @@ new Editor({
 
 Now run your dev server (for example with Vite: `npm run dev`) and open the page in your browser. You should see a working Tiptap editor.
 
-## A quick note about styling
+---
 
-Tiptap doesn’t include visual styles by default. The editor only outputs semantic HTML. You can style it however you like with your own CSS or a framework such as Tailwind or Bootstrap.
+## Without a build tool (CDN)
 
-If you’re using the StarterKit, it includes minimal defaults that make the text render like a basic document.
-Learn more in the [Styling guide](/editor/getting-started/style-editor).
+If you'd rather skip npm and build tools entirely, you can load Tiptap directly from a CDN using ES module imports. This works in all modern browsers.
 
-## Using a CDN (no build step)
+<Callout title="Note" variant="hint">
 
-If you’d rather skip the build tool, here’s a working example using CDN imports:
+Your `<script>` tag must include `type="module"` for the import syntax to work in the browser.
+
+</Callout>
+
+### Minimal example
 
 ```html
 <script type="module">
@@ -80,6 +87,255 @@ If you’d rather skip the build tool, here’s a working example using CDN impo
 
 <div class="element"></div>
 ```
+
+### Complete HTML file with toolbar
+
+Here's a copy-paste ready example that includes a toolbar with formatting buttons:
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tiptap Editor</title>
+    <style>
+      body {
+        margin: 2rem;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      }
+      .editor-container {
+        max-width: 48rem;
+        margin: 0 auto;
+      }
+      .toolbar {
+        display: flex;
+        gap: 0.25rem;
+        padding: 0.5rem;
+        border: 1px solid #d1d5db;
+        border-bottom: none;
+        border-radius: 0.375rem 0.375rem 0 0;
+        background: #f9fafb;
+        flex-wrap: wrap;
+      }
+      .toolbar button {
+        padding: 0.25rem 0.5rem;
+        font-size: 0.875rem;
+        border: 1px solid transparent;
+        border-radius: 0.25rem;
+        background: transparent;
+        cursor: pointer;
+      }
+      .toolbar button:hover {
+        background: #e5e7eb;
+      }
+      .toolbar button.is-active {
+        background: #111827;
+        color: #fff;
+      }
+      .tiptap {
+        padding: 0.75rem 1rem;
+        border: 1px solid #d1d5db;
+        border-radius: 0 0 0.375rem 0.375rem;
+        min-height: 10rem;
+        outline: none;
+      }
+      .tiptap p { margin: 0.5rem 0; }
+      .tiptap h1, .tiptap h2, .tiptap h3 { margin: 1rem 0 0.5rem; }
+      .tiptap ul, .tiptap ol { padding-left: 1.5rem; }
+      .tiptap pre {
+        background: #111827;
+        color: #f3f4f6;
+        padding: 0.75rem;
+        border-radius: 0.25rem;
+        font-size: 0.875rem;
+      }
+      .tiptap code {
+        background: #f3f4f6;
+        padding: 0.125rem 0.25rem;
+        border-radius: 0.25rem;
+        font-size: 0.875rem;
+      }
+      .tiptap pre code {
+        background: transparent;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="editor-container">
+      <div class="toolbar" id="toolbar">
+        <button data-tiptap-button="bold">Bold</button>
+        <button data-tiptap-button="italic">Italic</button>
+        <button data-tiptap-button="strike">Strike</button>
+        <button data-tiptap-button="code">Code</button>
+        <button data-tiptap-button="h1">H1</button>
+        <button data-tiptap-button="h2">H2</button>
+        <button data-tiptap-button="bulletList">Bullet List</button>
+        <button data-tiptap-button="orderedList">Ordered List</button>
+        <button data-tiptap-button="blockquote">Blockquote</button>
+        <button data-tiptap-button="codeBlock">Code Block</button>
+      </div>
+      <div id="editor"></div>
+    </div>
+
+    <script type="module">
+      import { Editor } from 'https://esm.sh/@tiptap/core'
+      import StarterKit from 'https://esm.sh/@tiptap/starter-kit'
+
+      const editor = new Editor({
+        element: document.querySelector('#editor'),
+        extensions: [StarterKit],
+        content: `
+          <h1>Welcome to Tiptap</h1>
+          <p>This is a text editor built with <strong>Vanilla JavaScript</strong> and loaded from a CDN.</p>
+          <p>Try the toolbar buttons above to format your text.</p>
+        `,
+      })
+
+      // Wire up toolbar buttons
+      const buttons = document.querySelectorAll('[data-tiptap-button]')
+      buttons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const command = button.dataset.tiptapButton
+
+          switch (command) {
+            case 'bold':
+              editor.chain().focus().toggleBold().run()
+              break
+            case 'italic':
+              editor.chain().focus().toggleItalic().run()
+              break
+            case 'strike':
+              editor.chain().focus().toggleStrike().run()
+              break
+            case 'code':
+              editor.chain().focus().toggleCode().run()
+              break
+            case 'h1':
+              editor.chain().focus().toggleHeading({ level: 1 }).run()
+              break
+            case 'h2':
+              editor.chain().focus().toggleHeading({ level: 2 }).run()
+              break
+            case 'bulletList':
+              editor.chain().focus().toggleBulletList().run()
+              break
+            case 'orderedList':
+              editor.chain().focus().toggleOrderedList().run()
+              break
+            case 'blockquote':
+              editor.chain().focus().toggleBlockquote().run()
+              break
+            case 'codeBlock':
+              editor.chain().focus().toggleCodeBlock().run()
+              break
+          }
+
+          updateActiveButtons()
+        })
+      })
+
+      function updateActiveButtons() {
+        const map = {
+          bold: () => editor.isActive('bold'),
+          italic: () => editor.isActive('italic'),
+          strike: () => editor.isActive('strike'),
+          code: () => editor.isActive('code'),
+          h1: () => editor.isActive('heading', { level: 1 }),
+          h2: () => editor.isActive('heading', { level: 2 }),
+          bulletList: () => editor.isActive('bulletList'),
+          orderedList: () => editor.isActive('orderedList'),
+          blockquote: () => editor.isActive('blockquote'),
+          codeBlock: () => editor.isActive('codeBlock'),
+        }
+
+        buttons.forEach((button) => {
+          const command = button.dataset.tiptapButton
+          const check = map[command]
+          if (check && check()) {
+            button.classList.add('is-active')
+          } else {
+            button.classList.remove('is-active')
+          }
+        })
+      }
+
+      editor.on('selectionUpdate', updateActiveButtons)
+      editor.on('update', updateActiveButtons)
+    </script>
+  </body>
+</html>
+```
+
+Save this as `index.html` and open it in any modern browser — no server required.
+
+### Live demo
+
+You can see a similar working example on CodeSandbox:
+
+[https://codesandbox.io/s/throbbing-smoke-now37q](https://codesandbox.io/s/throbbing-smoke-now37q?file=/index.html)
+
+---
+
+## Wiring a toolbar (plain JS)
+
+Tiptap is headless, so it doesn't ship with a built-in toolbar. You need to wire up your own UI buttons. Here is the pattern in plain JavaScript:
+
+```js
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+
+const editor = new Editor({
+  element: document.querySelector('#editor'),
+  extensions: [StarterKit],
+  content: '<p>Hello World!</p>',
+})
+
+// Listen for clicks and call editor commands
+document.querySelector('#bold-button').addEventListener('click', () => {
+  editor.chain().focus().toggleBold().run()
+})
+
+// Check if a mark or node is active to style the button
+const isBold = editor.isActive('bold')
+const isHeading1 = editor.isActive('heading', { level: 1 })
+const isBulletList = editor.isActive('bulletList')
+
+// Update button active state on selection change
+editor.on('selectionUpdate', () => {
+  document.querySelector('#bold-button').classList.toggle('is-active', editor.isActive('bold'))
+})
+```
+
+### Common editor commands
+
+| Command | Code |
+|---|---|
+| Bold | `editor.chain().focus().toggleBold().run()` |
+| Italic | `editor.chain().focus().toggleItalic().run()` |
+| Strike | `editor.chain().focus().toggleStrike().run()` |
+| Code (inline) | `editor.chain().focus().toggleCode().run()` |
+| Heading 1 | `editor.chain().focus().toggleHeading({ level: 1 }).run()` |
+| Heading 2 | `editor.chain().focus().toggleHeading({ level: 2 }).run()` |
+| Bullet List | `editor.chain().focus().toggleBulletList().run()` |
+| Ordered List | `editor.chain().focus().toggleOrderedList().run()` |
+| Blockquote | `editor.chain().focus().toggleBlockquote().run()` |
+| Code Block | `editor.chain().focus().toggleCodeBlock().run()` |
+| Undo | `editor.chain().focus().undo().run()` |
+| Redo | `editor.chain().focus().redo().run()` |
+
+Refer to the individual extension docs for available commands.
+
+---
+
+## Styling
+
+Tiptap doesn't include visual styles by default — it only outputs semantic HTML. You can style it however you like with your own CSS or a framework such as Tailwind or Bootstrap.
+
+The StarterKit includes minimal default styles that make the text render like a basic document.
+
+Learn more in the [Styling guide](/editor/getting-started/style-editor).
 
 ## Next steps
 


### PR DESCRIPTION
Enhance documentation by adding Vanilla JS examples for the bubble menu, floating menu, and mention extensions. Extend the setup documentation to provide clearer guidance for users.

Related:
https://github.com/ueberdosis/tiptap/issues/2486