### PR TITLE
docs: document static-renderer parity options and generateTocIds helper

### DIFF
--- a/src/content/editor/api/utilities/static-renderer.mdx
+++ b/src/content/editor/api/utilities/static-renderer.mdx
@@ -66,12 +66,14 @@ renderToHTMLString({
 function renderToHTMLString(options: {
   extensions: Extension[]
   content: ProsemirrorNode | JSONContent
+  textDirection?: 'ltr' | 'rtl' | 'auto'
   options?: TiptapHTMLStaticRendererOptions
 }): string
 ```
 
 - `extensions`: An array of Tiptap extensions that are used to render the content.
 - `content`: The content to render. Can be a Prosemirror Node instance or a JSON representation of a Prosemirror document.
+- `textDirection`: Mirrors the `textDirection` editor option on `Editor`. When set, the renderer applies the configured direction so the output includes the expected `dir` attribute.
 - `options`: An object with additional options.
 - `options.nodeMapping`: An object that maps Prosemirror nodes to HTML strings.
 - `options.markMapping`: An object that maps Prosemirror marks to HTML strings.
@@ -118,12 +120,14 @@ renderToMarkdown({
 function renderToMarkdown(options: {
   extensions: Extension[]
   content: ProsemirrorNode | JSONContent
+  textDirection?: 'ltr' | 'rtl' | 'auto'
   options?: TiptapMarkdownStaticRendererOptions
 }): string
 ```
 
 - `extensions`: An array of Tiptap extensions that are used to render the content.
 - `content`: The content to render. Can be a Prosemirror Node instance or a JSON representation of a Prosemirror document.
+- `textDirection`: Mirrors the `textDirection` editor option on `Editor`. When set, the renderer applies the configured direction so the output includes the expected `dir` attribute.
 - `options`: An object with additional options.
 - `options.nodeMapping`: An object that maps Prosemirror nodes to markdown strings.
 - `options.markMapping`: An object that maps Prosemirror marks to markdown strings.
@@ -166,12 +170,14 @@ renderToReactElement({
 function renderToReactElement(options: {
   extensions: Extension[]
   content: ProsemirrorNode | JSONContent
+  textDirection?: 'ltr' | 'rtl' | 'auto'
   options?: TiptapReactStaticRendererOptions
 }): ReactElement
 ```
 
 - `extensions`: An array of Tiptap extensions that are used to render the content.
 - `content`: The content to render. Can be a Prosemirror Node instance or a JSON representation of a Prosemirror document.
+- `textDirection`: Mirrors the `textDirection` editor option on `Editor`. When set, the renderer applies the configured direction so the output includes the expected `dir` attribute.
 - `options`: An object with additional options.
 - `options.nodeMapping`: An object that maps Prosemirror nodes to React components.
 - `options.markMapping`: An object that maps Prosemirror marks to React components.
@@ -300,6 +306,33 @@ renderToReactElement({
 ```
 
 <CodeDemo path="/Examples/StaticRenderingAdvanced" />
+
+## Limitations and workarounds
+
+The static renderer builds the schema and runs each extension's `renderHTML`, but does not instantiate an `Editor`. As a result:
+
+- `addProseMirrorPlugins`, `onCreate`, `onUpdate`, and transaction hooks do not run.
+- Extensions that assign attributes via those mechanisms — for example `UniqueID` (`data-id`) and `TableOfContents` (`id`, `data-toc-id`) — will not populate those attributes on their own.
+
+For these cases, pre-process the JSON document before rendering:
+
+```ts
+import { generateUniqueIds } from '@tiptap/extension-unique-id'
+import { generateTocIds } from '@tiptap/extension-table-of-contents'
+import { renderToHTMLString } from '@tiptap/static-renderer/pm/html-string'
+
+let doc = sourceJson
+doc = generateUniqueIds(doc, extensions) // if using UniqueID
+doc = generateTocIds(doc, extensions)    // if using TableOfContents
+
+const html = renderToHTMLString({
+  content: doc,
+  extensions,
+  textDirection: 'auto', // mirrors the editor option
+})
+```
+
+Editor-level options that affect output are accepted as top-level arguments (currently `textDirection`). Other editor options that depend on a runtime view or transaction stream are out of scope.
 
 ## Shared Options
 

--- a/src/content/editor/api/utilities/static-renderer.mdx
+++ b/src/content/editor/api/utilities/static-renderer.mdx
@@ -66,14 +66,14 @@ renderToHTMLString({
 function renderToHTMLString(options: {
   extensions: Extension[]
   content: ProsemirrorNode | JSONContent
-  textDirection?: 'ltr' | 'rtl' | 'auto'
+  staticEditorOptions?: { textDirection?: 'ltr' | 'rtl' | 'auto' }
   options?: TiptapHTMLStaticRendererOptions
 }): string
 ```
 
 - `extensions`: An array of Tiptap extensions that are used to render the content.
 - `content`: The content to render. Can be a Prosemirror Node instance or a JSON representation of a Prosemirror document.
-- `textDirection`: Mirrors the `textDirection` editor option on `Editor`. When set, the renderer applies the configured direction so the output includes the expected `dir` attribute.
+- `staticEditorOptions`: Optional editor-level options that affect rendered output. Currently supports `textDirection` (`'ltr' | 'rtl' | 'auto'`), which mirrors the `textDirection` editor option on `Editor` so the output includes the expected `dir` attribute.
 - `options`: An object with additional options.
 - `options.nodeMapping`: An object that maps Prosemirror nodes to HTML strings.
 - `options.markMapping`: An object that maps Prosemirror marks to HTML strings.
@@ -120,14 +120,14 @@ renderToMarkdown({
 function renderToMarkdown(options: {
   extensions: Extension[]
   content: ProsemirrorNode | JSONContent
-  textDirection?: 'ltr' | 'rtl' | 'auto'
+  staticEditorOptions?: { textDirection?: 'ltr' | 'rtl' | 'auto' }
   options?: TiptapMarkdownStaticRendererOptions
 }): string
 ```
 
 - `extensions`: An array of Tiptap extensions that are used to render the content.
 - `content`: The content to render. Can be a Prosemirror Node instance or a JSON representation of a Prosemirror document.
-- `textDirection`: Mirrors the `textDirection` editor option on `Editor`. When set, the renderer applies the configured direction so the output includes the expected `dir` attribute.
+- `staticEditorOptions`: Optional editor-level options that affect rendered output. Currently supports `textDirection` (`'ltr' | 'rtl' | 'auto'`), which mirrors the `textDirection` editor option on `Editor` so the output includes the expected `dir` attribute.
 - `options`: An object with additional options.
 - `options.nodeMapping`: An object that maps Prosemirror nodes to markdown strings.
 - `options.markMapping`: An object that maps Prosemirror marks to markdown strings.
@@ -170,14 +170,14 @@ renderToReactElement({
 function renderToReactElement(options: {
   extensions: Extension[]
   content: ProsemirrorNode | JSONContent
-  textDirection?: 'ltr' | 'rtl' | 'auto'
+  staticEditorOptions?: { textDirection?: 'ltr' | 'rtl' | 'auto' }
   options?: TiptapReactStaticRendererOptions
 }): ReactElement
 ```
 
 - `extensions`: An array of Tiptap extensions that are used to render the content.
 - `content`: The content to render. Can be a Prosemirror Node instance or a JSON representation of a Prosemirror document.
-- `textDirection`: Mirrors the `textDirection` editor option on `Editor`. When set, the renderer applies the configured direction so the output includes the expected `dir` attribute.
+- `staticEditorOptions`: Optional editor-level options that affect rendered output. Currently supports `textDirection` (`'ltr' | 'rtl' | 'auto'`), which mirrors the `textDirection` editor option on `Editor` so the output includes the expected `dir` attribute.
 - `options`: An object with additional options.
 - `options.nodeMapping`: An object that maps Prosemirror nodes to React components.
 - `options.markMapping`: An object that maps Prosemirror marks to React components.
@@ -328,11 +328,11 @@ doc = generateTocIds(doc, extensions)    // if using TableOfContents
 const html = renderToHTMLString({
   content: doc,
   extensions,
-  textDirection: 'auto', // mirrors the editor option
+  staticEditorOptions: { textDirection: 'auto' }, // mirrors a subset of EditorOptions
 })
 ```
 
-Editor-level options that affect output are accepted as top-level arguments (currently `textDirection`). Other editor options that depend on a runtime view or transaction stream are out of scope.
+Editor-level options that affect output are accepted via the `staticEditorOptions` object (currently `textDirection`). Other editor options that depend on a runtime view or transaction stream are out of scope.
 
 ## Shared Options
 

--- a/src/content/editor/extensions/functionality/table-of-contents.mdx
+++ b/src/content/editor/extensions/functionality/table-of-contents.mdx
@@ -237,3 +237,46 @@ The array returned by the storage or the `onUpdate` function includes objects st
 ```
 
 This should give you enough flexibility to render your own table of content.
+
+## Server side anchor ID utility
+
+The `generateTocIds` function allows you to assign anchor IDs (`id` and `data-toc-id`) to a Tiptap document on the server side, without needing to create an `Editor` instance. This is useful when you want to render the document statically — for example with `@tiptap/static-renderer` — and still get the same anchor attributes the `TableOfContents` plugin would produce in a live editor.
+
+### Parameters
+
+- **`doc`** (`JSONContent`): A Tiptap JSON document to add anchor IDs to
+- **`extensions`** (`Extensions`): The extensions to use. Must include the `TableOfContents` extension. To customize how the IDs are generated or which node types are treated as anchors, pass options like `getId` or `anchorTypes` to the `TableOfContents` extension.
+
+### Return type
+
+Returns a new Tiptap document (a `JSONContent` object) with `id` and `data-toc-id` attributes assigned to anchor-type nodes that were missing or had duplicate IDs.
+
+### Example
+
+```js
+import { generateTocIds, TableOfContents } from '@tiptap/extension-table-of-contents'
+import { StarterKit } from '@tiptap/starter-kit'
+
+const doc = {
+  type: 'doc',
+  content: [
+    { type: 'heading', attrs: { level: 1 }, content: [{ type: 'text', text: 'Introduction' }] },
+    { type: 'paragraph', content: [{ type: 'text', text: 'A paragraph.' }] },
+    { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'Details' }] },
+  ],
+}
+
+const newDoc = generateTocIds(doc, [StarterKit, TableOfContents])
+
+// Result:
+// {
+//   type: 'doc',
+//   content: [
+//     { type: 'heading', attrs: { level: 1, id: 'd4590f81-52e8-45ec-b317-2e9a805b03e3', 'data-toc-id': 'd4590f81-52e8-45ec-b317-2e9a805b03e3' }, content: [...] },
+//     { type: 'paragraph', content: [...] },
+//     { type: 'heading', attrs: { level: 2, id: 'c88f9b5f-7b91-442f-b4d9-ee0d04104827', 'data-toc-id': 'c88f9b5f-7b91-442f-b4d9-ee0d04104827' }, content: [...] }
+//   ]
+// }
+```
+
+The function automatically picks up the configuration from the `TableOfContents` extension, including `anchorTypes` and `getId`.


### PR DESCRIPTION
Companion docs for [ueberdosis/tiptap#7847](https://github.com/ueberdosis/tiptap/pull/7847), which closes [ueberdosis/tiptap#7637](https://github.com/ueberdosis/tiptap/issues/7637).

## Changes

- Documents the new optional `textDirection` parameter on `renderToHTMLString`, `renderToMarkdown`, and `renderToReactElement` (added in the code PR).
- Adds a **Limitations and workarounds** section to the static-renderer page explaining that plugin-driven extensions (`UniqueID`, `TableOfContents`) do not run in static rendering, with the recommended pre-process pattern using `generateUniqueIds` and `generateTocIds`.
- Adds a **Server side anchor ID utility** section to the `TableOfContents` extension page covering the new `generateTocIds` helper (parameters, return type, example), mirroring the existing `generateUniqueIds` documentation.

