### PR TITLE
Add knownHtmlTags parameter to Markdown and MarkdownManager configuration

### DIFF
--- a/src/content/editor/markdown/api/extension.mdx
+++ b/src/content/editor/markdown/api/extension.mdx
@@ -22,6 +22,7 @@ Markdown.configure({
   },
   marked?: typeof marked,
   markedOptions?: MarkedOptions,
+  knownHtmlTags?: string[],
 })
 ```
 
@@ -37,14 +38,20 @@ Markdown.configure({
   - Custom MarkedJS instance to use for parsing
 
 - **`markedOptions`** (optional)
+
   - Options passed to `marked.setOptions()`
   - See [marked documentation](https://marked.js.org/using_advanced#options)
+
+- **`knownHtmlTags`** (optional)
+
+  - Array of custom HTML tag names that should be treated as recognized HTML elements during parsing. This is useful for tags that represent custom ProseMirror nodes but are not natively recognized by the browser (e.g. `['mood', 'reaction']`). Particularly important for **server-side rendering** where `HTMLUnknownElement` is not available. Default: `[]`
 
 #### Example
 
 ```typescript
 import { Markdown } from '@tiptap/markdown'
 
+// Basic configuration
 const markdown = Markdown.configure({
   indentation: {
     style: 'space',
@@ -54,5 +61,10 @@ const markdown = Markdown.configure({
     gfm: true,
     breaks: false,
   },
+})
+
+// With custom HTML tags for server-side rendering
+const markdownWithHtmlTags = Markdown.configure({
+  knownHtmlTags: ['custom', 'ssomething', 'custom-tag'],
 })
 ```

--- a/src/content/editor/markdown/api/markdown-manager.mdx
+++ b/src/content/editor/markdown/api/markdown-manager.mdx
@@ -22,8 +22,15 @@ new MarkdownManager(options?: {
     style?: 'space' | 'tab',
     size?: number,
   },
+  knownHtmlTags?: string[],
 })
 ```
+
+#### Constructor Parameters
+
+- **`knownHtmlTags`** (optional)
+
+  - Array of custom HTML tag names that should be treated as recognized HTML elements during parsing. This is useful for tags that represent custom ProseMirror nodes but are not natively recognized by the browser (e.g. `['mood', 'reaction']`). Particularly important for **server-side rendering** where `HTMLUnknownElement` is not available. Default: `[]`
 
 ### `MarkdownManager.hasMarked()`
 
@@ -60,6 +67,15 @@ Parses a Markdown string into a Tiptap document.
 ```js
 const manager = new MarkdownManager()
 const doc = manager.parse('# Hello World')
+```
+
+```js
+// With knownHtmlTags for custom ProseMirror node tags
+const manager = new MarkdownManager({
+  extensions: [Document, Paragraph, Text],
+  knownHtmlTags: ['something', 'reaction'],
+})
+const doc = manager.parse('<reaction>happy</reaction>')
 ```
 
 Markdown parsing preserves consecutive empty paragraphs by combining normal blank-line separation with `&nbsp;` markers when needed. For example, the first empty paragraph in a run is represented by blank lines, while later empty paragraphs in the same run are represented by `&nbsp;` so they survive a roundtrip back to JSON.


### PR DESCRIPTION
Introduce the `knownHtmlTags` parameter to both the Markdown and MarkdownManager configurations. This addition allows for the recognition of custom HTML tags during parsing, which is particularly beneficial for server-side rendering scenarios. The default value is an empty array.