### PR TITLE
Migrate Server AI Toolkit docs to unified authentication

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/advanced-guides/tiptap-shorthand.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/advanced-guides/tiptap-shorthand.mdx
@@ -21,7 +21,6 @@ For example, to get the tool definitions:
 ```bash
 curl -X POST https://api.tiptap.dev/v3/ai/toolkit/tools \
   -H "Content-Type: application/json" \
-  -H "X-App-Id: YOUR_APP_ID" \
   -H "Authorization: Bearer YOUR_JWT_TOKEN" \
   -d '{
     "format": "shorthand",

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot.mdx
@@ -21,7 +21,8 @@ import { Requirements, RequirementItem } from '@/components/Requirements'
     or your preferred package manager.
   </RequirementItem>
   <RequirementItem label="3. Authenticate to the service">
-    Configure your Content AI credentials to access the Server AI Toolkit service.
+    Generate a JWT with the <code>AI:Toolkit</code> permission to access the Server AI Toolkit
+    service.
   </RequirementItem>
 </Requirements>
 
@@ -55,19 +56,13 @@ npx create-next-app@latest server-ai-agent-chatbot
 Install the core Tiptap packages, collaboration extensions, and the [Vercel AI SDK](https://ai-sdk.dev/) for OpenAI:
 
 ```bash
-npm install @tiptap/react @tiptap/starter-kit @tiptap/extension-collaboration @tiptap-pro/provider ai @ai-sdk/react @ai-sdk/openai zod uuid yjs jsonwebtoken
+npm install @tiptap/react @tiptap/starter-kit @tiptap/extension-collaboration @tiptap-pro/provider ai @ai-sdk/react @ai-sdk/openai zod uuid yjs jose
 ```
 
 Install the Server AI Toolkit package:
 
 ```bash
 npm install @tiptap/server-ai-toolkit
-```
-
-Install TypeScript types for jsonwebtoken:
-
-```bash
-npm install --save-dev @types/jsonwebtoken
 ```
 
 ## API endpoint
@@ -82,12 +77,14 @@ Create an API endpoint that uses the [Vercel AI SDK](https://ai-sdk.dev/) to cal
   guide](/content-ai/capabilities/server-ai-toolkit/install#set-up-authorization).
 </Callout>
 
-You also need an OpenAI API key and, if using Tiptap Cloud collaboration, a `TIPTAP_CLOUD_SECRET` for the Document Server. Add these to your `.env` file alongside the variables from the [authorization
+You also need an OpenAI API key and, if using Tiptap Cloud collaboration, a Document Server ID for
+the collaboration provider. Add these to your `.env` file alongside the variables from the
+[authorization
 guide](/content-ai/capabilities/server-ai-toolkit/install#set-up-authorization):
 
 ```sh
 # .env (in addition to the Server AI Toolkit variables)
-TIPTAP_CLOUD_SECRET=your-tiptap-cloud-document-server-secret
+TIPTAP_DOCUMENT_SERVER_ID=your-document-server-id
 OPENAI_API_KEY=your-openai-key # The AI SDK will pick this up automatically
 ```
 
@@ -119,7 +116,7 @@ export async function getToolDefinitions(editorContext: unknown): Promise<{
 
   const response = await fetch(`${apiBaseUrl}/v3/ai/toolkit/tools`, {
     method: 'POST',
-    headers: getAuthHeaders(),
+    headers: await getAuthHeaders(),
     body: JSON.stringify({
       editorContext,
     }),
@@ -141,7 +138,7 @@ export async function getToolDefinitions(editorContext: unknown): Promise<{
 
 #### Execute tool
 
-This function executes a tool via the Server AI Toolkit API. It sends the tool name, input parameters, document ID, and editor context data to the API. The server automatically fetches and saves the Tiptap Cloud document using the credentials in the JWT.
+This function executes a tool via the Server AI Toolkit API. It sends the tool name, input parameters, document ID, and editor context data to the API. The server automatically fetches and saves the Tiptap Cloud document when the JWT includes `Documents:Write` permission for that document.
 
 ```ts
 // lib/server-ai-toolkit/execute-tool.ts
@@ -160,7 +157,7 @@ export async function executeTool(
 
   const response = await fetch(`${apiBaseUrl}/v3/ai/toolkit/execute-tool`, {
     method: 'POST',
-    headers: getAuthHeaders(),
+    headers: await getAuthHeaders({ documentId }),
     body: JSON.stringify({
       toolName,
       input,
@@ -252,31 +249,40 @@ First, create a server function to generate a JWT for Tiptap Cloud collaboration
 // app/actions.ts
 'use server'
 
-import jwt from 'jsonwebtoken'
+import { SignJWT, importPKCS8 } from 'jose'
 
-const TIPTAP_CLOUD_SECRET = process.env.TIPTAP_CLOUD_SECRET
-const TIPTAP_CLOUD_DOCUMENT_SERVER_ID = process.env.TIPTAP_CLOUD_DOCUMENT_SERVER_ID
+const TIPTAP_DOCUMENT_SERVER_ID = process.env.TIPTAP_DOCUMENT_SERVER_ID
 
 export async function getCollabConfig(
   userId: string,
   documentName: string,
 ): Promise<{ token: string; appId: string }> {
-  if (!TIPTAP_CLOUD_SECRET) {
-    throw new Error('TIPTAP_CLOUD_SECRET environment variable is not set')
+  if (!process.env.TIPTAP_PRIVATE_KEY) {
+    throw new Error('TIPTAP_PRIVATE_KEY environment variable is not set')
   }
 
-  if (!TIPTAP_CLOUD_DOCUMENT_SERVER_ID) {
-    throw new Error('TIPTAP_CLOUD_DOCUMENT_SERVER_ID environment variable is not set')
+  if (!process.env.TIPTAP_ENVIRONMENT_ID) {
+    throw new Error('TIPTAP_ENVIRONMENT_ID environment variable is not set')
   }
 
-  const payload = {
+  if (!TIPTAP_DOCUMENT_SERVER_ID) {
+    throw new Error('TIPTAP_DOCUMENT_SERVER_ID environment variable is not set')
+  }
+
+  const privateKey = await importPKCS8(process.env.TIPTAP_PRIVATE_KEY, 'ES256')
+
+  const token = await new SignJWT({
+    permissions: [{ action: 'Documents:Write', resource: documentName }],
     sub: userId,
-    allowedDocumentNames: [documentName],
-  }
+  })
+    .setProtectedHeader({ alg: 'ES256' })
+    .setIssuer(process.env.TIPTAP_ENVIRONMENT_ID)
+    .setAudience(['Documents'])
+    .setIssuedAt()
+    .setExpirationTime('30m')
+    .sign(privateKey)
 
-  const token = jwt.sign(payload, TIPTAP_CLOUD_SECRET, { expiresIn: '1h' })
-
-  return { token, appId: TIPTAP_CLOUD_DOCUMENT_SERVER_ID }
+  return { token, appId: TIPTAP_DOCUMENT_SERVER_ID }
 }
 ```
 

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/comments.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/comments.mdx
@@ -31,7 +31,7 @@ import { getAuthHeaders } from '@/lib/server-ai-toolkit/get-auth-headers'
 
 const response = await fetch(`${apiBaseUrl}/toolkit/tools`, {
   method: 'POST',
-  headers: getAuthHeaders(),
+  headers: await getAuthHeaders(),
   body: JSON.stringify({
     editorContext,
     tools: {
@@ -48,7 +48,7 @@ const response = await fetch(`${apiBaseUrl}/toolkit/tools`, {
 
 ## Execute comment tools
 
-Comment tools require a **Tiptap Cloud document** because threads and comments are stored on the Tiptap Document Server. You do **not** need to pass the `document` field when using `experimental_documentOptions` — the AI Server fetches it from the Document Server automatically.
+Comment tools require a **Tiptap Cloud document** because threads and comments are stored on the Tiptap Document Server. You do **not** need to pass the `document` field when using `experimental_documentOptions` — the AI Server fetches it from the Document Server automatically. The JWT must include `Documents:Write` permission for the target document.
 
 ### Request body
 
@@ -65,7 +65,7 @@ Optionally include `experimental_commentsOptions` for metadata:
 ```ts
 const result = await fetch(`${apiBaseUrl}/toolkit/execute-tool`, {
   method: 'POST',
-  headers: getAuthHeaders(),
+  headers: await getAuthHeaders({ documentId: '123' }),
   body: JSON.stringify({
     toolName: 'editThreads',
     input: {},

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
@@ -52,7 +52,7 @@ import { getAuthHeaders } from '@/lib/server-ai-toolkit/get-auth-headers'
 
 const result = await fetch(`${apiBaseUrl}/toolkit/execute-tool`, {
   method: 'POST',
-  headers: getAuthHeaders(),
+  headers: await getAuthHeaders({ documentId: 'your-document-id' }),
   body: JSON.stringify({
     toolName: 'tiptapEdit',
     input: toolCallInput,
@@ -135,7 +135,7 @@ When fetching tool definitions, configure the `tiptapEdit` tool so it can includ
 ```ts
 const response = await fetch(`${apiBaseUrl}/toolkit/tools`, {
   method: 'POST',
-  headers: getAuthHeaders(),
+  headers: await getAuthHeaders(),
   body: JSON.stringify({
     editorContext,
     tools: {
@@ -153,7 +153,7 @@ Pass `experimental_commentsOptions` alongside `reviewOptions` when calling `exec
 ```ts
 const result = await fetch(`${apiBaseUrl}/toolkit/execute-tool`, {
   method: 'POST',
-  headers: getAuthHeaders(),
+  headers: await getAuthHeaders({ documentId: 'your-document-id' }),
   body: JSON.stringify({
     toolName: 'tiptapEdit',
     input: toolCallInput,

--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/editor-context.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/editor-context.mdx
@@ -70,12 +70,11 @@ const editor = new Editor({
 const editorContext = getEditorContext(editor)
 
 // Use with Server AI Toolkit API
+import { getAuthHeaders } from '@/lib/server-ai-toolkit/get-auth-headers'
+
 const response = await fetch('https://api.tiptap.dev/v3/ai/toolkit/tools', {
   method: 'POST',
-  headers: {
-    'Content-Type': 'application/json',
-    Authorization: `Bearer ${API_TOKEN}`,
-  },
+  headers: await getAuthHeaders(),
   body: JSON.stringify({
     editorContext,
   }),

--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
@@ -34,34 +34,52 @@ The Server AI Toolkit provides REST API endpoints for AI agent tools.
 All requests must include:
 
 - `Authorization: Bearer <JWT>`
-- `X-App-Id: <APP_ID>`
 
-Generate the JWT server-side with your AI secret. Get your App ID and secret key on the [Server AI
-Toolkit settings](https://cloud.tiptap.dev/v2/cloud/ai) page.
+Generate the JWT server-side with your ES256 private key from the Tiptap dashboard. The token must
+include the `AI:Toolkit` permission and set `aud` to `["AI"]`.
 
 ```ts
-import jwt from 'jsonwebtoken'
+import { SignJWT, importPKCS8 } from 'jose'
 
-const JWT_TOKEN = jwt.sign(
-  {
-    experimental_document_server_id: 'your-document-server-id',
-    experimental_document_server_management_api_secret:
-      'your-document-server-management-api-secret',
-  },
-  'your-ai-secret-key',
-  { expiresIn: '1h' },
-)
+const privateKey = await importPKCS8(process.env.TIPTAP_PRIVATE_KEY!, 'ES256')
+
+const JWT_TOKEN = await new SignJWT({
+  permissions: [{ action: 'AI:Toolkit', resource: '*' }],
+})
+  .setProtectedHeader({ alg: 'ES256' })
+  .setIssuer(process.env.TIPTAP_ENVIRONMENT_ID!)
+  .setAudience(['AI'])
+  .setIssuedAt()
+  .setExpirationTime('30m')
+  .sign(privateKey)
 ```
 
-See the [authorization guide](/content-ai/capabilities/server-ai-toolkit/install#set-up-authorization) for more information.
+See the [authorization guide](/content-ai/capabilities/server-ai-toolkit/install#set-up-authorization)
+and the [Authentication reference](/authentication) for more information.
 
-### Document Server credentials
+### Tiptap Cloud documents
 
-Include these JWT claims when you want the Server AI Toolkit to fetch and save Tiptap Cloud
-documents automatically:
+When you want the Server AI Toolkit to fetch and save Tiptap Cloud documents automatically via
+`experimental_documentOptions`, include `Documents:Write` in the JWT permissions and add
+`"Documents"` to the `aud` claim:
 
-- `experimental_document_server_id`
-- `experimental_document_server_management_api_secret`
+```ts
+const JWT_TOKEN = await new SignJWT({
+  permissions: [
+    { action: 'AI:Toolkit', resource: '*' },
+    { action: 'Documents:Write', resource: 'your-document-id' },
+  ],
+})
+  .setProtectedHeader({ alg: 'ES256' })
+  .setIssuer(process.env.TIPTAP_ENVIRONMENT_ID!)
+  .setAudience(['AI', 'Documents'])
+  .setIssuedAt()
+  .setExpirationTime('30m')
+  .sign(privateKey)
+```
+
+`Documents:Write` implies read and comment access, so you do not need separate `Documents:Read` or
+`Documents:Comment` permissions for toolkit workflows.
 
 ## Base URL
 
@@ -235,7 +253,6 @@ Example:
 curl --location 'BASE_URL/v3/ai/toolkit/workflows/edit' \
   --header 'Content-Type: application/json' \
   --header 'Authorization: Bearer YOUR_JWT_TOKEN' \
-  --header 'X-App-Id: YOUR_APP_ID' \
   --data '{
     "format": "shorthand"
   }'
@@ -276,7 +293,6 @@ Example:
 curl --location 'BASE_URL/v3/ai/toolkit/read/read-document' \
   --header 'Content-Type: application/json' \
   --header 'Authorization: Bearer YOUR_JWT_TOKEN' \
-  --header 'X-App-Id: YOUR_APP_ID' \
   --data '{
     "editorContext": { /* editor context data */ },
     "format": "shorthand",
@@ -330,7 +346,6 @@ Example:
 curl --location 'BASE_URL/v3/ai/toolkit/read/read-selection' \
   --header 'Content-Type: application/json' \
   --header 'Authorization: Bearer YOUR_JWT_TOKEN' \
-  --header 'X-App-Id: YOUR_APP_ID' \
   --data '{
     "editorContext": { /* editor context data */ },
     "range": { "from": 10, "to": 42 },
@@ -370,7 +385,6 @@ Example:
 curl --location 'BASE_URL/v3/ai/toolkit/read/threads' \
   --header 'Content-Type: application/json' \
   --header 'Authorization: Bearer YOUR_JWT_TOKEN' \
-  --header 'X-App-Id: YOUR_APP_ID' \
   --data '{
     "editorContext": { /* editor context data */ },
     "format": "shorthand",
@@ -414,7 +428,6 @@ Example:
 curl --location 'BASE_URL/v3/ai/toolkit/execute-workflow/insert-content' \
   --header 'Content-Type: application/json' \
   --header 'Authorization: Bearer YOUR_JWT_TOKEN' \
-  --header 'X-App-Id: YOUR_APP_ID' \
   --data '{
     "editorContext": { /* editor context data */ },
     "input": "This is the replacement content.",
@@ -463,7 +476,6 @@ Example:
 curl --location 'BASE_URL/v3/ai/toolkit/execute-workflow/tiptap-edit' \
   --header 'Content-Type: application/json' \
   --header 'Authorization: Bearer YOUR_JWT_TOKEN' \
-  --header 'X-App-Id: YOUR_APP_ID' \
   --data '{
     "editorContext": { /* editor context data */ },
     "input": {
@@ -517,7 +529,6 @@ Example:
 curl --location 'BASE_URL/v3/ai/toolkit/execute-workflow/proofreader' \
   --header 'Content-Type: application/json' \
   --header 'Authorization: Bearer YOUR_JWT_TOKEN' \
-  --header 'X-App-Id: YOUR_APP_ID' \
   --data '{
     "editorContext": { /* editor context data */ },
     "input": {
@@ -565,7 +576,6 @@ Example:
 curl --location 'BASE_URL/v3/ai/toolkit/execute-workflow/threads' \
   --header 'Content-Type: application/json' \
   --header 'Authorization: Bearer YOUR_JWT_TOKEN' \
-  --header 'X-App-Id: YOUR_APP_ID' \
   --data '{
     "editorContext": { /* editor context data */ },
     "input": {
@@ -597,9 +607,9 @@ curl --location 'BASE_URL/v3/ai/toolkit/execute-workflow/threads' \
 
 The API uses standard HTTP error codes:
 
-- `400 Bad Request`: Invalid body, invalid format, missing document source, or missing Document
-  Server credentials
-- `401 Unauthorized`: Missing or invalid JWT or App ID
+- `400 Bad Request`: Invalid body, invalid format, missing document source, or missing
+  `Documents:Write` permission for Tiptap Cloud document access
+- `401 Unauthorized`: Missing or invalid JWT
 - `404 Not Found`: Unknown endpoint or tool
 - `422 Unprocessable Entity`: Validation failed
 - `429 Too Many Requests`: Duplicate request or rate-limit protection

--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/review-options.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/review-options.mdx
@@ -13,7 +13,7 @@ import { getAuthHeaders } from '@/lib/server-ai-toolkit/get-auth-headers'
 
 const response = await fetch(`${apiBaseUrl}/toolkit/execute-tool`, {
   method: 'POST',
-  headers: getAuthHeaders(),
+  headers: await getAuthHeaders(),
   body: JSON.stringify({
     toolName: 'tiptapEdit',
     input: toolCallInput,

--- a/src/content/content-ai/capabilities/server-ai-toolkit/install.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/install.mdx
@@ -21,7 +21,8 @@ import Link from '@/components/Link'
     or your preferred package manager.
   </RequirementItem>
   <RequirementItem label="3. Authenticate to the service">
-    Configure your Content AI credentials to access the Server AI Toolkit service.
+    Generate a JWT with the <code>AI:Toolkit</code> permission to access the Server AI Toolkit
+    service.
   </RequirementItem>
 </Requirements>
 
@@ -70,12 +71,25 @@ For more details, see the [Editor context API reference](/content-ai/capabilitie
 
 ## Set up authorization
 
-The Server AI Toolkit is a cloud or on-premises service. Authenticate to access its REST API.
+The Server AI Toolkit is a cloud or on-premises service. Authenticate to access its REST API with a
+[unified JWT](/authentication).
 
-1. **Get your App ID and secret key** on the [Tiptap Cloud AI settings](https://cloud.tiptap.dev/v2/cloud/ai) page.
-2. **Get your Document Server credentials** (ID and management API secret) on the [Document Server settings](https://cloud.tiptap.dev/v2/configuration/document-server) page. These are included as JWT claims so the Server AI Toolkit can automatically fetch and save your Tiptap Cloud documents.
-3. **Generate a JWT** using a library like `jsonwebtoken`. In production, always create JWTs **server-side** to keep your secret safe.
-4. **Use the JWT** in your API requests. Pass it in the `Authorization` header as a Bearer token and the App ID in `X-App-Id`.
+1. **Create an asymmetric key pair** in your Tiptap dashboard and copy your environment hash ID and
+   private key.
+2. **Generate a JWT** using a library like [`jose`](https://github.com/panva/jose). In production,
+   always create JWTs **server-side** to keep your private key safe.
+3. **Include the `AI:Toolkit` permission** in the token's `permissions` array and set `aud` to
+   `["AI"]`.
+4. **Use the JWT** in your API requests. Pass it in the `Authorization` header as a Bearer token.
+
+See the [Authentication reference](/authentication) for the full claims reference, permission
+model, and security best practices.
+
+Install the JWT signing library:
+
+```bash
+npm install jose
+```
 
 ### Environment variables
 
@@ -84,40 +98,51 @@ Configure the following environment variables:
 ```sh
 # .env
 TIPTAP_CLOUD_AI_API_URL=https://api.tiptap.dev
-TIPTAP_CLOUD_AI_SECRET=your-secret-key
-TIPTAP_CLOUD_AI_APP_ID=your-app-id
-TIPTAP_CLOUD_DOCUMENT_SERVER_ID=your-tiptap-cloud-document-server-id
-TIPTAP_CLOUD_DOCUMENT_SERVER_MANAGEMENT_API_SECRET=your-tiptap-cloud-document-management-api-secret
+TIPTAP_ENVIRONMENT_ID=your-environment-hash-id
+TIPTAP_PRIVATE_KEY=your-private-key-pem
 ```
 
 - **TIPTAP_CLOUD_AI_API_URL**: The base URL for the Server AI Toolkit API.
-- **TIPTAP_CLOUD_AI_SECRET**: Your "Content AI Secret" from the [Content AI settings](https://cloud.tiptap.dev/v2/cloud/ai) page. Used to sign the JWT.
-- **TIPTAP_CLOUD_AI_APP_ID**: Your "Content AI App ID" from the [Content AI settings](https://cloud.tiptap.dev/v2/cloud/ai) page.
-- **TIPTAP_CLOUD_DOCUMENT_SERVER_ID**: Your Tiptap Cloud Document Server ID from the [Document Server settings](https://cloud.tiptap.dev/v2/configuration/document-server) page. Included as the `experimental_document_server_id` JWT claim so the Server AI Toolkit can fetch and save documents automatically.
-- **TIPTAP_CLOUD_DOCUMENT_SERVER_MANAGEMENT_API_SECRET**: Your Document Server management API secret. Included as the `experimental_document_server_management_api_secret` JWT claim for document access.
+- **TIPTAP_ENVIRONMENT_ID**: Your environment hash ID from the Tiptap dashboard. Used as the `iss`
+  claim when signing JWTs.
+- **TIPTAP_PRIVATE_KEY**: Your ES256 private key (PKCS#8 PEM) from the Tiptap dashboard. Used to
+  sign JWTs server-side.
 
 ### Create a JWT token
 
-This function generates a JWT from `TIPTAP_CLOUD_AI_SECRET` for authenticating with the Server AI Toolkit API. It includes Document Server credentials so the Server AI Toolkit can automatically fetch and save your Tiptap Cloud documents.
+This function generates a JWT for authenticating with the Server AI Toolkit API. Pass a
+`documentId` when the Server AI Toolkit should fetch and save Tiptap Cloud documents automatically
+via `experimental_documentOptions`.
 
 ```ts
 // lib/server-ai-toolkit/create-jwt-token.ts
-import jwt from 'jsonwebtoken'
+import { SignJWT, importPKCS8 } from 'jose'
+
+type CreateJwtTokenOptions = {
+  documentId?: string
+}
 
 /**
- * Generates a JWT from TIPTAP_CLOUD_AI_SECRET for authenticating with the Server AI Toolkit API
+ * Generates a JWT for authenticating with the Server AI Toolkit API
  */
-export function createJwtToken(): string {
-  return jwt.sign(
-    {
-      // Document Server credentials for automatic document fetching/saving
-      experimental_document_server_id: process.env.TIPTAP_CLOUD_DOCUMENT_SERVER_ID,
-      experimental_document_server_management_api_secret:
-        process.env.TIPTAP_CLOUD_DOCUMENT_SERVER_MANAGEMENT_API_SECRET,
-    },
-    process.env.TIPTAP_CLOUD_AI_SECRET,
-    { expiresIn: '1h' },
-  )
+export async function createJwtToken(options: CreateJwtTokenOptions = {}): Promise<string> {
+  const privateKey = await importPKCS8(process.env.TIPTAP_PRIVATE_KEY!, 'ES256')
+
+  const permissions: { action: string; resource: string }[] = [
+    { action: 'AI:Toolkit', resource: '*' },
+  ]
+
+  if (options.documentId) {
+    permissions.push({ action: 'Documents:Write', resource: options.documentId })
+  }
+
+  return new SignJWT({ permissions })
+    .setProtectedHeader({ alg: 'ES256' })
+    .setIssuer(process.env.TIPTAP_ENVIRONMENT_ID!)
+    .setAudience(options.documentId ? ['AI', 'Documents'] : ['AI'])
+    .setIssuedAt()
+    .setExpirationTime('30m')
+    .sign(privateKey)
 }
 ```
 
@@ -129,23 +154,34 @@ This function returns the authentication headers required for all Server AI Tool
 // lib/server-ai-toolkit/get-auth-headers.ts
 import { createJwtToken } from './create-jwt-token'
 
+type GetAuthHeadersOptions = {
+  documentId?: string
+}
+
 /**
  * Returns the authentication headers for the Server AI Toolkit API
  */
-export function getAuthHeaders(): Record<string, string> {
+export async function getAuthHeaders(
+  options: GetAuthHeadersOptions = {},
+): Promise<Record<string, string>> {
   return {
     'Content-Type': 'application/json',
-    Authorization: `Bearer ${createJwtToken()}`,
-    'X-App-Id': process.env.TIPTAP_CLOUD_AI_APP_ID,
+    Authorization: `Bearer ${await createJwtToken(options)}`,
   }
 }
 ```
 
 <Callout title="Alternative: provide documents directly" variant="info">
-  If you manage documents in your own storage instead of Tiptap Cloud, you can omit the
-  `experimental_document_server_id` and `experimental_document_server_management_api_secret` JWT
-  claims and pass documents directly via the `document` field in API requests. See the [REST API
+  If you manage documents in your own storage instead of Tiptap Cloud, omit the `documentId` option
+  and pass documents directly via the `document` field in API requests. The token only needs the
+  `AI:Toolkit` permission. See the [REST API
   reference](/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api).
+</Callout>
+
+<Callout title="Tiptap Cloud documents" variant="info">
+  When using `experimental_documentOptions`, include `Documents:Write` in the JWT permissions so the
+  Server AI Toolkit can fetch and save documents on your behalf. Pass the target document ID to
+  `getAuthHeaders({ documentId })`.
 </Callout>
 
 ## Call API endpoints
@@ -159,7 +195,7 @@ const apiBaseUrl = process.env.TIPTAP_CLOUD_AI_API_URL || 'https://api.tiptap.de
 
 const response = await fetch(`${apiBaseUrl}/v3/ai/toolkit/tools`, {
   method: 'POST',
-  headers: getAuthHeaders(),
+  headers: await getAuthHeaders(),
   body: JSON.stringify({
     editorContext,
   }),

--- a/src/content/content-ai/capabilities/server-ai-toolkit/overview.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/overview.mdx
@@ -25,7 +25,8 @@ import { CodeDemo } from '@/components/CodeDemo'
     or your preferred package manager.
   </RequirementItem>
   <RequirementItem label="3. Authenticate to the service">
-    Configure your Content AI credentials to access the Server AI Toolkit service.
+    Generate a JWT with the <code>AI:Toolkit</code> permission to access the Server AI Toolkit
+    service.
   </RequirementItem>
 </Requirements>
 

--- a/src/content/content-ai/capabilities/server-ai-toolkit/server-ai-toolkit-api.postman_collection.json
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/server-ai-toolkit-api.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "_postman_id": "server-ai-toolkit-api",
     "name": "Server AI Toolkit API",
-    "description": "Postman collection for the Tiptap Server AI Toolkit REST API endpoints",
+    "description": "Postman collection for the Tiptap Server AI Toolkit REST API endpoints. Authenticate with an ES256 JWT signed using your private key from the Tiptap dashboard. The token must include the AI:Toolkit permission. See https://tiptap.dev/docs/authentication for details.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -19,11 +19,6 @@
           {
             "key": "Authorization",
             "value": "Bearer {{JWT_TOKEN}}",
-            "type": "text"
-          },
-          {
-            "key": "X-App-Id",
-            "value": "{{APP_ID}}",
             "type": "text"
           }
         ],
@@ -56,10 +51,6 @@
               {
                 "key": "Authorization",
                 "value": "Bearer {{JWT_TOKEN}}"
-              },
-              {
-                "key": "X-App-Id",
-                "value": "{{APP_ID}}"
               }
             ],
             "body": {
@@ -105,11 +96,6 @@
             "key": "Authorization",
             "value": "Bearer {{JWT_TOKEN}}",
             "type": "text"
-          },
-          {
-            "key": "X-App-Id",
-            "value": "{{APP_ID}}",
-            "type": "text"
           }
         ],
         "body": {
@@ -141,10 +127,6 @@
               {
                 "key": "Authorization",
                 "value": "Bearer {{JWT_TOKEN}}"
-              },
-              {
-                "key": "X-App-Id",
-                "value": "{{APP_ID}}"
               }
             ],
             "body": {
@@ -186,10 +168,6 @@
               {
                 "key": "Authorization",
                 "value": "Bearer {{JWT_TOKEN}}"
-              },
-              {
-                "key": "X-App-Id",
-                "value": "{{APP_ID}}"
               }
             ],
             "body": {
@@ -230,11 +208,6 @@
     },
     {
       "key": "JWT_TOKEN",
-      "value": "",
-      "type": "string"
-    },
-    {
-      "key": "APP_ID",
       "value": "",
       "type": "string"
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fully replaces legacy per-service authentication across all Server AI Toolkit documentation with the unified ES256 JWT model documented at `/authentication`.

## Changes

- **Install guide** (`install.mdx`): New auth flow using `jose`, `TIPTAP_ENVIRONMENT_ID`, and `TIPTAP_PRIVATE_KEY`. Provides `createJwtToken()` and async `getAuthHeaders()` helpers with optional `documentId` for Tiptap Cloud document access via `Documents:Write`.
- **REST API reference** (`rest-api.mdx`): Rewritten authentication section, removed `X-App-Id` from all cURL examples, updated error codes.
- **Agent guides** (`ai-agent-chatbot`, `tracked-changes`, `comments`): Updated code samples to use unified JWT; migrated collaboration tokens from `jsonwebtoken` + `allowedDocumentNames` to `Documents:Write` permissions.
- **Overview, editor-context, review-options, tiptap-shorthand**: Updated requirement text and code samples.
- **Postman collection**: Removed `X-App-Id` header and `APP_ID` variable; updated description.

## Removed (legacy auth)

- `X-App-Id` header
- `TIPTAP_CLOUD_AI_SECRET` / `TIPTAP_CLOUD_AI_APP_ID`
- `experimental_document_server_*` JWT claims
- `jsonwebtoken` dependency in docs

## Unchanged

- `experimental_documentOptions` in API request bodies (document reference parameter, not auth)
- External demo repo (`ueberdosis/ai-toolkit-demos`) — out of scope

## Test plan

- [x] Grep `server-ai-toolkit/` confirms zero legacy auth string matches
- [ ] Review install guide auth section renders correctly
- [ ] Verify links to `/authentication` resolve
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7df2c80e-1adf-49fe-8a6e-d0412c899159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7df2c80e-1adf-49fe-8a6e-d0412c899159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

