### PR TITLE
Clarify Tracked Changes is separate from AI Toolkit products

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/agents/review-changes/index.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/review-changes/index.mdx
@@ -7,17 +7,22 @@ meta:
 ---
 
 import { Link } from '@/components/Link'
+import { Callout } from '@/components/ui/Callout'
 
 The AI Toolkit lets you show AI-generated changes in a review UI, so your users can accept or reject them.
 
 There are two approaches:
 
-- Use the [**Tracked Changes**](/tracked-changes/getting-started/overview) extension to render the review UI. Changes persist as part of the document and are visible to other users.
+- Use the [**Tracked Changes**](/tracked-changes/getting-started/overview) extension (a separate product) to render the review UI. Changes persist as part of the document and are visible to other users.
 - **AI Toolkit suggestions**: a decoration-based UI that's ephemeral and only visible to the current user of the document.
 
-## Tracked Changes
+## Use with Tracked Changes
 
-The AI Toolkit integrates with the [Tracked Changes extension](/tracked-changes/getting-started/overview) to show the review UI. Follow these guides to get started:
+<Callout title="Separate product" variant="info">
+  [Tracked Changes](/tracked-changes/getting-started/overview) is a separate Tiptap product from the AI Toolkit, sold separately. It handles user edits by default and can review AI edits when integrated with the AI Toolkit.
+</Callout>
+
+The AI Toolkit connects to the separately licensed [Tracked Changes extension](/tracked-changes/getting-started/overview) to show the review UI. Follow these guides to get started:
 
 <div className="grid md:grid-cols-2 gap-4 mt-6 md:items-start">
   <Link
@@ -25,7 +30,7 @@ The AI Toolkit integrates with the [Tracked Changes extension](/tracked-changes/
     className="flex flex-col p-4 border border-grayAlpha-200 rounded-lg hover:border-grayAlpha-300 transition-colors cursor-pointer no-underline"
   >
     <div className="flex items-center justify-between mb-2">
-      <h4 className="font-semibold text-black">Tracked changes</h4>
+      <h4 className="font-semibold text-black">Use with Tracked Changes</h4>
       <span className="text-sm text-blue-600 font-medium whitespace-nowrap ml-4">More &rarr;</span>
     </div>
     <div className="text-sm text-grayAlpha-700">

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/review-changes/index.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/review-changes/index.mdx
@@ -22,7 +22,7 @@ There are two approaches:
   [Tracked Changes](/tracked-changes/getting-started/overview) is a separate Tiptap product from the AI Toolkit, sold separately. It handles user edits by default and can review AI edits when integrated with the AI Toolkit.
 </Callout>
 
-The AI Toolkit connects to the separately licensed [Tracked Changes extension](/tracked-changes/getting-started/overview) to show the review UI. Follow these guides to get started:
+The AI Toolkit integrates with the [Tracked Changes extension](/tracked-changes/getting-started/overview) to show the review UI. Follow these guides to get started:
 
 <div className="grid md:grid-cols-2 gap-4 mt-6 md:items-start">
   <Link

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/review-changes/tracked-changes-with-comments.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/review-changes/tracked-changes-with-comments.mdx
@@ -11,16 +11,20 @@ sidebars:
 import { Callout } from '@/components/ui/Callout'
 import { CodeDemo } from '@/components/CodeDemo'
 
+<Callout title="Separate product" variant="info">
+  [Tracked Changes](/tracked-changes/getting-started/overview) is a separate Tiptap product from the AI Toolkit, sold separately. It handles user edits by default and can review AI edits when integrated with the AI Toolkit.
+</Callout>
+
 <Callout title="Experimental" variant="warning">
   The [Tracked Changes](/tracked-changes/getting-started/overview) extension is currently in Alpha phase.
 </Callout>
 
-<Callout title="Continuation from the tracked changes guide" variant="info">
-  This guide continues the [tracked changes
+<Callout title="Continuation from the Use with Tracked Changes guide" variant="info">
+  This guide continues the [Use with Tracked Changes
   guide](/content-ai/capabilities/ai-toolkit/agents/review-changes/tracked-changes). Read it first.
 </Callout>
 
-You can ask the AI to provide a justification for each change. Each justification becomes a comment thread linked to its tracked change, using the [Comments](/comments/getting-started/overview) extension.
+You can ask the AI to provide a justification for each change. Each justification becomes a comment thread linked to its tracked change, using the [Comments](/comments/getting-started/overview) extension. This guide builds on the [Use with Tracked Changes](/content-ai/capabilities/ai-toolkit/agents/review-changes/tracked-changes) integration and requires the separately licensed Tracked Changes extension.
 
 <CodeDemo isLarge path="" isScrollable src="https://ai-toolkit-demos.vercel.app/tracked-changes-comments" />
 

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/review-changes/tracked-changes.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/review-changes/tracked-changes.mdx
@@ -1,13 +1,17 @@
 ---
-title: Tracked changes
+title: Use with Tracked Changes
 meta:
-  title: Tracked changes | Tiptap Content AI
+  title: Use with Tracked Changes | Tiptap Content AI
   description: Display AI-generated changes as tracked changes that users can accept or reject individually.
   category: Content AI
 ---
 
 import { Callout } from '@/components/ui/Callout'
 import { CodeDemo } from '@/components/CodeDemo'
+
+<Callout title="Separate product" variant="info">
+  [Tracked Changes](/tracked-changes/getting-started/overview) is a separate Tiptap product from the AI Toolkit, sold separately. It handles user edits by default and can review AI edits when integrated with the AI Toolkit.
+</Callout>
 
 <Callout title="Experimental" variant="warning">
   The [Tracked Changes](/tracked-changes/getting-started/overview) extension is currently in Alpha phase.
@@ -18,7 +22,7 @@ import { CodeDemo } from '@/components/CodeDemo'
   guide](/content-ai/capabilities/ai-toolkit/agents/ai-agent-chatbot). Read it first.
 </Callout>
 
-Display AI-generated changes as tracked changes, so your users can review and accept or reject them individually. This integrates the AI Toolkit with the [Tracked Changes](/tracked-changes/getting-started/overview) extension.
+Display AI-generated changes as tracked changes, so your users can review and accept or reject them individually. This guide shows how to connect the AI Toolkit to the separately licensed [Tracked Changes](/tracked-changes/getting-started/overview) extension.
 
 
 <CodeDemo isLarge path="" isScrollable src="https://ai-toolkit-demos.vercel.app/tracked-changes" />
@@ -58,9 +62,9 @@ export async function POST(req: Request) {
 
 ### Client-side setup
 
-On the client, add the `TrackedChanges` extension and pass `reviewOptions` with mode `'trackedChanges'` to the `executeTool` method.
+On the client, install and add the `TrackedChanges` extension, then pass `reviewOptions` with mode `'trackedChanges'` to the `executeTool` method.
 
-The `TrackedChanges` extension must be configured with `enabled: false` — the AI Toolkit enables it automatically when needed.
+The `TrackedChanges` extension must be configured with `enabled: false` — the AI Toolkit temporarily enables it when applying AI edits.
 
 ```tsx
 import { useChat } from '@ai-sdk/react'

--- a/src/content/content-ai/capabilities/ai-toolkit/agents/review-changes/tracked-changes.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/review-changes/tracked-changes.mdx
@@ -64,7 +64,7 @@ export async function POST(req: Request) {
 
 On the client, install and add the `TrackedChanges` extension, then pass `reviewOptions` with mode `'trackedChanges'` to the `executeTool` method.
 
-The `TrackedChanges` extension must be configured with `enabled: false` — the AI Toolkit temporarily enables it when applying AI edits.
+The `TrackedChanges` extension must be configured with `enabled: false` while the AI is making edits.
 
 ```tsx
 import { useChat } from '@ai-sdk/react'

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
@@ -82,7 +82,7 @@ See the [review options reference](/content-ai/capabilities/server-ai-toolkit/ap
 
 ### Client-side setup
 
-On the client, install and add the `ServerAiToolkit` and `TrackedChanges` extensions. The `TrackedChanges` extension must be configured with `enabled: false` because the Server AI Toolkit temporarily enables it when writing AI edits.
+On the client, install and add the `ServerAiToolkit` and `TrackedChanges` extensions.
 
 ```tsx
 import { useChat } from '@ai-sdk/react'

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
@@ -11,11 +11,11 @@ sidebars:
 import { Callout } from '@/components/ui/Callout'
 import { CodeDemo } from '@/components/CodeDemo'
 
+Display server-side AI edits as tracked changes, so your users can review and accept or reject them individually. This integrates the Server AI Toolkit with the [Tracked Changes](/tracked-changes/getting-started/overview) extension.
+
 <Callout title="Separate product" variant="info">
   [Tracked Changes](/tracked-changes/getting-started/overview) is a separate Tiptap product from the Server AI Toolkit, sold separately. It handles user edits by default and can review AI edits when integrated with the Server AI Toolkit.
 </Callout>
-
-Display server-side AI edits as tracked changes, so your users can review and accept or reject them individually. This guide shows how to connect the Server AI Toolkit to the separately licensed [Tracked Changes](/tracked-changes/getting-started/overview) extension.
 
 <CodeDemo
   isLarge

--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx
@@ -1,7 +1,7 @@
 ---
-title: Tracked changes
+title: Use with Tracked Changes
 meta:
-  title: Tracked changes | Tiptap Server AI Toolkit
+  title: Use with Tracked Changes | Tiptap Server AI Toolkit
   description: Display server-side AI edits as tracked changes that users can accept or reject individually.
   category: Content AI
 sidebars:
@@ -11,7 +11,11 @@ sidebars:
 import { Callout } from '@/components/ui/Callout'
 import { CodeDemo } from '@/components/CodeDemo'
 
-Display server-side AI edits as tracked changes, so your users can review and accept or reject them individually. This integrates the Server AI Toolkit with the [Tracked Changes](/tracked-changes/getting-started/overview) extension.
+<Callout title="Separate product" variant="info">
+  [Tracked Changes](/tracked-changes/getting-started/overview) is a separate Tiptap product from the Server AI Toolkit, sold separately. It handles user edits by default and can review AI edits when integrated with the Server AI Toolkit.
+</Callout>
+
+Display server-side AI edits as tracked changes, so your users can review and accept or reject them individually. This guide shows how to connect the Server AI Toolkit to the separately licensed [Tracked Changes](/tracked-changes/getting-started/overview) extension.
 
 <CodeDemo
   isLarge
@@ -36,8 +40,8 @@ See the [source code on GitHub](https://github.com/ueberdosis/ai-toolkit-demos).
 
 1. The AI reads the document with `tiptapRead`.
 2. The AI edits the document with `tiptapEdit` in `trackedChanges` mode.
-3. The server writes tracked change marks instead of directly mutating the document.
-4. The client displays the tracked changes and lets users accept or reject them.
+3. The Server AI Toolkit writes tracked change marks through the Tracked Changes extension instead of directly mutating the document.
+4. The client displays the tracked changes with the Tracked Changes extension and lets users accept or reject them.
 
 ## Show tracked changes
 
@@ -78,7 +82,7 @@ See the [review options reference](/content-ai/capabilities/server-ai-toolkit/ap
 
 ### Client-side setup
 
-On the client, add the `ServerAiToolkit` and `TrackedChanges` extensions. The `TrackedChanges` extension must be configured with `enabled: false` because the server enables it automatically when writing tracked changes.
+On the client, install and add the `ServerAiToolkit` and `TrackedChanges` extensions. The `TrackedChanges` extension must be configured with `enabled: false` because the Server AI Toolkit temporarily enables it when writing AI edits.
 
 ```tsx
 import { useChat } from '@ai-sdk/react'

--- a/src/content/content-ai/sidebar.ts
+++ b/src/content/content-ai/sidebar.ts
@@ -52,7 +52,7 @@ export const sidebarConfig: SidebarConfig = {
                   href: '/content-ai/capabilities/ai-toolkit/agents/review-changes',
                   children: [
                     {
-                      title: 'Tracked changes',
+                      title: 'Use with Tracked Changes',
                       href: '/content-ai/capabilities/ai-toolkit/agents/review-changes/tracked-changes',
                     },
                     {
@@ -286,7 +286,7 @@ export const sidebarConfig: SidebarConfig = {
                   href: '/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot',
                 },
                 {
-                  title: 'Tracked changes',
+                  title: 'Use with Tracked Changes',
                   href: '/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes',
                 },
                 {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates AI Toolkit and Server AI Toolkit integration docs so readers understand that Tracked Changes is a separate, separately sold product—not part of the AI Toolkit packages.

## Changes

- Renamed integration page titles from **Tracked changes** to **Use with Tracked Changes** (AI Toolkit and Server AI Toolkit)
- Added a **Separate product** callout on each integration page explaining that Tracked Changes handles user edits and can review AI edits when integrated
- Updated sidebar labels and the Review changes index section/card to match
- Clarified wording that could imply Tracked Changes is bundled with or enabled by the AI Toolkit itself (e.g. "the AI Toolkit enables it automatically" → "temporarily enables the Tracked Changes extension")
- Applied the same callout and continuity updates to the tracked changes with comments guide

## Pages updated

- `src/content/content-ai/capabilities/ai-toolkit/agents/review-changes/tracked-changes.mdx`
- `src/content/content-ai/capabilities/ai-toolkit/agents/review-changes/tracked-changes-with-comments.mdx`
- `src/content/content-ai/capabilities/ai-toolkit/agents/review-changes/index.mdx`
- `src/content/content-ai/capabilities/server-ai-toolkit/agents/tracked-changes.mdx`
- `src/content/content-ai/sidebar.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c660e255-6c18-4ec0-933e-73b4f9be35f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c660e255-6c18-4ec0-933e-73b4f9be35f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

