### PR TITLE
docs: update @tiptap/pm exports on ProseMirror page

### DIFF
--- a/src/content/editor/core-concepts/prosemirror.mdx
+++ b/src/content/editor/core-concepts/prosemirror.mdx
@@ -6,7 +6,7 @@ meta:
   category: Editor
 ---
 
-Tiptap is built on top of ProseMirror, which has a pretty powerful API. To access it, we provide the package `@tiptap/pm`. This package re-exports the ProseMirror packages that Tiptap uses, such as `prosemirror-state`, `prosemirror-view`, and `prosemirror-model`.
+Tiptap is built on top of ProseMirror, which has a pretty powerful API. To access it, we provide the package `@tiptap/pm`. This package provides all important ProseMirror packages like `prosemirror-state`, `prosemirror-view` or `prosemirror-model`.
 
 Using the package for custom development makes sure that you always have the same version of ProseMirror which is used by Tiptap as well. This way, we can make sure that Tiptap and all extensions are compatible with each other and prevent version clashes.
 

--- a/src/content/editor/core-concepts/prosemirror.mdx
+++ b/src/content/editor/core-concepts/prosemirror.mdx
@@ -6,7 +6,7 @@ meta:
   category: Editor
 ---
 
-Tiptap is built on top of ProseMirror, which has a pretty powerful API. To access it, we provide the package `@tiptap/pm`. This package provides all important ProseMirror packages like `prosemirror-state`, `prosemirror-view` or `prosemirror-model`.
+Tiptap is built on top of ProseMirror, which has a pretty powerful API. To access it, we provide the package `@tiptap/pm`. This package re-exports the ProseMirror packages that Tiptap uses, such as `prosemirror-state`, `prosemirror-view`, and `prosemirror-model`.
 
 Using the package for custom development makes sure that you always have the same version of ProseMirror which is used by Tiptap as well. This way, we can make sure that Tiptap and all extensions are compatible with each other and prevent version clashes.
 
@@ -30,22 +30,19 @@ import { EditorState } from '@tiptap/pm/state'
 The following packages are available:
 
 - `@tiptap/pm/changeset`
-- `@tiptap/pm/collab`
 - `@tiptap/pm/commands`
 - `@tiptap/pm/dropcursor`
 - `@tiptap/pm/gapcursor`
 - `@tiptap/pm/history`
 - `@tiptap/pm/inputrules`
 - `@tiptap/pm/keymap`
-- `@tiptap/pm/markdown`
-- `@tiptap/pm/menu`
 - `@tiptap/pm/model`
-- `@tiptap/pm/schema-basic`
 - `@tiptap/pm/schema-list`
 - `@tiptap/pm/state`
 - `@tiptap/pm/tables`
-- `@tiptap/pm/trailing-node`
 - `@tiptap/pm/transform`
 - `@tiptap/pm/view`
+
+If you need other ProseMirror packages that are not re-exported by `@tiptap/pm` (for example `prosemirror-collab`, `prosemirror-markdown`, `prosemirror-menu`, `prosemirror-schema-basic`, or `prosemirror-trailing-node`), install them directly from npm.
 
 You can find out more about those libraries in the [ProseMirror documentation](https://prosemirror.net/docs/ref).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/ueberdosis/tiptap/issues/7775

## Summary

The [ProseMirror core concepts page](https://tiptap.dev/docs/editor/core-concepts/prosemirror) still listed `@tiptap/pm` subpath exports that were removed in [ueberdosis/tiptap#7749](https://github.com/ueberdosis/tiptap/pull/7749).

## Changes

- Remove outdated exports: `collab`, `markdown`, `menu`, `schema-basic`, and `trailing-node`
- Clarify that `@tiptap/pm` re-exports the ProseMirror packages Tiptap actually uses
- Add guidance to install other ProseMirror packages directly from npm when needed

## Remaining exports (aligned with `@tiptap/pm` on tiptap `main`)

`changeset`, `commands`, `dropcursor`, `gapcursor`, `history`, `inputrules`, `keymap`, `model`, `schema-list`, `state`, `tables`, `transform`, `view`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2deca2b3-45e8-40e8-8ee5-e5ec420baf7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2deca2b3-45e8-40e8-8ee5-e5ec420baf7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

