### PR TITLE
docs: document clearable mark config option and unsetAllMarks ignoreClearable

### DIFF
--- a/src/content/editor/api/commands/nodes-and-marks/unset-all-marks.mdx
+++ b/src/content/editor/api/commands/nodes-and-marks/unset-all-marks.mdx
@@ -6,10 +6,20 @@ meta:
   category: Editor
 ---
 
-`unsetAllMarks` will remove all marks from the current selection.
+`unsetAllMarks` will remove all marks from the current selection. By default, it respects the [`clearable`](/editor/extensions/custom-extensions/create-new/mark#clearable) option on each mark — marks with `clearable: false` will not be removed.
+
+## Parameters
+
+`options?: Record<string, any>`
+
+- `ignoreClearable?: boolean` - If `true`, removes all marks regardless of their `clearable` setting. Defaults to `false`
 
 ## Using the unsetAllMarks command
 
 ```js
+// removes all marks that have clearable: true (default behavior)
 editor.commands.unsetAllMarks()
+
+// removes all marks, ignoring the clearable option
+editor.commands.unsetAllMarks({ ignoreClearable: true })
 ```

--- a/src/content/editor/extensions/custom-extensions/create-new/mark.mdx
+++ b/src/content/editor/extensions/custom-extensions/create-new/mark.mdx
@@ -253,3 +253,31 @@ const CustomMark = Mark.create({
   code: true,
 })
 ```
+
+### `clearable`
+
+By default, marks can be removed using the `unsetAllMarks` command. You can set `clearable` to `false` to protect the mark from being removed by `unsetAllMarks`. The `unsetMark` command is not affected — only `unsetAllMarks` respects this option.
+
+You can also use a callback function to determine whether the mark can be cleared dynamically based on the editor state.
+
+```typescript
+const CustomMark = Mark.create({
+  name: 'customMark',
+
+  // This mark will not be removed by unsetAllMarks
+  clearable: false,
+})
+```
+
+```typescript
+const CustomMark = Mark.create({
+  name: 'customMark',
+
+  // Dynamically determine whether the mark can be cleared
+  clearable: () => {
+    return editor.state.doc.textContent.length < 100
+  },
+})
+```
+
+Defaults to `true`.


### PR DESCRIPTION
## Description

Documents two features added in [tiptap#7887](https://github.com/ueberdosis/tiptap/pull/7887):

**1. Mark config: `clearable`**
- New `MarkConfig` option: `clearable?: boolean | (() => boolean)`, defaults to `true`
- When set to `false`, the mark is preserved by `unsetAllMarks` (not affected by `unsetMark`)
- Added to the Mark API reference page under the existing mark options

**2. Command option: `unsetAllMarks({ ignoreClearable })`**
- `editor.commands.unsetAllMarks({ ignoreClearable: true })` removes all marks regardless of `clearable`
- Default behavior only removes marks where `clearable` is `true`
- Added a `## Parameters` section to the unsetAllMarks command page

## Changes

- `src/content/editor/extensions/custom-extensions/create-new/mark.mdx` — added `### clearable` section (28 lines)
- `src/content/editor/api/commands/nodes-and-marks/unset-all-marks.mdx` — added `## Parameters` section, updated description and examples (12 lines)

## Related

Closes #819