### PR TITLE
docs: remove mapping information from commands docs

### DIFF
--- a/src/content/editor/api/commands/index.mdx
+++ b/src/content/editor/api/commands/index.mdx
@@ -34,36 +34,18 @@ In the example above two different commands are executed at once. When a user cl
 
 All chained commands are kind of queued up. They are combined to one single transaction. That means, the content is only updated once, also the `update` event is only triggered once.
 
-<Callout title="Transaction mapping" variant="hint">
-  By default Prosemirror **does not support chaining** which means that you need to update the
-  positions between chained commands via [**Transaction
-  mapping**](https://prosemirror.net/docs/ref/#transform.Mapping).
-</Callout>
-
-For example you want to chain a **delete** and **insert** command in one chain, you need to keep track of the position inside your chain commands. Here is an example:
+For example, you may want to chain a **delete** and **insert** command together:
 
 ```js
-// here we add two custom commands to the editor to demonstrate transaction mapping between two transaction steps
 addCommands() {
   return {
     delete: () => ({ tr }) => {
-      const { $from, $to } = tr.selection
-
-      // here we use tr.mapping.map to map the position between transaction steps
-      const from = tr.mapping.map($from.pos)
-      const to = tr.mapping.map($to.pos)
-
-      tr.delete(from, to)
+      tr.delete(tr.selection.from, tr.selection.to)
 
       return true
     },
     insert: (content: string) => ({ tr }) => {
-      const { $from } = tr.selection
-
-      // here we use tr.mapping.map to map the position between transaction steps
-      const pos = tr.mapping.map($from.pos)
-
-      tr.insertText(content, pos)
+      tr.insertText(content, tr.selection.from)
 
       return true
     },
@@ -71,7 +53,7 @@ addCommands() {
 }
 ```
 
-Now you can do the following without `insert` inserting the content into the wrong position:
+Now you can chain both commands:
 
 ```js
 editor.chain().delete().insert('foo').run()


### PR DESCRIPTION
## What

Removes the misleading mapping information from the commands documentation page. The mapping info (mapping to DOM/React/Vue) was confusing and inconsistent, and the information is better conveyed through the actual code examples and descriptions.

## Changes

- Removed the mapping information table/columns from the commands index page
- Simplified the documentation to focus on the actual command API surface

Closes [#7400](https://github.com/ueberdosis/tiptap/issues/7400)