### PR TITLE
Fix Postman collection callout rendering in Server AI Toolkit REST API docs

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
@@ -18,14 +18,8 @@ The Server AI Toolkit provides REST API endpoints for AI agent tools.
 </Callout>
 
 <Callout title="Postman collection" variant="info">
-  Browse the{' '}
-  <a
-    href="https://www.postman.com/tiptap-platform/tiptap-workspace/collection/42722929-6a366c4c-10e4-4674-93c3-da35b70357a7?action=share&source=copy-link&creator=42722929"
-    target="_blank"
-    rel="noopener noreferrer"
-  >
-    Postman collection
-  </a>{' '}
+  Browse the [Postman
+  collection](https://www.postman.com/tiptap-platform/tiptap-workspace/collection/42722929-6a366c4c-10e4-4674-93c3-da35b70357a7?action=share&source=copy-link&creator=42722929)
   for the Server AI Toolkit REST API.
 </Callout>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes TT-557

## Problem

On the [Server AI Toolkit REST API](https://tiptap.dev/docs/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api) page, the "Postman collection" info callout rendered the link text on its own line:

- "Browse the"
- "**Postman collection**" (link)
- "for the Server AI Toolkit REST API."

## Cause

The callout used a multiline HTML `<a>` element mixed with JSX text nodes. MDX wrapped each fragment in separate `<p>` tags, forcing unwanted line breaks.

## Solution

Use a markdown link inside the `<Callout>`, consistent with other docs pages (e.g. collaboration metrics REST API). This keeps the sentence in a single paragraph while still opening the external Postman URL in a new tab via the shared MDX `a` component.

## Testing

- `pnpm run build:next` completes successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TT-557](https://linear.app/tiptap/issue/TT-557/rendering-issue-in-server-ai-toolkit-docs)

<div><a href="https://cursor.com/agents/bc-ccbe1e67-8ca1-47c6-a18e-481bfb7dcce2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccbe1e67-8ca1-47c6-a18e-481bfb7dcce2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

