### PR TITLE
fix(docs): remove invalid position from templateWorkflow examples

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/workflows.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/workflows.mdx
@@ -423,7 +423,6 @@ useEffect(() => {
   toolkit.templateWorkflow({
     template: templateJson,
     values: object as Record<string, unknown>,
-    position: 'document',
     hasFinished: !isLoading,
     workflowId,
   })

--- a/src/content/content-ai/capabilities/ai-toolkit/workflows/template.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/workflows/template.mdx
@@ -206,7 +206,6 @@ export default function Page() {
     toolkit.templateWorkflow({
       template,
       values: object as Record<string, unknown>,
-      position: 'document',
       hasFinished: !isLoading,
       workflowId,
     })
@@ -365,7 +364,6 @@ By default, the `templateWorkflow` method removes all `_templateSlot` attributes
 toolkit.templateWorkflow({
   template,
   values: object,
-  position: 'document',
   hasFinished: !isLoading,
   workflowId,
   preserveSlotAttr: true,
@@ -391,7 +389,6 @@ const toolkit = getAiToolkit(editor)
 toolkit.templateWorkflow({
   template: currentDoc,
   values: newValues,
-  position: 'document',
   preserveSlotAttr: true,
 })
 ```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes TT-278.

The template workflow tutorial and API reference used `position: 'document'`, which is not a valid `InsertPosition` value (`"afterbegin" | "afterend" | "beforebegin" | "beforeend"`). Omitting `position` is the correct way to replace the entire document.

## Changes

- Removed `position: 'document'` from the streaming example in `workflows/template.mdx`
- Removed the same invalid field from the `preserveSlotAttr` and re-fill examples in that guide
- Removed it from the `templateWorkflow` API reference example in `workflows.mdx`

The "Insert template in part of the document" section still documents valid `position` usage with a `Range` object.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TT-278](https://linear.app/tiptap/issue/TT-278/type-error-in-template-workflow-demo-code)

<div><a href="https://cursor.com/agents/bc-5eb5c2e3-b808-4e2b-93c7-507a010c68ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5eb5c2e3-b808-4e2b-93c7-507a010c68ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

