### PR TITLE
fix(docs): TypeScript tool output type in review changes guide (TT-222)

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/agents/review-changes/suggestions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/agents/review-changes/suggestions.mdx
@@ -44,7 +44,7 @@ const [reviewState, setReviewState] = useState({
   // Data for the tool call result
   tool: '',
   toolCallId: '',
-  output: '',
+  output: null as unknown,
   // Feedback events collected from user actions
   userFeedback: [] as SuggestionFeedbackEvent[],
 })
@@ -162,10 +162,12 @@ Then, in the React component, display a button to reject/accept the changes:
 
           // Add feedback to tool output if there are any changes that were not accepted
           if (userFeedback.length > 0 && userFeedback.some((event) => !event.accepted)) {
-            output += `\n\n<user_feedback>\n${JSON.stringify(userFeedback)}\n</user_feedback>`
+            const outputString =
+              typeof output === 'string' ? output : JSON.stringify(output)
+            output = `${outputString}\n\n<user_feedback>\n${JSON.stringify(userFeedback)}\n</user_feedback>`
           }
 
-          addtoolOutput({
+          addToolOutput({
             tool: reviewState.tool,
             toolCallId: reviewState.toolCallId,
             output,
@@ -190,7 +192,7 @@ Then, in the React component, display a button to reject/accept the changes:
           const rejectionMessage =
             'Some changes you made were rejected by the user. Ask the user why, and what you can do to improve them.'
           const outputWithFeedback = `${rejectionMessage}\n\n<user_feedback>\n${JSON.stringify(userFeedback)}\n</user_feedback>`
-          addtoolOutput({
+          addToolOutput({
             tool: reviewState.tool,
             toolCallId: reviewState.toolCallId,
             output: outputWithFeedback,
@@ -302,7 +304,7 @@ export default function Page() {
     // Data for the tool call result
     tool: '',
     toolCallId: '',
-    output: '',
+    output: null as unknown,
     // Feedback events collected from user actions
     userFeedback: [] as SuggestionFeedbackEvent[],
   })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes TT-222.

## Problem

In the [Review changes – Suggestions](https://tiptap.dev/content-ai/capabilities/ai-toolkit/agents/review-changes/suggestions) guide, `reviewState.output` was initialized as `''`, so TypeScript inferred `string`. Assigning `result.output` (typed as `ToolOutput`) caused a type error.

There were also typos: `addtoolOutput` instead of `addToolOutput`.

## Solution

- Initialize `output` as `null as unknown` so `reviewState.output` accepts `ToolOutput` from `executeTool`.
- When appending user feedback on accept, stringify non-string `unknown` values before concatenation.
- Fix `addtoolOutput` → `addToolOutput` in the accept/reject handlers.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TT-222](https://linear.app/tiptap/issue/TT-222/fix-typescript-issue-in-review-changes-guide)

<div><a href="https://cursor.com/agents/bc-6681e97e-272e-46fe-be8c-a14bd7d1d6ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6681e97e-272e-46fe-be8c-a14bd7d1d6ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

