### PR TITLE
docs(ui-components): image node pro resize/source + CLI init flow

### DIFF
--- a/src/content/ui-components/getting-started/cli.mdx
+++ b/src/content/ui-components/getting-started/cli.mdx
@@ -20,7 +20,9 @@ npx @tiptap/cli@latest [command] [options]
 
 ### `init`
 
-Initialize your project and install dependencies. This command sets up your project configuration and adds any specified components.
+Initialize your project and install dependencies. This command sets up your project configuration and adds any specified components as editable source files.
+
+Run in an empty directory, it scaffolds a new Vite or Next.js project; run in an existing project, it configures it. Either way, the components are copied into your `components/` folder — you then import and render them in your own page. They are not wired into a page for you, so a freshly scaffolded app still shows the framework's default starter page until you render a component. See the [Next.js](/ui-components/install/next) or [Vite](/ui-components/install/vite) guide for the full flow.
 
 ```bash
 npx @tiptap/cli@latest init

--- a/src/content/ui-components/getting-started/overview.mdx
+++ b/src/content/ui-components/getting-started/overview.mdx
@@ -81,6 +81,16 @@ No matter the type (free or cloud-connected), you can inspect the source code an
   gradually.
 </Callout>
 
+## How components are installed
+
+Tiptap UI Components are not published as an npm package. The [CLI](/ui-components/getting-started/cli) copies them into your project as source files you own and can edit:
+
+```bash
+npx @tiptap/cli@latest add <component>
+```
+
+Each component also pulls in the other components, hooks, icons, libs, and styles it depends on — automatically. That is why an installed component's imports (for example `@/components/tiptap-node/image-node/image-node-extension`) resolve to files in your own codebase rather than a module in `node_modules`. To get everything a demo on these pages uses, install that component or template with the command above; each component page lists its referenced files under **Referenced Components**.
+
 ## Design defaults
 
 Components are designed to feel vanilla and blend into your design. They come with neutral styling: minimal colors, basic spacing, and no strong visual opinions. You can use them as-is or customize them to match your brand.

--- a/src/content/ui-components/install/next.mdx
+++ b/src/content/ui-components/install/next.mdx
@@ -30,6 +30,31 @@ Alternatively, select **Template** to scaffold a full example project.
   directly to **Add Styles**.
 </Callout>
 
+<Callout title="A new project still shows the default Next.js page" variant="warning">
+  `init` scaffolds a standard Next.js app and copies the components you chose into your
+  `components/` folder as source — but it does **not** modify `app/page.tsx`. Until you render a
+  Tiptap component there yourself, `npm run dev` shows Next.js's default starter page. This is
+  expected, not a broken install.
+</Callout>
+
+## Render the editor
+
+Open `app/page.tsx` and render the template or component you installed. For example, if you added the **Simple Editor** template during `init`:
+
+```tsx
+import { SimpleEditor } from '@/components/tiptap-templates/simple/simple-editor'
+
+export default function Page() {
+  return <SimpleEditor />
+}
+```
+
+Start the dev server and open the page to see your editor:
+
+```bash
+npm run dev
+```
+
 ## Add Tiptap components
 
 Install Tiptap UI components using the CLI. For example, to add the `HeadingButton` component:

--- a/src/content/ui-components/install/vite.mdx
+++ b/src/content/ui-components/install/vite.mdx
@@ -72,6 +72,30 @@ export default defineConfig({
 })
 ```
 
+## Render the editor
+
+<Callout title="A new project still shows the default Vite page" variant="warning">
+  Scaffolding creates a standard Vite + React app. Adding components copies them into
+  `src/components/` as source, but `src/App.tsx` still renders Vite's default starter page until you
+  render a Tiptap component there yourself. This is expected, not a broken install.
+</Callout>
+
+Replace the contents of `src/App.tsx` with the template or component you installed. For example, the **Simple Editor** template:
+
+```tsx
+import { SimpleEditor } from '@/components/tiptap-templates/simple/simple-editor'
+
+export default function App() {
+  return <SimpleEditor />
+}
+```
+
+Start the dev server to see your editor:
+
+```bash
+npm run dev
+```
+
 ## Add Tiptap components
 
 Install Tiptap UI components using the CLI. For example, to add the `HeadingButton` component:

--- a/src/content/ui-components/node-components/image-node-pro.mdx
+++ b/src/content/ui-components/node-components/image-node-pro.mdx
@@ -18,8 +18,9 @@ tags:
 ---
 
 import { CodeDemo } from '@/components/CodeDemo'
+import { Callout } from '@/components/ui/Callout'
 
-An enhanced image node component for Tiptap editors. Features floating toolbar controls, image alignment options, download functionality, and advanced management capabilities with responsive styling and accessibility features.
+An enhanced image node component for Tiptap editors. Features drag-to-resize, editable captions, floating toolbar controls, image alignment options, download functionality, and advanced management capabilities with responsive styling and accessibility features.
 
 <CodeDemo isScrollable src="https://template.tiptap.dev/preview/tiptap-node/image-node-pro" />
 
@@ -30,6 +31,15 @@ Add the component via the Tiptap CLI:
 ```bash
 npx @tiptap/cli@latest add image-node-pro
 ```
+
+<Callout title="Where is the source code?" variant="info">
+  The preview above is a live demo. To get its full source — the image node **and** every component
+  it references — run the install command above. Tiptap UI Components are delivered as editable
+  source files copied into your project (under `@/components/…`), not as an npm package. That is why
+  the imports in the examples below resolve to files in your own codebase rather than a module in
+  `node_modules`. See [Referenced Components](#referenced-components) for the full list the CLI adds
+  for you.
+</Callout>
 
 ## Components
 
@@ -64,6 +74,8 @@ export default function ImageEditor() {
 
 #### Features
 
+- Drag-to-resize: hover an image and drag the handle on either side to set its width
+- Editable image captions
 - Floating toolbar with alignment controls
 - Image download functionality
 - Delete node button
@@ -111,9 +123,10 @@ The image node system works through several integrated layers:
 
 1. **Enhanced Display**: Extends the basic Tiptap Image extension with additional styling and responsive behavior
 2. **Floating Toolbar**: Provides contextual controls that appear when an image is selected
-3. **Alignment System**: Manages image positioning with left, center, and right alignment options
-4. **Node Management**: Handles image deletion and download functionality through toolbar actions
-5. **State Integration**: Seamlessly integrates with Tiptap's node system and command architecture
+3. **Resizing**: Drag handles on either side of a hovered image let you set its width interactively
+4. **Alignment System**: Manages image positioning with left, center, and right alignment options
+5. **Node Management**: Handles image deletion and download functionality through toolbar actions
+6. **State Integration**: Seamlessly integrates with Tiptap's node system and command architecture
 
 The floating toolbar automatically appears when an image is selected and provides quick access to alignment controls, download functionality, and node deletion.
 
@@ -127,9 +140,14 @@ The floating toolbar automatically appears when an image is selected and provide
 
 ### Referenced Components
 
+The CLI installs these automatically alongside the image node — you do not add them by hand. They are the files that the image node imports from within your project:
+
 - `use-tiptap-editor` (hook)
 - `tiptap-utils` (lib)
 - `delete-node-button` (component)
 - `image-download-button` (component)
 - `image-align-button` (component)
+- `image-caption-button` (component)
+- `image-upload-button` (component)
+- `refresh-ccw-icon` (icon)
 - `separator` (primitive)


### PR DESCRIPTION
## Why
Customer feedback surfaced four documentation gaps around Image Node Pro and
getting started:
1. Drag-to-resize and captions were never documented as features.
2. No clear path to view/copy a demo's full source.
3. Confusion that demos import "files not in the npm package."
4. `init` shows the framework's default page, with no documented next step.

## Changes
- **image-node-pro.mdx** — add drag-to-resize + captions to the intro,
  Features, and How It Works; add a "Where is the source code?" callout;
  fix the Referenced Components list (added `image-caption-button`,
  `image-upload-button`, `refresh-ccw-icon`) and note they auto-install.
- **getting-started/overview.mdx** — new "How components are installed"
  section explaining the source-not-package model.
- **getting-started/cli.mdx** — clarify the `init` command's behavior.
- **install/next.mdx** + **install/vite.mdx** — add a "Render the editor"
  step + a callout that the default starter page is expected until you render
  a component.