### PR TITLE
docs(export-docx): reflect paragraph and heading spacing round-tripping on export

### DIFF
--- a/src/content/conversion/content-types/text-and-formatting/headings.mdx
+++ b/src/content/conversion/content-types/text-and-formatting/headings.mdx
@@ -32,7 +32,8 @@ In Word, headings are paragraphs with a heading style applied (Heading 1 through
 | Text alignment | Supported | Supported (TextAlign) | Supported |
 | Inline formatting | Supported | Supported | Supported |
 | Heading numbering | Converted to indent attr | Indent rendered (`padding-left`); numbering glyphs not generated | Not preserved |
-| Per-heading spacing/indent/line-height/font-size | Converted to attrs | Supported | Export defaults applied |
+| Per-heading spacing / indent / line-height | Converted to attrs | Supported | Supported (proportional line height only; a negative first-line indent becomes a hanging indent) |
+| Per-heading font-size | Converted to attr | Supported | Export defaults applied |
 | Named-style typography (theme) | Catalog available via [CSS injection](/conversion/import/docx/css-injection) | Renders via injected CSS | Export defaults applied |
 
 ## Import

--- a/src/content/conversion/content-types/text-and-formatting/paragraphs.mdx
+++ b/src/content/conversion/content-types/text-and-formatting/paragraphs.mdx
@@ -18,7 +18,7 @@ Paragraphs are the most fundamental content type in any document. In Word they c
 - **Configuration:** None required.
 
 <Callout title="Paragraph formatting needs ConvertKit's custom Paragraph" variant="hint">
-  Text content and alignment round-trip with any paragraph node. Paragraph-level spacing, indentation, line height, and contextual spacing are extracted during import and rendered as inline CSS by ConvertKit's custom Paragraph. If you swap ConvertKit's Paragraph for a stock one (or disable the slot), those attributes stay in the JSON but are stripped on `setEditorContent()`. The [Styling converted content](/conversion/getting-started/guides/styling-converted-content) guide covers how to extend the schema for additional attributes. None of these paragraph-level attributes round-trip on export today; see the support overview below.
+  Text content and alignment round-trip with any paragraph node. Paragraph-level spacing, indentation, line height, and contextual spacing are extracted during import and rendered as inline CSS by ConvertKit's custom Paragraph. If you swap ConvertKit's Paragraph for a stock one (or disable the slot), those attributes stay in the JSON but are stripped on `setEditorContent()`. The [Styling converted content](/conversion/getting-started/guides/styling-converted-content) guide covers how to extend the schema for additional attributes. Paragraph spacing, indentation, contextual spacing, and proportional line height now round-trip on export; see the support overview below.
 </Callout>
 
 ## Support overview
@@ -27,10 +27,10 @@ Paragraphs are the most fundamental content type in any document. In Word they c
 | --- | --- | --- | --- |
 | Text content | Supported | Supported | Supported |
 | Text alignment | Supported | Supported (TextAlign) | Supported |
-| Line height | Supported (paragraph attr) | Supported (`line-height: <value>`) | Not preserved (the export reads line height from a `textStyle` mark, which the importer does not produce) |
-| Paragraph spacing (before/after) | Supported (`spacingBefore`, `spacingAfter` attrs) | Supported (`margin-top` / `margin-bottom`) | Not preserved |
-| Indentation | Supported (`indent`, `firstLineIndent` attrs) | Supported (`padding-left` / `text-indent`) | Not preserved |
-| Contextual spacing | Supported (`contextualSpacing` attr) | Supported (`data-contextual-spacing` + injected CSS rule) | Not preserved |
+| Line height | Supported (paragraph attr) | Supported (`line-height: <value>`) | Proportional values round-trip (unitless multiple or percentage); fixed `px`/`pt` line heights are not preserved |
+| Paragraph spacing (before/after) | Supported (`spacingBefore`, `spacingAfter` attrs) | Supported (`margin-top` / `margin-bottom`) | Supported |
+| Indentation | Supported (`indent`, `firstLineIndent` attrs) | Supported (`padding-left` / `text-indent`) | Supported (a negative first-line indent becomes a hanging indent) |
+| Contextual spacing | Supported (`contextualSpacing` attr) | Supported (`data-contextual-spacing` + injected CSS rule) | Supported |
 
 ## Import
 
@@ -86,11 +86,12 @@ During DOCX export, each `paragraph` node is written as a Word paragraph with th
 
 - All text content and inline marks
 - Text alignment is read from the paragraph node attributes and mapped to Word alignment
-- Line height is read from `textStyle` marks if present. Note that import stores line height as a paragraph attribute while export reads it from textStyle marks. These are different locations that require custom schema work to bridge.
+- Line height is read from the `lineHeight` paragraph attribute (a block-level `textStyle` mark still takes precedence). Proportional values — a unitless multiple such as `1.5` or a percentage such as `150%` — are written as Word line spacing; fixed `px`/`pt` line heights have no proportional equivalent and are not preserved.
+- Paragraph spacing (`spacingBefore` / `spacingAfter`), left and first-line indentation (`indent` / `firstLineIndent`), and contextual spacing (`contextualSpacing`) are read from the paragraph node attributes. A negative first-line indent is written as a hanging indent. These attributes also apply to styled paragraphs such as blockquotes.
 
 ### What is not exported
 
-All other paragraph attributes (margins, borders, indentation, background color) are not read during export regardless of whether they exist in the JSON.
+Paragraph borders and background color are not read during export regardless of whether they exist in the JSON.
 
 ### Customizing export styles
 

--- a/src/content/conversion/export/docx/editor-extension.mdx
+++ b/src/content/conversion/export/docx/editor-extension.mdx
@@ -328,6 +328,10 @@ The DOCX export automatically respects node-level attributes set by the editor, 
 | **Table cell `rowspan`**             | Cells spanning multiple rows are correctly exported                                                                                                                          |
 | **Paragraph `textAlign: 'justify'`** | Correctly mapped to `AlignmentType.JUSTIFIED` (previously fell through to left alignment)                                                                                    |
 | **Text run `backgroundColor`**       | `textStyle` mark `backgroundColor` exported as solid character shading                                                                                                       |
+| **Paragraph/heading `lineHeight`**   | Proportional line height — a unitless multiple (e.g. `1.5`) or a percentage (e.g. `150%`) — is written as DOCX line spacing. Fixed `px`/`pt` line heights have no proportional equivalent and are skipped |
+| **Paragraph/heading spacing**        | `spacingBefore` and `spacingAfter` are written as space before/after the paragraph                                                                                          |
+| **Paragraph/heading indentation**    | `indent` and `firstLineIndent` are written as left and first-line indentation; a negative `firstLineIndent` becomes a hanging indent                                         |
+| **Paragraph/heading `contextualSpacing`** | Suppresses spacing between adjacent paragraphs of the same style in the export                                                                                          |
 
 ## What to expect
 
@@ -337,7 +341,7 @@ The DOCX export automatically respects node-level attributes set by the editor, 
 
 ## What not to expect
 
-- **Round-trip identity.** Importing a DOCX, editing it, and exporting it back is not byte-identical. A handful of attributes (paragraph line-height, tab stops) are extracted on import but not written on export today. See the [feature support matrix](/conversion/getting-started/feature-support-matrix) for the full list.
+- **Round-trip identity.** Importing a DOCX, editing it, and exporting it back is not byte-identical. A handful of attributes (tab stops, and fixed `px`/`pt` line heights) are extracted on import but not written on export today. See the [feature support matrix](/conversion/getting-started/feature-support-matrix) for the full list.
 - **Pixel-perfect Word match.** We aim for visually faithful round-trips on the supported feature set; absolute parity with Word's rendering engine is out of scope.
 - **Page layout from the editor.** DOCX export preserves headers, footers, and page-format settings you configure on the export options. It does not infer page boundaries from on-screen pagination — pair with the [Pages extension](/pages/getting-started/overview) when you need pagination-aware exports.
 

--- a/src/content/conversion/getting-started/feature-support-matrix.mdx
+++ b/src/content/conversion/getting-started/feature-support-matrix.mdx
@@ -67,16 +67,16 @@ The import service extracts paragraph-level styling attributes like spacing, ind
 | Feature | Import | Editor | Export |
 | --- | --- | --- | --- |
 | [Text alignment](/conversion/content-types/text-and-formatting/text-alignment) | ✓ | ✓ | ✓ |
-| [Line spacing](/conversion/content-types/text-and-formatting/paragraphs) | ✓ | ✓ | ✕*** |
-| [Paragraph spacing](/conversion/content-types/text-and-formatting/paragraphs) | ✓ | ✓ | ✕ |
-| [Indentation](/conversion/content-types/text-and-formatting/paragraphs) | ✓ | ✓ | ✕ |
+| [Line spacing](/conversion/content-types/text-and-formatting/paragraphs) | ✓ | ✓ | ✓*** |
+| [Paragraph spacing](/conversion/content-types/text-and-formatting/paragraphs) | ✓ | ✓ | ✓ |
+| [Indentation](/conversion/content-types/text-and-formatting/paragraphs) | ✓ | ✓ | ✓ |
 | [Letter spacing](/conversion/content-types/text-and-formatting/font-family-size) | ✓ | ✕* | ✕ |
 | [Paragraph borders](/conversion/content-types/text-and-formatting/paragraphs) | ✕ | ✕ | ✕ |
 | [Word styles](/conversion/content-types/structures-and-media/word-styles) | ~ | ~** | ~ |
 
 **\*** Letter spacing is extracted as `textStyle.letterSpacing` but no bundled extension renders it. To render imported letter spacing, [extend TextStyle](/conversion/getting-started/guides/styling-converted-content#extending-extensions-for-unsupported-attributes).<br />
 **\*\*** Word's named-style typography is not applied by default. Use [CSS injection](/conversion/import/docx/css-injection) to extract it as scoped CSS.<br />
-**\*\*\*** Line height imports as a paragraph node attribute and renders correctly in the editor with ConvertKit. The DOCX export reads line height from a `textStyle` mark instead, so round-trip is broken: imported values are present in the editor but dropped on export.
+**\*\*\*** Only proportional line spacing round-trips on export: a unitless multiple such as `1.5` or a percentage such as `150%`. Fixed line heights carrying a unit (e.g. `24px`, `18pt`) have no proportional DOCX equivalent and are not preserved.
 
 ## Lists
 


### PR DESCRIPTION
## Summary

Paragraph/heading spacing, indentation, contextual spacing, and proportional
line height now survive DOCX export. Update the feature support matrix, the
export editor-extension node-attribute table, and the paragraphs/headings
content-type references — the docs previously stated these were dropped.