### PR TITLE
docs(ai-toolkit): document filter option for rejectAllSuggestions

### DIFF
--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/suggestions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/suggestions.mdx
@@ -264,11 +264,12 @@ result.aiFeedback.events
 
 Rejects all active suggestions without applying them.
 
-This method removes all suggestions from the active suggestions list without applying them to the document. It returns feedback about what was rejected.
+This method removes suggestions from the active suggestions list without applying them to the document. You can optionally filter which suggestions are rejected. Suggestions that do not match the filter remain active. It returns feedback about what was rejected.
 
 ### Parameters
 
-None
+- `options?` (`RejectAllSuggestionsOptions`): Options for the `rejectAllSuggestions` method
+  - `filter?` (`(suggestion: Suggestion) => boolean`): A predicate that determines which suggestions are rejected
 
 ### Returns
 

--- a/src/content/content-ai/capabilities/ai-toolkit/api-reference/suggestions.mdx
+++ b/src/content/content-ai/capabilities/ai-toolkit/api-reference/suggestions.mdx
@@ -264,7 +264,7 @@ result.aiFeedback.events
 
 Rejects all active suggestions without applying them.
 
-This method removes suggestions from the active suggestions list without applying them to the document. You can optionally filter which suggestions are rejected. Suggestions that do not match the filter remain active. It returns feedback about what was rejected.
+By default, this method removes all active suggestions from the suggestions list without applying them to the document. You can optionally filter which suggestions are rejected. Suggestions that do not match the filter remain active. It returns feedback about what was rejected.
 
 ### Parameters
 


### PR DESCRIPTION
Docs of "[Add filter option to reject all suggestions by arnaugomez · Pull Request #869 · ueberdosis/tiptap-pro](https://github.com/ueberdosis/tiptap-pro/pull/869)" https://github.com/ueberdosis/tiptap-pro/pull/869
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->

Documents the new optional `filter` parameter on `rejectAllSuggestions` in the AI Toolkit API reference.

## Changes

- Updated the `rejectAllSuggestions` section in `suggestions.mdx` to describe `RejectAllSuggestionsOptions` and its optional `filter` predicate
- Clarified that suggestions not matching the filter remain active after rejection
- Matches the existing documentation pattern used for `acceptAllSuggestions`

## Related

Reflects the `filter` option added to `rejectAllSuggestions` in `@tiptap-pro/ai-toolkit`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f3c1d86-6f81-4947-a725-3e0d410bf2cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f3c1d86-6f81-4947-a725-3e0d410bf2cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

