### PR TITLE
Integrate new DOCX editor demo and add live demo page

### DIFF
--- a/src/content/pages/getting-started/live-demo.mdx
+++ b/src/content/pages/getting-started/live-demo.mdx
@@ -1,0 +1,62 @@
+---
+title: Pages Live Demo
+tags:
+  - type: team
+  - type: beta
+meta:
+  title: Pages Live Demo | Tiptap Pages
+  description: Try a live demo of Tiptap Pages, a paginated DOCX editor with configurable page layout, headers and footers, and DOCX/PDF export.
+  category: Pages
+sidebars:
+  hideSecondary: true
+---
+
+import { ExternalLinkIcon, Expand } from 'lucide-react'
+import { CodeDemo } from '@/components/CodeDemo'
+import { Link } from '@/components/Link'
+import { Callout } from '@/components/ui/Callout'
+
+This demo shows Tiptap Pages in a real word processor. It combines pagination, collaboration, configurable page layout, and DOCX/PDF export in a single editor.
+
+<CodeDemo
+  isScrollable
+  isLarge
+  src="https://template.tiptap.dev/docx"
+  caption={
+    <>
+      <strong>Try Tiptap Pages</strong> in this interactive DOCX editor demo with pagination,
+      headers and footers, and DOCX/PDF export.
+    </>
+  }
+  captionActions={
+    <>
+      <a
+        href="https://template.tiptap.dev/docx"
+        target="_blank"
+        className="flex items-center gap-1 text-grayAlpha-600 hover:text-grayAlpha-800 font-medium whitespace-nowrap"
+      >
+        Full screen
+        <Expand className="size-3" />
+      </a>
+    </>
+  }
+/>
+
+### Paginated editing
+
+- **Page layout**: Content flows across visual pages with built-in formats (A4, Letter, and more) and configurable margins
+- **Headers and footers**: Double-click a header or footer to edit it in place, with `{page}` and `{total}` placeholders
+- **Page breaks**: Insert explicit breaks or let Pages handle automatic pagination
+- **Zoom**: Visual zoom that does not affect document content or export
+
+### Document workflows
+
+- **Collaboration**: The whole document is part of a shared collaborative session, including its headers and footers
+- **DOCX import and export**: Round-trip Word documents with headers, footers, and pagination preserved via [Tiptap Conversion](/conversion/getting-started/overview)
+- **PDF export**: Render the paginated layout to a print-ready PDF
+
+<Callout title="Access the source code" variant="info">
+  We are working on making the complete source code for this demo available through the Tiptap CLI.
+  It will be released soon. Usage is subject to our [Terms of
+  Service](https://tiptap.dev/terms-of-service) and [Pro License](https://tiptap.dev/pro-license).
+</Callout>

--- a/src/content/pages/getting-started/overview.mdx
+++ b/src/content/pages/getting-started/overview.mdx
@@ -11,12 +11,44 @@ sidebars:
   hideSecondary: true
 ---
 
+import { ExternalLinkIcon, Expand } from 'lucide-react'
 import { Callout } from '@/components/ui/Callout'
 import { CodeDemo } from '@/components/CodeDemo'
+import Link from '@/components/Link'
 
-Tiptap Pages is a paginated editing layer for Tiptap. It adds page boundaries, page formats, headers, footers, page breaks, and zoom on top of any Tiptap editor — so your reader can author a report, a letter, a contract, or a book the way they would in a word processor.
+Tiptap Pages is a paginated editing layer for Tiptap. It adds page boundaries, page formats, headers, footers, page breaks, and zoom on top of any Tiptap editor. With it, your reader can author a report, a letter, a contract, or a book the way they would in a word processor.
 
-<CodeDemo isPro path="/Extensions/Pages" />
+<CodeDemo
+  isScrollable
+  isLarge
+  src="https://template.tiptap.dev/docx"
+  caption={
+    <>
+      <strong>Try Tiptap Pages</strong> in this interactive DOCX editor demo with pagination,
+      headers and footers, and DOCX/PDF export.
+    </>
+  }
+  captionActions={
+    <>
+      <a
+        href="https://template.tiptap.dev/docx"
+        target="_blank"
+        className="flex items-center gap-1 text-grayAlpha-600 hover:text-grayAlpha-800 font-medium whitespace-nowrap"
+      >
+        Full screen
+        <Expand className="size-3" />
+      </a>
+      <span className="text-grayAlpha-300">|</span>
+      <Link
+        href="/pages/getting-started/live-demo"
+        className="flex items-center gap-1 text-grayAlpha-600 hover:text-grayAlpha-800 font-medium whitespace-nowrap"
+      >
+        Learn more
+        <ExternalLinkIcon className="size-3" />
+      </Link>
+    </>
+  }
+/>
 
 <Callout title="Pro package" variant="hint">
   Pages is a Pro package included with [Tiptap subscriptions](https://tiptap.dev/pricing). Before
@@ -25,19 +57,19 @@ Tiptap Pages is a paginated editing layer for Tiptap. It adds page boundaries, p
 
 ## What this does
 
-- **Paginated layout** — content flows across visual pages of a chosen format (A4, Letter, custom).
-- **Page formats and margins** — built-in formats with sensible defaults, plus full control via custom format objects.
-- **Headers and footers** — static text, HTML strings, or Tiptap JSON; with `{page}` and `{total}` placeholders; and with separate slots for first page or odd/even pages, mirroring Word.
-- **Edit-in-place** — double-click a header or footer to open a fully featured Tiptap editor in the overlay.
-- **Zoom** — visual zoom in `[0.25, 4]` that does not affect document content or export.
-- **Page breaks** — insert explicit breaks via the [PageBreak extension](/pages/core-concepts/page-break-node), or let Pages handle automatic breaks.
+- **Paginated layout**: Content flows across visual pages of a chosen format (A4, Letter, custom).
+- **Page formats and margins**: Built-in formats come with sensible defaults, and custom format objects give you full control.
+- **Headers and footers**: Define them as static text, HTML strings, or Tiptap JSON. They support `{page}` and `{total}` placeholders, and you can set separate slots for the first page or for odd and even pages, mirroring Word.
+- **Edit-in-place**: Double-click a header or footer to open a fully featured Tiptap editor in the overlay.
+- **Zoom**: Visual zoom in `[0.25, 4]` that does not affect document content or export.
+- **Page breaks**: Insert explicit breaks via the [PageBreak extension](/pages/core-concepts/page-break-node), or let Pages handle automatic breaks.
 
 ## What you install with it
 
 Pages does **not** ship a node and mark schema. To use it you also install:
 
-- **`@tiptap-pro/extension-convert-kit`** — the canonical editor kit for Conversion and Pages workflows. ConvertKit registers a DOCX-aware schema (paragraphs, headings, lists, images, marks).
-- **`@tiptap-pro/extension-pages-tablekit`** — pagination-safe tables. Required, because ConvertKit's bundled tables are not designed to paginate.
+- **`@tiptap-pro/extension-convert-kit`**: The canonical editor kit for Conversion and Pages workflows. ConvertKit registers a DOCX-aware schema (paragraphs, headings, lists, images, marks).
+- **`@tiptap-pro/extension-pages-tablekit`**: Pagination-safe tables. Required, because ConvertKit's bundled tables are not designed to paginate.
 
 ```bash
 npm install @tiptap-pro/extension-convert-kit \
@@ -68,32 +100,32 @@ See the [install guide](/pages/getting-started/install) for the full walkthrough
 
 ## What works
 
-- Built-in page formats: A4, A3, A5, Letter, Legal, Tabloid; plus custom formats with arbitrary dimensions and margins.
+- Built-in page formats: A4, A3, A5, Letter, Legal, Tabloid. You can also define custom formats with arbitrary dimensions and margins.
 - Header and footer content as plain text, HTML, or Tiptap JSON, with `{page}` / `{total}` placeholders.
 - Different headers and footers for the first page and for odd/even pages, like Word.
-- Live editing of headers and footers in dedicated overlays. They participate in collaboration alongside the main document — see [Adding collaboration to Pages](/pages/guides/collaboration-with-pages).
+- Live editing of headers and footers in dedicated overlays. They participate in collaboration alongside the main document. See [Adding collaboration to Pages](/pages/guides/collaboration-with-pages).
 - Programmatic control: open or close a header/footer editor for a specific page, react to page format changes, react to zoom changes.
 - Lock or unlock header/footer editing per overlay, at config-time or runtime via `editableHeader` / `editableFooter` options and `setHeaderEditable` / `setFooterEditable` commands.
 - Pagination-safe tables via [PagesTableKit](/pages/guides/pages-tablekit). Tables shrink proportionally to fit the page, exact-height rows clip, declared widths are preserved.
-- Round-trip with Tiptap Conversion: imported DOCX headers and footers are auto-applied; exported DOCX, PDF, ODT, EPUB carry headers, footers, and pagination through.
+- Round-trip with Tiptap Conversion: imported DOCX headers and footers are auto-applied, and exported DOCX, PDF, ODT, and EPUB files carry headers, footers, and pagination through.
 
 ## What won't work
 
-These are real, documented limits — not bugs. If your workflow depends on any of them, treat the constraint as a design boundary.
+These are real, documented limits, not bugs. If your workflow depends on any of them, treat the constraint as a design boundary.
 
-- **Non-splittable blocks larger than a page cause an infinite layout loop.** This is the single most important limitation to know about before adopting Pages. Table rows, figures, positioned containers, and most other Block Formatting Context (BFC) elements cannot be split across pages — the layout can only move the whole block to the next page. If the block is taller than the page itself, it can't fit there either, and the layout keeps trying to move it forward and never stabilises. The result is an unresponsive editor. This is a hard limit of the current approach to splitting content between pages, not a near-term roadmap item. See [Limitations](/pages/core-concepts/limitations#oversized-non-splittable-blocks-cause-an-infinite-layout-loop) for the full treatment, including how to detect and prevent it. The table-specific case lives in [PagesTableKit's Known issues](/pages/guides/pages-tablekit#known-issues).
+- **Non-splittable blocks larger than a page cause an infinite layout loop.** This is the single most important limitation to know about before adopting Pages. Table rows, figures, positioned containers, and most other Block Formatting Context (BFC) elements cannot be split across pages. The layout can only move the whole block to the next page. If the block is taller than the page itself, it can't fit there either, and the layout keeps trying to move it forward and never stabilises. The result is an unresponsive editor. This is a hard limit of the current approach to splitting content between pages, not a near-term roadmap item. See [Limitations](/pages/core-concepts/limitations#oversized-non-splittable-blocks-cause-an-infinite-layout-loop) for the full treatment, including how to detect and prevent it. The table-specific case lives in [PagesTableKit's Known issues](/pages/guides/pages-tablekit#known-issues).
 - **No per-page styling, no page templates.** Every page uses the same layout and visual styling.
 - **No browser-print integration.** Use the [Conversion extensions and REST endpoints](/conversion/getting-started/overview) for print-ready output.
 
 ## What to expect
 
-- **Beta surface.** Pages is in active development. Pin exact package versions if you depend on it; minor versions may introduce breaking changes.
+- **Beta surface.** Pages is in active development. Pin exact package versions if you depend on it, because minor versions may introduce breaking changes.
 - **Pixel values are CSS pixels.** All dimensions in the API correspond to standard browser CSS pixels (one inch is 96 px). The `cmToPixels` and `inchToPixels` utilities round-trip cleanly so you can author in real-world units.
 - **Edit-in-place that participates in collaboration.** Double-clicking a header or footer opens a full Tiptap editor, and that editor is part of the same collaborative session as the main document.
 
 ## What not to expect
 
-- **Pages is not a full editor by itself** — it's a layout overlay. Pair it with `ConvertKit` for the document schema and `TableKit` from `extension-pages-tablekit` for tables.
+- **Pages is not a full editor by itself.** It is a layout overlay. Pair it with `ConvertKit` for the document schema and `TableKit` from `extension-pages-tablekit` for tables.
 - **Pages does not implement DOCX import or export by itself.** It's a rendering target. For round-trip with files, pair it with the [Conversion](/conversion/getting-started/overview) extensions: import via `extension-import-docx`, export via `extension-export-docx`, `extension-export-pdf`, etc.
 - **Pages does not own table rendering for paginated content.** Use [PagesTableKit](/pages/guides/pages-tablekit), not the open-source `@tiptap/extension-table` or ConvertKit's built-in tables.
 
@@ -101,11 +133,11 @@ These are real, documented limits — not bugs. If your workflow depends on any 
 
 The two products were built to work together:
 
-- [Conversion overview](/conversion/getting-started/overview) — the import/export pipeline.
-- [Import DOCX](/conversion/import/docx/editor-extension) — bring Word documents into your paginated editor (headers and footers auto-apply).
-- [Export DOCX](/conversion/export/docx/editor-extension) — export paginated content with headers and footers preserved.
-- [Export PDF](/conversion/export/pdf/editor-extension) — render the paginated layout to a PDF.
-- [From zero to print-ready](/pages/guides/zero-to-print-ready) — full end-to-end walkthrough.
+- [Conversion overview](/conversion/getting-started/overview): the import/export pipeline.
+- [Import DOCX](/conversion/import/docx/editor-extension): bring Word documents into your paginated editor (headers and footers auto-apply).
+- [Export DOCX](/conversion/export/docx/editor-extension): export paginated content with headers and footers preserved.
+- [Export PDF](/conversion/export/pdf/editor-extension): render the paginated layout to a PDF.
+- [From zero to print-ready](/pages/guides/zero-to-print-ready): full end-to-end walkthrough.
 
 ## Related
 

--- a/src/content/pages/sidebar.ts
+++ b/src/content/pages/sidebar.ts
@@ -18,6 +18,11 @@ export const sidebarConfig: SidebarConfig = {
           title: 'Install',
           href: '/pages/getting-started/install',
         },
+        {
+          title: 'Live demo',
+          href: '/pages/getting-started/live-demo',
+          tags: ['New'],
+        },
       ],
     },
     {


### PR DESCRIPTION
Replace the embedded Pages demo on the getting-started overview with the new DOCX editor template (template.tiptap.dev/docx)