### PR TITLE
Improve code block copy button positioning

### DIFF
--- a/src/components/Codeblock.tsx
+++ b/src/components/Codeblock.tsx
@@ -14,7 +14,7 @@ export const Codeblock = forwardRef<HTMLDivElement, CodeblockProps>(
   ({ children, className, disableCopy, ...rest }, ref) => {
     const contentRef = useRef<HTMLDivElement>(null)
     const wrapperClassName = cn(
-      'bg-black text-white my-5 p-4 rounded-lg text-sm flex items-start gap-2',
+      'bg-black text-white my-5 p-4 rounded-lg text-sm relative items-start gap-2',
       className,
     )
 
@@ -29,14 +29,14 @@ export const Codeblock = forwardRef<HTMLDivElement, CodeblockProps>(
 
     return (
       <div className={wrapperClassName} {...rest} ref={ref}>
-        <div ref={contentRef} className="self-center w-full overflow-auto max-h-[36rem]">
+        <div ref={contentRef} className="overflow-auto max-h-[36rem]">
           {children}
         </div>
         {disableCopy ? null : (
           <button
             onClick={onCopy}
             aria-label={clipboard.copied ? 'Copied' : 'Copy code'}
-            className="flex items-center justify-center bg-white/0 border border-white/20 rounded size-8 hover:bg-white/10 hover:border-white/40 transition-colors duration-200"
+            className="absolute top-3 right-4 flex items-center justify-center bg-black border border-white/20 rounded size-8 hover:bg-white/10 hover:border-white/40 transition-colors duration-200"
           >
             <span className="relative size-4">
               <CopyIcon

--- a/src/components/Codeblock.tsx
+++ b/src/components/Codeblock.tsx
@@ -36,7 +36,7 @@ export const Codeblock = forwardRef<HTMLDivElement, CodeblockProps>(
           <button
             onClick={onCopy}
             aria-label={clipboard.copied ? 'Copied' : 'Copy code'}
-            className="absolute top-3 right-4 flex items-center justify-center bg-black border border-white/20 rounded size-8 hover:bg-white/10 hover:border-white/40 transition-colors duration-200"
+            className="absolute top-4 right-4 flex items-center justify-center bg-black border border-white/20 rounded size-8 hover:bg-white/10 hover:border-white/40 transition-colors duration-200"
           >
             <span className="relative size-4">
               <CopyIcon


### PR DESCRIPTION
## Problem
- The copy button created an unnecessary empty strip on the right side of code blocks.

## What Changes
- Positioned the copy button as an overlay inside the code block.
- Fixed the unused right-side space.

## Screenshots

### Before
https://github.com/user-attachments/assets/de4fc508-5236-4716-82bf-0cd714724d89

### After
https://github.com/user-attachments/assets/18b79f6f-6f96-450a-a761-d2d11baa8105


