### PR TITLE
Document version query param of GET /api/documents/ endpoint

### DIFF
--- a/src/content/collaboration/documents/rest-api.mdx
+++ b/src/content/collaboration/documents/rest-api.mdx
@@ -154,7 +154,7 @@ curl --location --request PUT 'https://YOUR_APP_ID.collab.tiptap.cloud/api/admin
 ## Get a document
 
 ```bash
-GET /api/documents/:identifier?format=:format&fragment=:fragment
+GET /api/documents/:identifier?format=:format&fragment=:fragment&version=:version
 ```
 
 This call lets you export the specified document with all fragments in JSON or Yjs format. If the document is currently open on your
@@ -166,6 +166,8 @@ with `Y.encodeStateAsUpdate`.
 - `fragment` can be an array (e.g., `fragment=a&fragment=b`) or a single fragment you want to
 export. By default, we only export the `default` fragment. This parameter is only applicable when using
 the `json` or `text`format; with `yjs`, you'll always get the entire Yjs document.
+
+- `version` is the version of the Y.js document to retrieve.
 
 ```bash
 curl --location 'https://YOUR_APP_ID.collab.tiptap.cloud/api/documents/DOCUMENT_NAME' \

--- a/src/content/collaboration/documents/rest-api.mdx
+++ b/src/content/collaboration/documents/rest-api.mdx
@@ -167,7 +167,7 @@ with `Y.encodeStateAsUpdate`.
 export. By default, we only export the `default` fragment. This parameter is only applicable when using
 the `json` or `text`format; with `yjs`, you'll always get the entire Yjs document.
 
-- `version` is the version of the Y.js document to retrieve.
+- `version` (`string`, optional): the version of the Y.js document to retrieve. Defaults to the latest version.
 
 ```bash
 curl --location 'https://YOUR_APP_ID.collab.tiptap.cloud/api/documents/DOCUMENT_NAME' \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Documents the `version` query parameter on `GET /api/documents/:identifier` in the collaboration REST API reference.

The parameter specifies the version of the Y.js document to retrieve. It is added to the endpoint signature and described alongside the existing `format` and `fragment` query parameters.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a74599e-2391-4e4d-a4d6-f64d4625add2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a74599e-2391-4e4d-a4d6-f64d4625add2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

