### PR TITLE
Remove deprecated image generation models and update image generation guide

### DIFF
--- a/src/content/content-ai/capabilities/generation/image-generation.mdx
+++ b/src/content/content-ai/capabilities/generation/image-generation.mdx
@@ -1,48 +1,94 @@
 ---
-title: AI image generation editor command
+title: Generate images
 tags:
   - type: start
 meta:
   title: Generate images | Tiptap Content AI Docs
-  description: Integrate the aiImagePrompt into your editor to generate images with AI with a custom prompt and style. More in the docs!
+  description: Generate images with the OpenAI API and insert them into your Tiptap editor.
   category: Content AI
 ---
 
-import { Requirements, RequirementItem } from '@/components/Requirements'
+import { Callout } from '@/components/ui/Callout'
 
-<Requirements>
-  <RequirementItem label="1. Activate trial or subscribe">
-    Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start
-    plan](https://cloud.tiptap.dev/v2/billing) in your account.
-  </RequirementItem>
-  <RequirementItem label="2. Integrate an AI provider">
-    Configure OpenAI in your [AI settings](https://cloud.tiptap.dev/v2/cloud/ai) or review the
-    [Custom LLM guides](/content-ai/capabilities/generation/custom-llms).
-  </RequirementItem>
-  <RequirementItem label="3. Install from private registry">
-    To install the frontend extensions, authenticate to Tiptap’s private npm registry by following
-    the [setup guide](/guides/pro-extensions).
-  </RequirementItem>
-</Requirements>
+Generate images with AI and insert them in your document.
 
-The `aiImagePrompt` command in Tiptap Content AI enables you to generate images directly within the editor. You can use different OpenAI models and customize the style of the generated images.
+## Install the Image extension
 
-## Integrate aiImagePrompt
-
-Generates an image based on your prompt and the desired style.
-
-Make sure to load the image extension (`'@tiptap/extension-image'`) in your editor instance.
+Add the [`@tiptap/extension-image`](/editor/extensions/nodes/image) extension to your editor.
 
 ```js
-editor.chain().focus().aiImagePrompt(options: ImageOptions).run()
+import Image from '@tiptap/extension-image'
+import { Editor } from '@tiptap/core'
+
+const editor = new Editor({
+  extensions: [Image],
+})
 ```
 
-## Image command options
+## Generate the image on your server
 
-With these settings you can control how the image is generated:
+Call the OpenAI API from a server-side route so your API key is not exposed to the browser. Use an image generation model such as `gpt-image-2`.
 
-| Setting   | Type                                                                                            | Default          | Definition               |
-| --------- | ----------------------------------------------------------------------------------------------- | ---------------- | ------------------------ |
-| modelName | `dall-e-2`, `dall-e-3`, `null`                                                                  | `dall-e-3`       | The model used at OpenAI |
-| style     | `photorealistic`, `digital_art`, `comic_book`, `neon_punk`, `isometric`, `line_art`, `3d_model` | `photorealistic` | Define the image style   |
-| size      | `256x256`, `512x512`, `1024x1024`                                                               | `null`           |
+Then, store the generated image in your application's storage solution, such as S3, R2, Supabase Storage, or your own media service. Return the stored image URL to the client.
+
+<Callout title="Avoid storing images as base64" variant="warning">
+  Storing generated images as base64 in the document is not recommended, especially in collaborative documents. Base64 images significantly increase document size, slow down syncing, and can make collaboration updates more expensive to process.
+</Callout>
+
+```js
+import OpenAI from 'openai'
+
+const openai = new OpenAI()
+
+export async function POST(request) {
+  const { prompt } = await request.json()
+
+  const result = await openai.images.generate({
+    model: 'gpt-image-2',
+    prompt,
+    size: '1024x1024',
+  })
+
+  const imageBuffer = Buffer.from(result.data[0].b64_json, 'base64')
+  const imageSrc = await uploadImageToStorage(imageBuffer, {
+    contentType: 'image/png',
+    fileName: `generated-${Date.now()}.png`,
+  })
+
+  return Response.json({
+    imageSrc,
+  })
+}
+```
+
+The `uploadImageToStorage` function depends on your application. It should upload the image bytes to your storage provider and return a URL that the editor can render.
+
+## Insert the generated image
+
+Call your server route from the client and pass the returned image source to `setImage`.
+
+```js
+async function generateAndInsertImage(prompt) {
+  const response = await fetch('/api/generate-image', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ prompt }),
+  })
+
+  const { imageSrc } = await response.json()
+
+  editor.commands.setImage({ src: imageSrc })
+}
+```
+
+You can include additional attributes when inserting the image. See a [list of all available options](/editor/extensions/nodes/image).
+
+```js
+editor.commands.setImage({
+  src: imageSrc,
+  alt: prompt,
+  title: prompt,
+})
+```

--- a/src/content/content-ai/capabilities/generation/overview.mdx
+++ b/src/content/content-ai/capabilities/generation/overview.mdx
@@ -38,7 +38,7 @@ Add your own custom commands on top and even integrate your own proprietary LLM 
 - [Pre-configured default commands](/content-ai/capabilities/generation/text-generation)
 - [Autocompletion for efficient editing](/content-ai/capabilities/generation/text-generation/autocompletion)
 - Real-time streaming for commands
-- Compatibility with various OpenAI models (e.g., gpt-4o, gpt-4o-mini, gpt-5, dall-e-3)
+- Compatibility with various OpenAI models (e.g., gpt-4o, gpt-4o-mini, gpt-5, gpt-image-2)
 - [Create your own prompts and commands](/content-ai/capabilities/generation/text-generation/custom-commands)
 - [Custom LLM integration](/content-ai/capabilities/generation/custom-llms)
 - Works seamlessly with Tiptap Collaboration ([learn more](/content-ai/resources/collaboration))

--- a/src/content/content-ai/capabilities/generation/overview.mdx
+++ b/src/content/content-ai/capabilities/generation/overview.mdx
@@ -38,7 +38,7 @@ Add your own custom commands on top and even integrate your own proprietary LLM 
 - [Pre-configured default commands](/content-ai/capabilities/generation/text-generation)
 - [Autocompletion for efficient editing](/content-ai/capabilities/generation/text-generation/autocompletion)
 - Real-time streaming for commands
-- Compatibility with various OpenAI models (e.g., gpt-4o, gpt-4o-mini, gpt-5, gpt-image-2)
+- Compatibility with various OpenAI models (e.g. GPT-5, GPT-5 mini, GPT Image 2)
 - [Create your own prompts and commands](/content-ai/capabilities/generation/text-generation/custom-commands)
 - [Custom LLM integration](/content-ai/capabilities/generation/custom-llms)
 - Works seamlessly with Tiptap Collaboration ([learn more](/content-ai/resources/collaboration))

--- a/src/content/content-ai/capabilities/generation/text-generation/built-in-commands.mdx
+++ b/src/content/content-ai/capabilities/generation/text-generation/built-in-commands.mdx
@@ -147,8 +147,8 @@ We currently support the following OpenAI chat models:
 
 When configuring the Tiptap AI extension, consider the specific needs of your application:
 
-- **For Cost-Effective Operations:** Opt for GPT-3 or DALL-E 2 if the primary concern is budget and the tasks do not demand the most advanced capabilities.
-- **For Advanced Requirements:** Choose GPT-4o or DALL-E 3 when your application requires the highest level of language understanding or image generation quality, and budget is less of a constraint.
+- **For Cost-Effective Operations:** Opt for GPT-5-mini if the primary concern is budget and the tasks do not demand the most advanced capabilities.
+- **For Advanced Requirements:** Choose GPT-5 when your application requires the highest level of language understanding or image generation quality, and budget is less of a constraint.
 
 The Tiptap AI extension's flexible configuration allows you to tailor the AI integration to match your specific requirements and budgetary considerations.
 

--- a/src/content/content-ai/capabilities/generation/text-generation/built-in-commands.mdx
+++ b/src/content/content-ai/capabilities/generation/text-generation/built-in-commands.mdx
@@ -147,7 +147,7 @@ We currently support the following OpenAI chat models:
 
 When configuring the Tiptap AI extension, consider the specific needs of your application:
 
-- **For Cost-Effective Operations:** Opt for GPT-5-mini if the primary concern is budget and the tasks do not demand the most advanced capabilities.
+- **For Cost-Effective Operations:** Opt for GPT-5 mini if the primary concern is budget and the tasks do not demand the most advanced capabilities.
 - **For Advanced Requirements:** Choose GPT-5 when your application requires the highest level of language understanding or image generation quality, and budget is less of a constraint.
 
 The Tiptap AI extension's flexible configuration allows you to tailor the AI integration to match your specific requirements and budgetary considerations.


### PR DESCRIPTION
Fixes issue [TT-663: Check AI Generation extension for deprecated models](https://linear.app/tiptap/issue/TT-663/check-ai-generation-extension-for-deprecated-models)

DALL-E models were retired https://developers.openai.com/api/docs/deprecations so they need to be removed from the docs.

Additionally, the image generation functionality of AI Generation is equivalent to calling the backend followed by calling the `setImage` command. Plus our custom image generation backend did not support storing the images in a storage solution like S3, which is essential for any application where images are integrated into the editor. So we updated the guide to support this case.

As discussed here: https://ueberdosis.slack.com/archives/C06CHAC89HB/p1781877025009469?thread_ts=1781794569.052319&cid=C06CHAC89HB