### PR TITLE
Simplify Server AI Toolkit Overview page to highlight the Getting Started Guide.

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/overview.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/overview.mdx
@@ -75,29 +75,6 @@ Get started quickly with these guides:
   </Link>
 </div>
 
-## Core capabilities
-
-The Server AI Toolkit provides server-side equivalents of the AI Toolkit functionality.
-
-### AI agent tools
-
-Build [AI agents](/content-ai/capabilities/server-ai-toolkit/agents) that can perform complex tasks by working with Tiptap documents.
-
-<div className="grid md:grid-cols-2 gap-6 mt-6 md:items-start">
-  <Link
-    href="/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot"
-    className="flex flex-col p-4 border border-grayAlpha-200 rounded-lg hover:border-grayAlpha-300 transition-colors cursor-pointer no-underline"
-  >
-    <div className="flex items-center justify-between mb-2">
-      <h4 className="font-semibold text-black">AI Agent Chatbot</h4>
-      <span className="text-sm text-blue-600 font-medium whitespace-nowrap ml-4">More →</span>
-    </div>
-    <div className="text-sm text-grayAlpha-700">
-      Build a conversational AI capable of editing documents and interacting through chat.
-    </div>
-  </Link>
-</div>
-
 ### Built with efficiency in mind
 
 The Server AI Toolkit adapts to cost-sensitive use cases. The available tools, like `tiptapEdit` and `proofread`, use an efficient format that allows AI to apply edits fast and keep token consumption low.

--- a/src/content/content-ai/capabilities/server-ai-toolkit/overview.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/overview.mdx
@@ -41,18 +41,39 @@ read and edit Tiptap documents without a browser-based editor.
   src="https://ai-toolkit-demos.vercel.app/server-ai-agent-chatbot"
 />
 
-## Capabilities
-
-The Server AI Toolkit includes the building blocks for any custom AI functionality:
-
-- **Tools** for building [AI agents](/content-ai/capabilities/server-ai-toolkit/agents) capable of complex tasks.
-- [**Workflows**](/content-ai/capabilities/server-ai-toolkit/workflows) for single-purpose
-  automations are coming soon in upcoming releases.
-
 <Callout title="Compatible with any AI model" variant="info">
   Use the Server AI Toolkit with any AI model capable of producing text, including open source and
   self-hosted models.
 </Callout>
+
+## Get started
+
+Get started quickly with these guides:
+
+<div className="grid md:grid-cols-2 gap-6 mt-6 md:items-start">
+  <Link
+    href="/content-ai/capabilities/server-ai-toolkit/install"
+    className="flex flex-col p-4 border border-grayAlpha-200 rounded-lg hover:border-grayAlpha-300 transition-colors cursor-pointer no-underline"
+  >
+    <div className="flex items-center justify-between mb-2">
+      <h4 className="font-semibold text-black">Installation guide</h4>
+      <span className="text-sm text-blue-600 font-medium whitespace-nowrap ml-4">More →</span>
+    </div>
+    <div className="text-sm text-grayAlpha-700">Set up the Server AI Toolkit in your app</div>
+  </Link>
+  <Link
+    href="/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot"
+    className="flex flex-col p-4 border border-grayAlpha-200 rounded-lg hover:border-grayAlpha-300 transition-colors cursor-pointer no-underline"
+  >
+    <div className="flex items-center justify-between mb-2">
+      <h4 className="font-semibold text-black">AI Agent Chatbot</h4>
+      <span className="text-sm text-blue-600 font-medium whitespace-nowrap ml-4">More →</span>
+    </div>
+    <div className="text-sm text-grayAlpha-700">
+      Build a conversational AI capable of editing documents and interacting through chat.
+    </div>
+  </Link>
+</div>
 
 ## Core capabilities
 
@@ -75,37 +96,16 @@ Build [AI agents](/content-ai/capabilities/server-ai-toolkit/agents) that can pe
       Build a conversational AI capable of editing documents and interacting through chat.
     </div>
   </Link>
-  <Link
-    href="/content-ai/capabilities/server-ai-toolkit/advanced-guides/custom-nodes"
-    className="flex flex-col p-4 border border-grayAlpha-200 rounded-lg hover:border-grayAlpha-300 transition-colors cursor-pointer no-underline"
-  >
-    <div className="flex items-center justify-between mb-2">
-      <h4 className="font-semibold text-black">Custom nodes</h4>
-      <span className="text-sm text-blue-600 font-medium whitespace-nowrap ml-4">More →</span>
-    </div>
-    <div className="text-sm text-grayAlpha-700">
-      Configure schema awareness for custom nodes and marks so your AI can generate them reliably.
-    </div>
-  </Link>
 </div>
 
-### Workflows
+### Built with efficiency in mind
 
-Server-side workflows will be available in the upcoming releases of the Server AI Toolkit. See the
-[Workflows](/content-ai/capabilities/server-ai-toolkit/workflows) page for the current status.
+The Server AI Toolkit adapts to cost-sensitive use cases. The available tools, like `tiptapEdit` and `proofread`, use an efficient format that allows AI to apply edits fast and keep token consumption low.
 
-### Tiptap Shorthand and Tiptap Edit
-
-The Server AI Toolkit is built with efficiency in mind and adapts to cost-sensitive use cases.
-
-It leverages our specialized edit format, Tiptap Edit, which lets AI make small, precise edits without replacing the entire document.
-
-[Tiptap Shorthand](/content-ai/capabilities/server-ai-toolkit/advanced-guides/tiptap-shorthand) is a token-efficient format for encoding Tiptap documents. It reduces AI token costs by up to 80% without sacrificing accuracy.
-
-By combining Tiptap Edit with Tiptap Shorthand, you can work with documents in a way that's both fast and cost-effective.
+[Tiptap Shorthand](/content-ai/capabilities/server-ai-toolkit/advanced-guides/tiptap-shorthand) (alpha) is a token-efficient format used for encoding Tiptap documents. It reduces AI token costs by up to 80% without sacrificing accuracy.
 
 ## Deployment options
 
-The Server AI Toolkit can be accessed as a cloud service or deployed on your AI infrastructure.
+The Server AI Toolkit can be accessed as a cloud service or deployed on-premises, entirely on your own infrastructure.
 
 <EnterpriseCalloutAuto variant="server-ai-toolkit" renderMode="inline" />


### PR DESCRIPTION
Only modifies the Overview page of the Server AI Toolkit.

This is part of the broader refactor of the docs.

The goal of this change is to make it easier for integrators to find the getting started guide. 