### PR TITLE
docs(ui-components): add DOCX Editor template page

### DIFF
--- a/src/content/ui-components/components/font-family-combobox.mdx
+++ b/src/content/ui-components/components/font-family-combobox.mdx
@@ -1,0 +1,203 @@
+---
+title: Font Family Combobox
+meta:
+  title: Font family combobox | Tiptap UI Components
+  description: Add a searchable, grouped font-family picker with live previews to your Tiptap editor. More in the documentation!
+  category: UI Components
+component:
+  name: Font family combobox
+  description: A searchable, grouped font-family picker with per-typeface previews and a configurable catalog.
+  type: component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: Type
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+A searchable font-family picker for Tiptap editors. The trigger shows the active font; opening it reveals a fuzzy search field and fonts grouped by category, each previewed in its own typeface. A “Default font” option unsets any inline font.
+
+It is a richer, searchable counterpart to the `font-family-dropdown-menu`, and it pairs with the `FontFamily` mark from `@tiptap/extension-text-style`. The component is **catalog-agnostic**: pass your own `fonts`, `categories`, and `defaultFont`, or rely on the bundled web-safe defaults. All editor logic lives in the `useFontFamilyCombobox` hook.
+
+<CodeDemo isScrollable src="https://template.tiptap.dev/preview/tiptap-ui/font-family-combobox" />
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add font-family-combobox
+```
+
+## Components
+
+### `<FontFamilyCombobox />`
+
+A prebuilt searchable font picker built on Ariakit’s menu-with-combobox composite.
+
+#### Usage
+
+```tsx
+export default function MyEditor() {
+  return (
+    <FontFamilyCombobox
+      editor={editor}
+      hideWhenUnavailable={true}
+      onOpenChange={(isOpen) => console.log('Picker', isOpen ? 'opened' : 'closed')}
+    />
+  )
+}
+```
+
+To use your own catalog, supply `fonts`, `categories`, and `defaultFont`. Each option’s `category` is matched against a category `id`, and an option’s optional `fallbackFor` lets imported system fonts (e.g. `"Arial"`) resolve to a bundled family.
+
+```tsx
+const fonts = [
+  { value: 'inter', label: 'Inter', family: 'Inter', hint: 'UI sans', category: 'sans-serif', default: true },
+  { value: 'georgia', label: 'Georgia', family: 'Georgia, serif', hint: 'Serif', category: 'serif' },
+]
+const categories = [
+  { id: 'sans-serif', label: 'Sans-serif' },
+  { id: 'serif', label: 'Serif' },
+]
+
+<FontFamilyCombobox editor={editor} fonts={fonts} categories={categories} defaultFont={fonts[0]} />
+```
+
+#### Props
+
+The component also forwards any extra `Button` props (except `type`) to the trigger.
+
+| Name                  | Type                   | Default                       | Description                                                         |
+| --------------------- | ---------------------- | ----------------------------- | ------------------------------------------------------------------- |
+| `editor`              | `Editor \| null`       | `undefined`                   | The Tiptap editor instance.                                         |
+| `fonts`               | `FontFamilyOption[]`   | `defaultFontFamilyOptions`    | The fonts to offer in the picker.                                   |
+| `defaultFont`         | `FontFamilyOption`     | `defaultFontFamilyOption`     | The font the document falls back to when no inline font is applied. |
+| `categories`          | `FontFamilyCategory[]` | `defaultFontFamilyCategories` | Category groups to render, matched against each font’s `category`.  |
+| `hideWhenUnavailable` | `boolean`              | `false`                       | Hides the picker when font family cannot be applied.                |
+| `onOpenChange`        | `(boolean) => void`    | `undefined`                   | Callback for when the picker opens or closes.                       |
+
+#### Types
+
+```tsx
+interface FontFamilyOption {
+  label: string // display name in the picker
+  value: string // stable identifier
+  family: string // CSS font-family applied to the document; previewed in this typeface
+  hint?: string // short descriptor under the label, e.g. "Calibri-like"
+  category: string // group id (matched against a FontFamilyCategory)
+  default?: boolean // marks the default option (no inline font)
+  fallbackFor?: string[] // system fonts this family stands in for on import
+}
+
+interface FontFamilyCategory {
+  id: string
+  label: string
+}
+```
+
+## Hooks
+
+### `useFontFamilyCombobox()`
+
+A headless hook exposing the selection state and actions needed to build a custom font picker.
+
+#### Usage
+
+```tsx
+function MyFontPicker() {
+  const { isVisible, triggerLabel, selectFont, selectDefault, filterFonts } = useFontFamilyCombobox(
+    { editor, hideWhenUnavailable: true },
+  )
+
+  if (!isVisible) return null
+
+  const results = filterFonts('geo') // ranked matches for a search query
+  // …render your own UI using selectFont(font) / selectDefault()
+}
+```
+
+#### Props
+
+| Name                  | Type                 | Default                    | Description                                              |
+| --------------------- | -------------------- | -------------------------- | -------------------------------------------------------- |
+| `editor`              | `Editor \| null`     | `undefined`                | The Tiptap editor instance.                              |
+| `fonts`               | `FontFamilyOption[]` | `defaultFontFamilyOptions` | The fonts to offer.                                      |
+| `defaultFont`         | `FontFamilyOption`   | `defaultFontFamilyOption`  | The document’s fallback font when nothing inline is set. |
+| `hideWhenUnavailable` | `boolean`            | `false`                    | Hides the picker when font family is unavailable.        |
+
+#### Return Values
+
+| Name               | Type                                    | Description                                                       |
+| ------------------ | --------------------------------------- | ----------------------------------------------------------------- |
+| `isVisible`        | `boolean`                               | Whether the picker should be rendered.                            |
+| `canToggle`        | `boolean`                               | Whether font family can be applied in the current state.          |
+| `isActive`         | `boolean`                               | Whether an explicit inline font is active (not the default).      |
+| `fonts`            | `FontFamilyOption[]`                    | The configured fonts.                                             |
+| `defaultFont`      | `FontFamilyOption`                      | The configured default font.                                      |
+| `selectionState`   | `FontFamilySelectionState`              | The selection’s font state (`default` / `font` / `mixed`).        |
+| `activeFontFamily` | `string`                                | The applied `font-family` for the selection (empty when default). |
+| `activeFont`       | `FontFamilyOption \| undefined`         | The resolved option for the active family, if any.                |
+| `triggerLabel`     | `string`                                | Label for the trigger (active font, `Mixed`, or `Default · …`).   |
+| `selectFont`       | `(font: FontFamilyOption) => void`      | Apply a font family to the selection.                             |
+| `selectDefault`    | `() => void`                            | Unset any inline font (use the document default).                 |
+| `filterFonts`      | `(query: string) => FontFamilyOption[]` | Rank the configured fonts against a search query.                 |
+
+## Utilities
+
+### Default catalog
+
+```tsx
+import {
+  defaultFontFamilyOptions,
+  defaultFontFamilyCategories,
+  defaultFontFamilyOption,
+} from '@/components/tiptap-ui/font-family-combobox'
+```
+
+A web-safe set (Arial, Verdana, Tahoma, Times New Roman, Georgia, Courier New) grouped into Sans-serif / Serif / Monospace, so the component is usable out of the box without loading any webfont.
+
+### Helpers
+
+```tsx
+import {
+  filterFontsByQuery,
+  findFontByFamily,
+  resolveFontFamily,
+  getActiveFontOption,
+  getFontFamilySelectionState,
+  getFontFamilyTriggerLabel,
+} from '@/components/tiptap-ui/font-family-combobox'
+
+filterFontsByQuery(fonts, 'geo') // ranked matches (blank query → unchanged order)
+findFontByFamily(fonts, 'Georgia') // the option whose family matches, or undefined
+resolveFontFamily(fonts, 'Arial') // map a system font through each option's fallbackFor
+getActiveFontOption(fonts, 'Inter') // resolve an applied family to an option
+getFontFamilySelectionState(editor) // { kind: 'default' | 'font' | 'mixed', fontFamily }
+getFontFamilyTriggerLabel(state, defaultFont, fonts) // the trigger label string
+```
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` — Core Tiptap React integration
+- `@tiptap/pm` — ProseMirror model/state used to read the selection’s font marks
+- `match-sorter` — Fuzzy ranking for the search field
+- `@tiptap/extension-text-style` — Provides the `FontFamily` mark this picker applies
+
+### Referenced Components
+
+- `use-tiptap-editor` (hook)
+- `use-composed-ref` (hook)
+- `font-family-dropdown-menu` (component — shared editor helpers)
+- `button` (primitive)
+- `combobox` (primitive)
+- `input` (primitive)
+- `menu` (primitive)
+- `check-icon` (icon)
+- `chevron-down-icon` (icon)

--- a/src/content/ui-components/components/numbering-format-dropdown-menu.mdx
+++ b/src/content/ui-components/components/numbering-format-dropdown-menu.mdx
@@ -1,0 +1,255 @@
+---
+title: Numbering Format Dropdown Menu
+meta:
+  title: Numbering format dropdown menu | Tiptap UI Components
+  description: Add a picker for ordered-list numbering styles (decimal, alpha, roman, nested) to your Tiptap editor. More in the documentation!
+  category: UI Components
+component:
+  name: Numbering format dropdown menu
+  description: A dropdown for choosing the numbering style of an ordered list — decimal, parenthesised, nested, alpha, roman, or zero-padded.
+  type: component
+  isFree: false
+  isCloud: false
+  isOpen: false
+  isNew: true
+  icon: ListOrdered
+tags:
+  - type: start
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+import { Callout } from '@/components/ui/Callout'
+
+A numbering-style picker for ordered lists. It renders a `ListButton` to toggle the ordered list alongside a dropdown of numbering styles — decimal, parenthesised, nested decimal, upper/lower alpha, upper/lower roman, and zero-padded — each shown as a small nested-list preview.
+
+The active format is read from and applied through the **`orderedListNumbering` extension** (part of `@tiptap-pro/extension-convert-kit`), so the on-screen markers always match the format that was registered. All editor logic is exposed by the `useNumberingFormatDropdownMenu` hook, so you can build a fully custom UI on top of it.
+
+<CodeDemo
+  isScrollable
+  src="https://template.tiptap.dev/preview/tiptap-ui/numbering-format-dropdown-menu"
+/>
+
+<Callout title="Requires the orderedListNumbering extension" variant="warning">
+  This component reads and writes a `numberingFormat` id on the outermost ordered list. The matching
+  level definitions (what each id renders as on screen and on export) are supplied by the extension
+  config — see [Setup](#setup) below. Without it, selecting a format has no visible effect.
+</Callout>
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add numbering-format-dropdown-menu
+```
+
+## Setup
+
+The component only stores a format **id** on the list; the extension owns the actual marker rendering. Configure `orderedListNumbering` (via ConvertKit) with one level definition per format id you want to offer, and the same definitions can be passed to `ExportDocx` for a faithful round-trip.
+
+```tsx
+import { ConvertKit } from '@tiptap-pro/extension-convert-kit'
+
+const NUMBERING_FORMATS = [
+  {
+    id: 'decimal',
+    levels: Array.from({ length: 9 }, (_v, depth) => ({
+      baseStyle: ['decimal', 'lowerLetter', 'lowerRoman'][depth % 3],
+      textTemplate: `%${depth + 1}.`,
+    })),
+  },
+  // …one entry per id you offer (see NUMBERING_FORMAT_IDS)
+]
+
+const editor = useEditor({
+  extensions: [
+    ConvertKit.configure({
+      orderedListNumbering: {
+        formats: NUMBERING_FORMATS,
+        defaultFormat: 'decimal',
+      },
+    }),
+    // …
+  ],
+})
+```
+
+## Components
+
+### `<NumberingFormatDropdownMenu />`
+
+A prebuilt component that pairs an ordered-list toggle with the numbering-style dropdown.
+
+#### Usage
+
+```tsx
+export default function MyEditor() {
+  return (
+    <NumberingFormatDropdownMenu
+      editor={editor}
+      hideWhenUnavailable={true}
+      modal={false}
+      onOpenChange={(isOpen) => console.log('Dropdown', isOpen ? 'opened' : 'closed')}
+    />
+  )
+}
+```
+
+#### Props
+
+The component also forwards any extra `Button` props (except `type`) to the dropdown trigger.
+
+| Name                  | Type                | Default           | Description                                               |
+| --------------------- | ------------------- | ----------------- | --------------------------------------------------------- |
+| `editor`              | `Editor \| null`    | `undefined`       | The Tiptap editor instance.                               |
+| `formats`             | `NumberingFormat[]` | `DEFAULT_FORMATS` | The numbering format ids to offer in the dropdown.        |
+| `hideWhenUnavailable` | `boolean`           | `false`           | Hides the dropdown when an ordered list is not available. |
+| `modal`               | `boolean`           | `true`            | Whether the dropdown traps focus as a modal.              |
+| `onOpenChange`        | `(boolean) => void` | `undefined`       | Callback for when the dropdown opens or closes.           |
+
+### `<NumberingFormatButton />`
+
+A single format option, rendered as a small nested-list preview. Used to build the dropdown grid, or on its own.
+
+#### Props
+
+| Name                  | Type              | Default     | Description                                             |
+| --------------------- | ----------------- | ----------- | ------------------------------------------------------- |
+| `editor`              | `Editor \| null`  | `undefined` | The Tiptap editor instance.                             |
+| `format`              | `NumberingFormat` | —           | The numbering format this button applies. **Required.** |
+| `hideWhenUnavailable` | `boolean`         | `false`     | Hides the button when an ordered list is not available. |
+| `onFormatSet`         | `() => void`      | `undefined` | Called after the format is successfully applied.        |
+
+## Hooks
+
+### `useNumberingFormatDropdownMenu()`
+
+A headless hook with the full state and actions needed to build a custom numbering dropdown.
+
+#### Usage
+
+```tsx
+function MyNumberingDropdown() {
+  const {
+    isVisible,
+    currentFormat,
+    canToggle,
+    formats,
+    setFormat,
+    isFormatActive,
+    getFormatLabel,
+  } = useNumberingFormatDropdownMenu({ editor, hideWhenUnavailable: true })
+
+  if (!isVisible) return null
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger disabled={!canToggle}>Numbering</DropdownMenuTrigger>
+      <DropdownMenuContent>
+        {formats.map((format) => (
+          <DropdownMenuItem
+            key={format}
+            data-active-state={isFormatActive(format) ? 'on' : 'off'}
+            onClick={() => setFormat(format)}
+          >
+            {getFormatLabel(format)}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+```
+
+#### Props
+
+| Name                  | Type                | Default           | Description                                             |
+| --------------------- | ------------------- | ----------------- | ------------------------------------------------------- |
+| `editor`              | `Editor \| null`    | `undefined`       | The Tiptap editor instance.                             |
+| `formats`             | `NumberingFormat[]` | `DEFAULT_FORMATS` | The numbering format ids to offer.                      |
+| `hideWhenUnavailable` | `boolean`           | `false`           | Hides the dropdown when an ordered list is unavailable. |
+
+#### Return Values
+
+| Name             | Type                                   | Description                                                      |
+| ---------------- | -------------------------------------- | ---------------------------------------------------------------- |
+| `isVisible`      | `boolean`                              | Whether the dropdown should be rendered.                         |
+| `currentFormat`  | `string`                               | The currently applied format id (`"decimal"` when none is set).  |
+| `isActive`       | `boolean`                              | Whether any of the offered formats is currently active.          |
+| `canToggle`      | `boolean`                              | Whether a numbering format can be set in the current state.      |
+| `formats`        | `NumberingFormat[]`                    | The offered format ids.                                          |
+| `setFormat`      | `(format: NumberingFormat) => boolean` | Apply a format; returns `true` on success.                       |
+| `isFormatActive` | `(format: NumberingFormat) => boolean` | Whether a given format is the active one (for an active marker). |
+| `getFormatLabel` | `(format: NumberingFormat) => string`  | Human-readable preview label for a format, e.g. `"1. 2. 3."`.    |
+
+### `useNumberingFormatButton()`
+
+State and handlers for a single format option.
+
+#### Props
+
+| Name                  | Type              | Default     | Description                                   |
+| --------------------- | ----------------- | ----------- | --------------------------------------------- |
+| `editor`              | `Editor \| null`  | `undefined` | The Tiptap editor instance.                   |
+| `format`              | `NumberingFormat` | —           | The format this button applies. **Required.** |
+| `hideWhenUnavailable` | `boolean`         | `false`     | Hides the button when unavailable.            |
+| `onFormatSet`         | `() => void`      | `undefined` | Called after the format is set.               |
+
+#### Return Values
+
+| Name              | Type            | Description                                          |
+| ----------------- | --------------- | ---------------------------------------------------- |
+| `isVisible`       | `boolean`       | Whether the button should be rendered.               |
+| `isActive`        | `boolean`       | Whether this format is currently active.             |
+| `handleSetFormat` | `() => boolean` | Applies the format; returns `true` on success.       |
+| `canSet`          | `boolean`       | Whether the format can be set in the current state.  |
+| `label`           | `string`        | The preview label for the format, e.g. `"1. 2. 3."`. |
+
+## Utilities
+
+### Format ids and labels
+
+```tsx
+import {
+  NUMBERING_FORMAT_IDS,
+  NUMBERING_FORMAT_LABELS,
+  DEFAULT_FORMATS,
+} from '@/components/tiptap-ui/numbering-format-dropdown-menu'
+```
+
+`NumberingFormat` is one of: `decimal`, `decimal-paren`, `decimal-nested`, `upper-alpha`, `lower-alpha`, `upper-roman`, `lower-roman`, `decimal-zero`. `NUMBERING_FORMAT_IDS` lists them in dropdown order; `DEFAULT_FORMATS` is the default offered set; `NUMBERING_FORMAT_LABELS` maps each id to its preview string (e.g. `"A. B. C."`).
+
+### Editor helpers
+
+```tsx
+import {
+  setNumberingFormat,
+  isNumberingFormatActive,
+  getCurrentNumberingFormat,
+  canSetNumberingFormat,
+  getFormatLabel,
+} from '@/components/tiptap-ui/numbering-format-dropdown-menu'
+
+setNumberingFormat(editor, 'upper-roman') // applies the format, returns boolean
+getCurrentNumberingFormat(editor) // active format id, or null when not in a list
+isNumberingFormatActive(editor, 'decimal') // boolean
+canSetNumberingFormat(editor) // boolean
+getFormatLabel('lower-alpha') // "a. b. c."
+```
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` — Core Tiptap React integration
+- `@tiptap-pro/extension-convert-kit` — Provides the `orderedListNumbering` extension that stores and renders the format
+
+### Referenced Components
+
+- `use-tiptap-editor` (hook)
+- `list-button` (component)
+- `button` (primitive)
+- `button-group` (primitive)
+- `dropdown-menu` (primitive)
+- `tiptap-utils` (lib)
+- `chevron-down-icon` (icon)

--- a/src/content/ui-components/components/zoom-dropdown-menu.mdx
+++ b/src/content/ui-components/components/zoom-dropdown-menu.mdx
@@ -1,0 +1,186 @@
+---
+title: Zoom Dropdown Menu
+meta:
+  title: Zoom dropdown menu | Tiptap UI Components
+  description: Add a controlled zoom control with steppers, presets, a numeric input, and fit-to-page to your editor UI. More in the documentation!
+  category: UI Components
+component:
+  name: Zoom dropdown menu
+  description: A headless, fully controlled zoom control with stepper buttons, presets, a numeric input, and an optional fit-to-page action.
+  type: component
+  isFree: true
+  isCloud: false
+  isOpen: true
+  isNew: true
+  icon: ZoomIn
+tags:
+  - type: mit
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+
+A controlled zoom control for paginated or canvas-style editors. It pairs zoom-out / zoom-in stepper buttons with a percentage trigger whose popover offers a numeric input, preset levels, and an optional “Fit to page” action.
+
+The component is fully **headless and presentational** — it holds no zoom state of its own and has **no Tiptap editor dependency**. You own the zoom value and pass it in through `currentZoom` / `onZoomChange`, so it works with any zoom implementation. All of the control logic lives in the `useZoomDropdownMenu` hook, making the built-in UI just one possible renderer.
+
+<CodeDemo isScrollable src="https://template.tiptap.dev/preview/tiptap-ui/zoom-dropdown-menu" />
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add zoom-dropdown-menu
+```
+
+## Components
+
+### `<ZoomDropdownMenu />`
+
+A prebuilt React component that renders the stepper buttons, the percentage trigger, and the popover with input, presets, and fit-to-page.
+
+#### Usage
+
+```tsx
+import { useState } from 'react'
+import { ZoomDropdownMenu, type ZoomLevel } from '@/components/tiptap-ui/zoom-dropdown-menu'
+
+export default function MyToolbar() {
+  const [zoom, setZoom] = useState<ZoomLevel>(100)
+
+  return (
+    <ZoomDropdownMenu currentZoom={zoom} onZoomChange={setZoom} onFitToPage={() => setZoom(100)} />
+  )
+}
+```
+
+#### Props
+
+The component also forwards any extra `Button` props (except `type`) to the percentage trigger.
+
+| Name           | Type                     | Default        | Description                                                         |
+| -------------- | ------------------------ | -------------- | ------------------------------------------------------------------- |
+| `currentZoom`  | `number`                 | `100`          | The current zoom level (percentage). Controlled by you.             |
+| `onZoomChange` | `(zoom: number) => void` | `undefined`    | Called with the next zoom level whenever the user changes it.       |
+| `onFitToPage`  | `() => void`             | `undefined`    | Called when “Fit to page” is triggered. Omit to hide that action.   |
+| `min`          | `number`                 | `40`           | Smallest selectable zoom level.                                     |
+| `max`          | `number`                 | `200`          | Largest selectable zoom level.                                      |
+| `presets`      | `readonly number[]`      | `ZOOM_PRESETS` | Preset levels offered in the picker and used when stepping up/down. |
+
+## Hooks
+
+### `useZoomDropdownMenu()`
+
+A headless hook that derives everything a zoom UI needs. The consumer owns the value (`currentZoom` / `onZoomChange`); the hook computes the clamped value, min/max flags, the text field state with parse-and-commit, keyboard handling, preset stepping, and the fit-to-page passthrough.
+
+#### Usage
+
+```tsx
+function MyZoomControl(props) {
+  const { zoom, zoomIn, zoomOut, isMinZoom, isMaxZoom } = useZoomDropdownMenu(props)
+
+  return (
+    <div>
+      <button onClick={zoomOut} disabled={isMinZoom}>
+        -
+      </button>
+      <span>{zoom}%</span>
+      <button onClick={zoomIn} disabled={isMaxZoom}>
+        +
+      </button>
+    </div>
+  )
+}
+```
+
+#### Props
+
+| Name           | Type                     | Default        | Description                                             |
+| -------------- | ------------------------ | -------------- | ------------------------------------------------------- |
+| `currentZoom`  | `number`                 | `100`          | The current zoom level (percentage). Controlled by you. |
+| `onZoomChange` | `(zoom: number) => void` | `undefined`    | Called with the next zoom level whenever it changes.    |
+| `onFitToPage`  | `() => void`             | `undefined`    | Called when fit-to-page is triggered. Omit to hide it.  |
+| `min`          | `number`                 | `40`           | Smallest selectable zoom level.                         |
+| `max`          | `number`                 | `200`          | Largest selectable zoom level.                          |
+| `presets`      | `readonly number[]`      | `ZOOM_PRESETS` | Preset levels offered and used for stepping.            |
+
+#### Return Values
+
+| Name                 | Type                                                 | Description                                                            |
+| -------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------- |
+| `zoom`               | `number`                                             | The clamped current zoom level.                                        |
+| `min`                | `number`                                             | The effective minimum zoom.                                            |
+| `max`                | `number`                                             | The effective maximum zoom.                                            |
+| `presets`            | `readonly number[]`                                  | The preset levels.                                                     |
+| `isMinZoom`          | `boolean`                                            | Whether the current zoom is at (or below) `min`.                       |
+| `isMaxZoom`          | `boolean`                                            | Whether the current zoom is at (or above) `max`.                       |
+| `canFitToPage`       | `boolean`                                            | Whether a fit-to-page action is available (`onFitToPage` provided).    |
+| `zoomIn`             | `() => void`                                         | Step to the next preset above the current zoom.                        |
+| `zoomOut`            | `() => void`                                         | Step to the next preset below the current zoom.                        |
+| `setZoom`            | `(zoom: number) => void`                             | Apply an arbitrary level (clamped to `min`/`max`).                     |
+| `inputValue`         | `string`                                             | Controlled value for a percentage text field.                          |
+| `setInputValue`      | `(value: string) => void`                            | Setter for the text field value.                                       |
+| `commitInput`        | `() => void`                                         | Parse and apply the text field (reverts if invalid). Wire to `onBlur`. |
+| `handleInputKeyDown` | `(e: React.KeyboardEvent<HTMLInputElement>) => void` | Enter/Escape handling for the text field. Wire to `onKeyDown`.         |
+| `fitToPage`          | `() => void`                                         | Invoke the consumer’s fit-to-page handler.                             |
+
+## Utilities
+
+The component module also exports a few pure helpers and constants for building custom zoom logic.
+
+### `clampZoom(value, min?, max?)`
+
+Clamps a zoom value to the supported range, rounded to the nearest integer.
+
+```tsx
+import { clampZoom } from '@/components/tiptap-ui/zoom-dropdown-menu'
+
+clampZoom(87.6) // 88
+clampZoom(999) // 200
+```
+
+### `parsePercent(input)`
+
+Parses a percentage string (e.g. `"100%"` or `"100"`) to a number, or returns `null` for invalid input.
+
+```tsx
+import { parsePercent } from '@/components/tiptap-ui/zoom-dropdown-menu'
+
+parsePercent('125%') // 125
+parsePercent('abc') // null
+```
+
+### `getNextPresetZoom(currentZoom, direction, presets?, min?, max?)`
+
+Returns the next preset level above or below the current zoom.
+
+```tsx
+import { getNextPresetZoom } from '@/components/tiptap-ui/zoom-dropdown-menu'
+
+getNextPresetZoom(100, 'up') // 125
+getNextPresetZoom(100, 'down') // 90
+```
+
+### Constants
+
+- `ZOOM_MIN` (`40`), `ZOOM_MAX` (`200`), `ZOOM_DEFAULT` (`100`)
+- `ZOOM_PRESETS` — `[40, 50, 75, 90, 100, 125, 150, 175, 200]`
+- `ZoomLevel` — the exported `number` type alias used across the API
+
+## Requirements
+
+### Dependencies
+
+- `react` — the control is presentational and does not depend on Tiptap.
+
+### Referenced Components
+
+- `button` (primitive)
+- `button-group` (primitive)
+- `card` (primitive)
+- `input` (primitive)
+- `popover` (primitive)
+- `separator` (primitive)
+- `fullscreen-icon` (icon)
+- `minus-icon` (icon)
+- `plus-icon` (icon)

--- a/src/content/ui-components/sidebar.ts
+++ b/src/content/ui-components/sidebar.ts
@@ -73,6 +73,11 @@ export const sidebarConfig: SidebarConfig = {
           href: '/ui-components/templates/notion-like-editor',
           tags: ['Start'],
         },
+        {
+          title: 'DOCX Editor',
+          href: '/ui-components/templates/docx-editor',
+          tags: ['Team'],
+        },
       ],
     },
     {

--- a/src/content/ui-components/sidebar.ts
+++ b/src/content/ui-components/sidebar.ts
@@ -158,6 +158,10 @@ export const sidebarConfig: SidebarConfig = {
               href: '/ui-components/components/emoji-trigger-button',
             },
             {
+              title: 'Font family combobox',
+              href: '/ui-components/components/font-family-combobox',
+            },
+            {
               title: 'Heading button',
               href: '/ui-components/components/heading-button',
             },
@@ -206,6 +210,10 @@ export const sidebarConfig: SidebarConfig = {
               href: '/ui-components/components/move-node-button',
             },
             {
+              title: 'Numbering format dropdown menu',
+              href: '/ui-components/components/numbering-format-dropdown-menu',
+            },
+            {
               title: 'Reset all formatting button',
               href: '/ui-components/components/reset-all-formatting-button',
             },
@@ -232,6 +240,10 @@ export const sidebarConfig: SidebarConfig = {
             {
               title: 'Undo redo button',
               href: '/ui-components/components/undo-redo-button',
+            },
+            {
+              title: 'Zoom dropdown menu',
+              href: '/ui-components/components/zoom-dropdown-menu',
             },
           ],
         },

--- a/src/content/ui-components/templates/docx-editor.mdx
+++ b/src/content/ui-components/templates/docx-editor.mdx
@@ -1,0 +1,262 @@
+---
+title: DOCX Editor
+meta:
+  title: DOCX Editor | Tiptap UI Components
+  description: A paginated, Word-style document editor built on Tiptap Pages with real-time collaboration, editable headers and footers, footnotes, page breaks, a live Word preview, and DOCX/PDF export.
+  category: UI Components
+tags:
+  - type: team
+---
+
+import { ArrowRightIcon } from 'lucide-react'
+import { CodeDemo } from '@/components/CodeDemo'
+import { Button } from '@/components/ui/Button'
+import { Link } from '@/components/Link'
+import { Callout } from '@/components/ui/Callout'
+
+The **DOCX Editor Template** is a paginated, Word-style document editor. Unlike the continuous-canvas editors, it renders content on discrete pages with real margins, editable headers and footers, footnotes, manual page breaks, and a configurable page format—then exports a faithful `.docx` file and renders a live Word preview next to the editor.
+
+It is built on the [Tiptap Pages](/pages/getting-started/overview) extension and the [Conversion](/conversion/getting-started/overview) DOCX/PDF exporters, with real-time collaboration provided by [Tiptap Collaboration](/collaboration/getting-started/overview).
+
+<div className="flex items-center gap-4 mt-8">
+  <Button variant="primary" size="medium">
+    <Link
+      href="https://template.tiptap.dev/docx"
+      className="flex items-center justify-center gap-2"
+    >
+      View in Full Screen
+      <ArrowRightIcon className="size-3.5" />
+    </Link>
+  </Button>
+</div>
+
+<CodeDemo isScrollable isLarge src="https://template.tiptap.dev/docx" />
+
+<Callout title="Team plan required" variant="warning">
+  The DOCX Editor template requires at least a **Team plan** subscription to use in production. You
+  can integrate and test it during your trial period. Usage of this template is subject to our
+  [Terms of Service](https://tiptap.dev/terms-of-service) and [Pro
+  License](https://tiptap.dev/pro-license).
+</Callout>
+
+## Overview
+
+The template combines several Tiptap Pro extensions into a single document-editing experience:
+
+- **[Pages](/pages/getting-started/overview)** — pagination, page format (size, orientation, margins), headers and footers, footnotes, and zoom.
+- **[Convert / Export DOCX](/conversion/export/docx/editor-extension)** — turns the editor document into a real Word `.docx` file in the browser.
+- **[Export PDF](/conversion/export/pdf/editor-extension)** — generates the side-by-side Word preview through the Tiptap Conversion API.
+- **[Collaboration](/collaboration/getting-started/overview)** — real-time multi-user editing of the body, headers, footers, and footnotes.
+
+On top of these, the template adds a Word-like toolbar, a document-settings sidebar, an editable header/footer overlay, and a set of small workarounds that make the Pages interactions feel native.
+
+## Installation
+
+You'll need a Tiptap account with an active subscription or trial. Create one at [cloud.tiptap.dev/register](https://cloud.tiptap.dev/register).
+
+### For existing projects
+
+```bash
+npx @tiptap/cli@latest add docx
+```
+
+### For new projects
+
+```bash
+npx @tiptap/cli@latest init docx
+```
+
+This template requires styling and configuration setup.
+
+### Styling
+
+We stay unopinionated about styling frameworks, so you'll need to integrate it with your setup. Follow the [style setup guide](/ui-components/getting-started/style) to ensure the editor displays correctly.
+
+The template ships SCSS, so make sure `sass` (and `sass-embedded`) are available as dev dependencies in your project.
+
+### Environment variables
+
+The DOCX Editor uses two cloud services: **Collaboration** (for real-time editing) and **Conversion** (for the PDF/Word preview). Provide values for the following variables.
+
+**Collaboration**
+
+- `NEXT_PUBLIC_TIPTAP_COLLAB_APP_ID` — your Collaboration (document server) App ID.
+- `NEXT_PUBLIC_TIPTAP_COLLAB_TOKEN` — a JWT for accessing Collaboration services.
+- `NEXT_PUBLIC_TIPTAP_COLLAB_DOC_PREFIX` — *(optional)* prefix prepended to every document name.
+- `NEXT_PUBLIC_USE_JWT_TOKEN_API_ENDPOINT` — *(production)* an API endpoint that returns a freshly signed JWT, instead of shipping a static token to the client.
+
+**Conversion (PDF / Word preview)**
+
+- `NEXT_PUBLIC_TIPTAP_CONVERSION_APP_ID` — your Conversion App ID (read on the client and passed to the PDF exporter).
+- `TIPTAP_CONVERSION_SECRET` — *(server only)* the Conversion secret used by the `/api/convert/token` route to sign a short-lived (10 minute) JWT for the preview.
+
+The `NEXT_PUBLIC_`-prefixed variables must be available on the client. Depending on your framework, use the matching prefix:
+
+- [Next.js](/ui-components/install/next): `NEXT_PUBLIC_`. For example, `NEXT_PUBLIC_TIPTAP_COLLAB_APP_ID`.
+- [Vite + React](/ui-components/install/vite): `VITE_`. For example, `VITE_TIPTAP_COLLAB_APP_ID`.
+- Other frameworks: follow your framework's rules and wire the values into `tiptap-collab-utils.ts`.
+
+<Callout title="Generate the JWT" variant="info">
+  To get started quickly, you can use the example JWTs from your Tiptap Cloud account and store them
+  in the token environment variables. Example JWTs are valid for a short time and should not be used
+  in production. In production, implement an API endpoint that generates JWTs on the server side. See
+  the full guide on [JWT authentication](/guides/authentication).
+</Callout>
+
+If Collaboration is not configured, the editor renders a setup notice prompting you to set the App ID and token (or the JWT endpoint). You can also append `?noCollab=1` to the URL to disable collaboration for local testing.
+
+## Usage
+
+Render the `PageDocxEditor` component. Each document is a collaborative room, so pass a unique `room` ID per document.
+
+```tsx
+import { PageDocxEditor } from '@/components/tiptap-templates/page-docx/components/page-docx-editor'
+import initialContent from '@/components/tiptap-templates/page-docx/data/content.json'
+
+export default function App() {
+  return <PageDocxEditor room="contract-123" initialContent={initialContent} />
+}
+```
+
+### Routing
+
+The template ships with a page that mirrors how the demo runs: visiting `/docx` redirects to `/docx/<room-id>` with a freshly generated room ID, and the `[slug]` route renders the editor for that room while preloading the Google Fonts used by the font picker. Each room is a separate, persisted collaborative document.
+
+### Props
+
+The exported `PageDocxEditor` component accepts:
+
+| Prop              | Type              | Description                                                                                                                                          |
+| ----------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `room`            | `string`          | Collaboration room ID. Each document should use a unique room. If omitted, a random room is created.                                                 |
+| `initialContent`  | `JSONContent`     | Tiptap JSON seeded into the document the first time the room is opened. The template ships a sample NDA. Seeding is guarded so it never duplicates.   |
+| `invertMenu`      | `boolean`         | Renders the toolbar at the bottom of the screen instead of the top. Can also be toggled with the `?menu=invert` query parameter. Defaults to `false`. |
+| `settingsStorage` | `SettingsStorage` | Persistence backend for sidebar UI settings (page format, header/footer settings, preview toggle). Defaults to a localStorage adapter. See [Settings persistence](#settings-persistence). |
+
+## Features
+
+A fully paginated document editor with a Word-like toolbar, document settings, and live export.
+
+- **Pagination**: Content flows across real pages with configurable size, orientation, and margins.
+- **Headers and footers**: Editable per-document, with different first page and different odd/even variants, adjustable distance from the page edge, and dynamic page-number fields.
+- **Footnotes**: Word-like footnotes—references in the body, content in a per-page area above the footer, edited in an automatically-numbered overlay.
+- **Manual page breaks**: Insert a break that consumes the remaining page space and pushes following content to the next page, exactly like Word.
+- **Document settings**: Page size (20+ presets plus custom), orientation, margins, units, page gap, and page background color.
+- **Zoom & fit-to-page**: 40%–200% presets with an automatic fit-to-page mode that scales the page to the available width.
+- **Font family**: A categorized, searchable font picker. Carlito (a Calibri-compatible metric match) is the default and the embedded export font.
+- **Ordered-list numbering**: Eight numbering schemes (decimal, alpha, roman, nested, and more) that stay identical on screen and in the exported document.
+- **Rich text formatting**: Headings, bold/italic/strike/code, text color, links, inline images, bullet lists, line spacing, text alignment, and font size.
+- **DOCX export**: One-click download of a real `.docx` file, generated entirely in the browser.
+- **Live Word preview**: A side-by-side PDF rendering of the document as Word would lay it out, refreshable on demand.
+- **Real-time collaboration**: Live multi-user editing of the body, headers, footers, and footnotes with presence carets.
+- **Dark and light mode**: Fully themed out of the box.
+- **Responsive design**: A mobile layout with a full-screen preview mode and an overflowing toolbar that collapses extra controls into a menu.
+
+### Pagination and page format
+
+The page geometry is owned by the Pages extension and configured from the document-settings sidebar. You can set:
+
+- **Page size** — A4, A5, A6, JIS B5, US Letter, US Legal, Executive, postcards, envelopes, and more, plus a **Custom** size with explicit width and height.
+- **Orientation** — portrait or landscape.
+- **Margins** — top, bottom, left, and right, with an optional “link margins” toggle that keeps all four in sync.
+- **Unit** — `cm`, `in`, `mm`, or `px`; all inputs reformat to the selected unit.
+- **Page gap** — the space between pages in the editor canvas.
+- **Page background color** — a transparent default plus a palette of preset colors.
+
+Settings entered in the sidebar drive the live editor; conversely, changes made through the Pages extension (including remote changes from a collaborator) flow back into the sidebar and persisted settings.
+
+### Headers and footers
+
+Double-click any header or footer zone—or open the **Headers & footers** tab in the sidebar—to edit it in an overlay pinned over the live page. The sample document ships a header (document title + logo) and a footer (label, “Confidential”, and a `{page} of {pages}` field) laid out in tables.
+
+Supported options:
+
+- **Different first page** — a distinct header/footer on page 1.
+- **Different odd & even pages** — alternating headers/footers for book-style layouts.
+- **Distance to page edge** — header distance from the top and footer distance from the bottom, in the document's unit (clamped to Word's range, defaulting to ~1.25 cm).
+- **Page numbers** — insert a current-page or total-pages field. These render as `{page}` / `{pages}` tokens in the editor and become live Word fields on export.
+
+Because Pages keeps a separate inner editor per variant (default / first / odd / even), the sidebar includes a small pager to step between the reachable variants for the current document.
+
+### Footnotes
+
+Footnotes are a feature of the Pages extension. Insert one from the toolbar (or with the keyboard shortcut) and a numbered reference is placed in the body while the footnote content opens in an overlay editor; the rendered footnote sits in a dedicated area above the footer on its page. On export, the DOCX exporter extracts these into real Word footnotes automatically.
+
+### Page breaks
+
+A manual page break always leaves an empty paragraph before the break and drops the caret into a paragraph after it—matching how Word treats a manual break. Backspacing from that trailing empty paragraph deletes adjacent page breaks one at a time before falling back to normal editing. Insert a break from the toolbar or with `Mod-Enter`.
+
+### Zoom
+
+The zoom control offers presets from 40% to 200% plus a **Fit to page** action. By default the editor is in an automatic mode that scales the page down to fit the available column width and back up to 100% as the viewport grows; choosing a preset switches to a fixed manual zoom. Zoom is published as a `--zoom` CSS variable so portalled overlays (such as the header/footer editors) scale consistently.
+
+### Export and preview
+
+- **DOCX export** downloads a `.docx` file built in the browser by the Export DOCX extension—no server round-trip. Page size, margins (including header/footer expansion), background color, ordered-list numbering, and page-number fields are all carried into the document, the Carlito font is embedded, and editor CSS-variable colors are normalized to fixed hex values so the file looks the same everywhere.
+- **Word preview** is an on-demand PDF rendering of the same document, shown beside the editor (and full-screen on mobile). It is generated through the Tiptap Conversion API using a short-lived token from the `/api/convert/token` route, then rendered with `react-pdf`. The preview refreshes when you open it, when the page layout changes, and via an **Update preview** button when the document has unsaved changes.
+
+### Real-time collaboration
+
+The body binds to a `TiptapCollabProvider` document, and each header/footer variant and the footnotes story sync through their own collaborative fields. Presence carets are shown for the body only (the inner editors intentionally forward content sync but not carets, to avoid duplicate cursors across the shared provider). The default header/footer chrome and the initial body content are seeded once per room, gated on the provider being synced so a returning room keeps whatever was edited.
+
+### Settings persistence
+
+Sidebar UI settings (page format, header/footer settings, and the preview toggle) are persisted per room. By default they are stored in `localStorage` under room-scoped keys. The backend is pluggable via the `settingsStorage` prop and a `SettingsStorage` adapter interface:
+
+```ts
+interface SettingsStorage {
+  get<T = unknown>(key: string): T | null
+  set<T = unknown>(key: string, value: T): void
+  remove(key: string): void
+}
+```
+
+Pass `noopStorage` to disable persistence entirely, or implement the interface to persist settings to your own backend (for example, a database keyed by document).
+
+## Component breakdown
+
+The template is composed of its own components, hooks, and libraries on top of a set of shared Tiptap UI components.
+
+### Template components
+
+- `page-docx-editor` — the root component: collaboration setup, the editor instance, layout, and effects.
+- `page-docx-main-toolbar` — the Word-like toolbar, with overflow handling.
+- `page-docx-header-footer-overlay` — the floating “edit” affordance over hovered header/footer zones.
+- `page-docx-pdf-preview` — the `react-pdf` Word preview pane.
+- `page-docx-loading-overlay`, `floating`, `theme-toggle` — supporting UI.
+- `sidebar/*` — the document and header/footer settings panels, footer pagination, and the settings-panel primitives.
+- `zoom-dropdown-menu`, `font-family-combobox`, `numbering-format-dropdown-menu` — the specialized toolbar controls.
+
+### Hooks
+
+- `use-page-editor-state` — derives page state (active editor type, page count, current page, header/footer flags) from the Pages storage.
+- `use-zoom`, `use-auto-export`, `use-page-docx-export` — zoom, dirty-tracking, and the DOCX/PDF export actions.
+- `use-overlay-focus`, `use-overlay-labels`, `use-element-rect`, `use-mobile-typography-guard` — overlay behavior and layout helpers.
+
+### Lib
+
+- `page-docx-utils`, `page-docx-pages` — units/conversions, page-format helpers, and settings sync.
+- `page-docx-export`, `page-docx-export-colors`, `page-docx-fonts` — export layout/styles, color normalization, and the font registry.
+- `settings-storage`, `settings-storage-context` — the pluggable persistence adapter and its React context.
+
+### Extensions and workarounds
+
+- `extensions/extension-page-token-highlight` — the inline `{page}` / `{pages}` page-number node and its DOCX adapter.
+- `workaround/page-break`, `workaround/header-footer`, `workaround/footnote` — small, well-commented patches that make the Pages interactions (caret placement, overlay focus and scroll, footnote scroll-into-view) behave like a desktop word processor.
+
+### Tiptap Pro extensions
+
+- `@tiptap-pro/extension-pages`
+- `@tiptap-pro/extension-convert-kit`
+- `@tiptap-pro/extension-export-docx`
+- `@tiptap-pro/extension-export-pdf`
+- `@tiptap-pro/extension-pagebreak`
+- `@tiptap-pro/provider`
+
+### Reused UI components
+
+The toolbar and sidebar reuse the open-source UI components, including `mark-button`, `list-button`, `heading-button` / `heading-dropdown-menu`, `text-button`, `font-size-dropdown-menu`, `line-spacing-dropdown-menu`, `text-align-dropdown-menu`, `color-text-popover`, and `link-popover`, plus the `button`, `card`, `combobox`, `dropdown-menu`, `popover`, `sidebar`, and `toolbar` primitives.
+
+## License
+
+The DOCX Editor template uses Tiptap Pro extensions and requires an active **Team plan** (or higher) subscription. Usage is subject to the [Tiptap Pro License](https://tiptap.dev/pro-license) and [Terms of Service](https://tiptap.dev/terms-of-service). The open-source UI components it builds on remain MIT licensed.

--- a/src/content/ui-components/templates/docx-editor.mdx
+++ b/src/content/ui-components/templates/docx-editor.mdx
@@ -82,13 +82,13 @@ The DOCX Editor uses two cloud services: **Collaboration** (for real-time editin
 
 - `NEXT_PUBLIC_TIPTAP_COLLAB_APP_ID` — your Collaboration (document server) App ID.
 - `NEXT_PUBLIC_TIPTAP_COLLAB_TOKEN` — a JWT for accessing Collaboration services.
-- `NEXT_PUBLIC_TIPTAP_COLLAB_DOC_PREFIX` — *(optional)* prefix prepended to every document name.
-- `NEXT_PUBLIC_USE_JWT_TOKEN_API_ENDPOINT` — *(production)* an API endpoint that returns a freshly signed JWT, instead of shipping a static token to the client.
+- `NEXT_PUBLIC_TIPTAP_COLLAB_DOC_PREFIX` — _(optional)_ prefix prepended to every document name.
+- `NEXT_PUBLIC_USE_JWT_TOKEN_API_ENDPOINT` — _(production)_ an API endpoint that returns a freshly signed JWT, instead of shipping a static token to the client.
 
 **Conversion (PDF / Word preview)**
 
 - `NEXT_PUBLIC_TIPTAP_CONVERSION_APP_ID` — your Conversion App ID (read on the client and passed to the PDF exporter).
-- `TIPTAP_CONVERSION_SECRET` — *(server only)* the Conversion secret used by the `/api/convert/token` route to sign a short-lived (10 minute) JWT for the preview.
+- `TIPTAP_CONVERSION_SECRET` — _(server only)_ the Conversion secret used by the `/api/convert/token` route to sign a short-lived (10 minute) JWT for the preview.
 
 The `NEXT_PUBLIC_`-prefixed variables must be available on the client. Depending on your framework, use the matching prefix:
 
@@ -99,8 +99,8 @@ The `NEXT_PUBLIC_`-prefixed variables must be available on the client. Depending
 <Callout title="Generate the JWT" variant="info">
   To get started quickly, you can use the example JWTs from your Tiptap Cloud account and store them
   in the token environment variables. Example JWTs are valid for a short time and should not be used
-  in production. In production, implement an API endpoint that generates JWTs on the server side. See
-  the full guide on [JWT authentication](/guides/authentication).
+  in production. In production, implement an API endpoint that generates JWTs on the server side.
+  See the full guide on [JWT authentication](/guides/authentication).
 </Callout>
 
 If Collaboration is not configured, the editor renders a setup notice prompting you to set the App ID and token (or the JWT endpoint). You can also append `?noCollab=1` to the URL to disable collaboration for local testing.
@@ -126,11 +126,11 @@ The template ships with a page that mirrors how the demo runs: visiting `/docx` 
 
 The exported `PageDocxEditor` component accepts:
 
-| Prop              | Type              | Description                                                                                                                                          |
-| ----------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `room`            | `string`          | Collaboration room ID. Each document should use a unique room. If omitted, a random room is created.                                                 |
-| `initialContent`  | `JSONContent`     | Tiptap JSON seeded into the document the first time the room is opened. The template ships a sample NDA. Seeding is guarded so it never duplicates.   |
-| `invertMenu`      | `boolean`         | Renders the toolbar at the bottom of the screen instead of the top. Can also be toggled with the `?menu=invert` query parameter. Defaults to `false`. |
+| Prop              | Type              | Description                                                                                                                                                                               |
+| ----------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `room`            | `string`          | Collaboration room ID. Each document should use a unique room. If omitted, a random room is created.                                                                                      |
+| `initialContent`  | `JSONContent`     | Tiptap JSON seeded into the document the first time the room is opened. The template ships a sample NDA. Seeding is guarded so it never duplicates.                                       |
+| `invertMenu`      | `boolean`         | Renders the toolbar at the bottom of the screen instead of the top. Can also be toggled with the `?menu=invert` query parameter. Defaults to `false`.                                     |
 | `settingsStorage` | `SettingsStorage` | Persistence backend for sidebar UI settings (page format, header/footer settings, preview toggle). Defaults to a localStorage adapter. See [Settings persistence](#settings-persistence). |
 
 ## Features
@@ -230,8 +230,8 @@ The template is composed of its own components, hooks, and libraries on top of a
 ### Hooks
 
 - `use-page-editor-state` — derives page state (active editor type, page count, current page, header/footer flags) from the Pages storage.
-- `use-zoom`, `use-auto-export`, `use-page-docx-export` — zoom, dirty-tracking, and the DOCX/PDF export actions.
-- `use-overlay-focus`, `use-overlay-labels`, `use-element-rect`, `use-mobile-typography-guard` — overlay behavior and layout helpers.
+- `use-zoom`, `use-auto-export`, `use-page-docx-export`, `use-page-docx-insert-actions` — zoom, dirty-tracking, the DOCX/PDF export actions, and the toolbar insert actions (footnote / page break / image).
+- `use-overlay-focus`, `use-overlay-labels`, `use-mobile-typography-guard` — overlay behavior and layout helpers. Live element-rect tracking comes from the shared `use-bounding-rect` hook.
 
 ### Lib
 


### PR DESCRIPTION
## What

Adds documentation for the **DOCX Editor** template (registry name `docx`,
folder `page-docx`) under **UI Components → Templates**, alongside Simple
Editor and Notion Editor.

The template is a paginated, Word-style editor built on Tiptap **Pages** +
**Conversion** (Export DOCX/PDF) + **Collaboration**.

## Changes

- **New page** `src/content/ui-components/templates/docx-editor.mdx` covering:
  overview/architecture, CLI install (`add docx` / `init docx`), styling,
  environment variables (Collaboration + Conversion), usage & props, routing,
  and a detailed Features section — pagination, headers/footers (different
  first page / odd-even, distance, page-number fields), footnotes, page
  breaks, document settings, zoom, fonts, ordered-list numbering, DOCX export,
  live Word preview, collaboration, and pluggable settings persistence —
  plus a component breakdown and license.
- **Sidebar** `src/content/ui-components/sidebar.ts`: new "DOCX Editor" entry
  in the Templates group, tagged `Team`.