### PR TITLE
docs(conversion): document comments argument for DOCX export REST API

### DIFF
--- a/src/content/conversion/export/docx/rest-api.mdx
+++ b/src/content/conversion/export/docx/rest-api.mdx
@@ -31,7 +31,7 @@ import ElementOverridesRestApi from '../_shared/_element-overrides-rest-api.mdx'
 
 The DOCX export API converts Tiptap JSON documents into `.docx` (Microsoft Word) files. It uses the same conversion library as the [editor extension](/conversion/export/docx/editor-extension) and produces equivalent DOCX output for standard content.
 
-The REST API supports [style overrides](/conversion/export/docx/styles), [custom-node rendering via the DSL](/conversion/export/docx/custom-nodes-dsl), page size and margins, headers/footers, and element-level overrides (`tableOverrides`, `paragraphOverrides`, `textRunOverrides`, `tableCellOverrides`, `imageOverrides`). It does not accept JavaScript-function options. For the function-based custom-node API, use the [editor extension](/conversion/export/docx/editor-extension), which also works server-side.
+The REST API supports [style overrides](/conversion/export/docx/styles), [custom-node rendering via the DSL](/conversion/export/docx/custom-nodes-dsl), page size and margins, headers/footers, comment threads, and element-level overrides (`tableOverrides`, `paragraphOverrides`, `textRunOverrides`, `tableCellOverrides`, `imageOverrides`). It does not accept JavaScript-function options. For the function-based custom-node API, use the [editor extension](/conversion/export/docx/editor-extension), which also works server-side.
 
 <Callout title="Review the postman collection" variant="hint">
   You can also experiment with the Document Conversion API by heading over to our [Postman
@@ -98,6 +98,7 @@ curl --output example.docx -X POST "https://api.tiptap.dev/v2/convert/export/doc
 | `imageOverrides`     | `Object`          | Image rendering overrides                                                                                                                                                                                                                                                                                                                                                    | `undefined` |
 | `customNodeDsl`      | `Object`          | [Custom-node DSL](/conversion/export/docx/custom-nodes-dsl) rules                                                                                                                                                                                                                                                                                                            | `undefined` |
 | `placeholders`       | `Object \| false` | Optional `{ page?, total? }` rename map matching `Pages.configure({ placeholders })` so renamed tokens (e.g. `{p}` / `{pages}`) in plain-text headers/footers become live `PAGE` / `NUMPAGES` fields. Pass `false` to disable substitution entirely (literal `{page}` / `{total}` text in the exported `.docx`). See [Custom token names](#custom-token-names-placeholders). | `undefined` |
+| `comments`           | `Object`          | Comment threads to embed as native Word comments: `{ threads: [...] }`. Each thread carries its messages, author, dates, and resolved state, and is anchored to the document's `inlineThread` / `blockThread` marks. See [Comments](#comments).                                                                                                                              | `undefined` |
 
 #### Page Size Configuration
 
@@ -206,9 +207,9 @@ The `footers` object allows you to customize the footers of your exported DOCX d
 <Callout title="`{page}` / `{total}` tokens become live Word fields" variant="info">
   The REST API translates `{page}`, `{total}`, and the `{numpages}` synonym inside plain-text
   headers/footers into live Word `PAGE` / `NUMPAGES` fields in the exported `.docx`. Custom token
-  names (e.g. `{p}` / `{pages}`) require passing the optional `placeholders` rename map. See
-  [Custom token names](#custom-token-names-placeholders) below. Pass `"placeholders": false` to ship
-  the tokens as literal text instead.
+  names (e.g. `{p}` / `{pages}`) require passing the optional `placeholders` rename map. See [Custom
+  token names](#custom-token-names-placeholders) below. Pass `"placeholders": false` to ship the
+  tokens as literal text instead.
 </Callout>
 
 #### Custom token names (`placeholders`)
@@ -236,6 +237,52 @@ curl --output example.docx -X POST "https://api.tiptap.dev/v2/convert/export/doc
       "doc": "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Document with custom footers\"}]}]}",
       "exportType": "blob",
       "footers": {"evenAndOddFooters": true, "default": "Default Footer", "first": "First Page Footer", "even": "Even Page Footer"}
+    }'
+```
+
+### Comments
+
+Pass a `comments` object to embed comment threads as native Word comments in the exported `.docx`. Each thread is anchored to the text it belongs to through the document's own comment markers: an `inlineThread` mark whose `data-thread-id` matches the thread `id`, or a `blockThread` node. The `comments` field supplies the thread bodies, authors, dates, and resolved state.
+
+The shape mirrors the editor's export extension:
+
+| Field                  | Type               | Description                                                                                                                    |
+| ---------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| `threads`              | `Array`            | The comment threads to embed.                                                                                                  |
+| `threads[].id`         | `String`           | Thread id. Must match the `data-thread-id` on the matching `inlineThread` / `blockThread` in `doc`.                            |
+| `threads[].resolvedAt` | `String \| null`   | When set, the thread is exported as resolved.                                                                                  |
+| `threads[].comments`   | `Array`            | The thread's messages, root first, then replies in order.                                                                      |
+| `comments[].id`        | `String`           | Message id.                                                                                                                    |
+| `comments[].content`   | `String \| Object` | The message body as plain text or Tiptap JSON.                                                                                 |
+| `comments[].data`      | `Object`           | Optional metadata: `author`, `initials`, `dateIso`, `dateUtc`, and round-trip identities (`originalWId`, `originalDurableId`). |
+
+When omitted, the export contains no comments, so existing requests are unaffected.
+
+**Example cURL with a comment thread:**
+
+```bash
+curl --output example.docx -X POST "https://api.tiptap.dev/v2/convert/export/docx" \
+    -H "Authorization: Bearer YOUR_TOKEN" \
+    -H "X-App-Id: YOUR_APP_ID" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "doc": "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Reviewed text\",\"marks\":[{\"type\":\"inlineThread\",\"attrs\":{\"data-thread-id\":\"T1\"}}]}]}]}",
+      "exportType": "blob",
+      "comments": {
+        "threads": [
+          {
+            "id": "T1",
+            "resolvedAt": null,
+            "comments": [
+              {
+                "id": "c1",
+                "content": "Please cite a source.",
+                "data": { "author": "Ada Lovelace", "initials": "AL", "dateIso": "2026-01-01T00:00:00.000Z" }
+              }
+            ]
+          }
+        ]
+      }
     }'
 ```
 


### PR DESCRIPTION
Documents the new optional `comments` request argument on the DOCX export REST API (`POST /v2/convert/export/docx` and the generic `/export`), shipped in Convert v2.30.0 (TT-692).

## Changes
- Added a `comments` row to the **Body** parameter table.
- New **Comments** section: payload shape (`threads[].id/resolvedAt/comments[].{id,content,data}`), how threads anchor to `inlineThread` / `blockThread` marks via `data-thread-id`, and a cURL example.
- Mentioned comment threads in the intro feature list.

Backward compatible: `comments` is optional and omitting it exports with no comments.

Pairs with the Convert service MR: https://git.ueberlab.com/tiptap/tiptap-convert-v2/-/merge_requests/181