### PR TITLE
docs(conversion): document import DOCX commentThreads + documentName reconciliation

### DIFF
--- a/src/content/conversion/import/docx/rest-api.mdx
+++ b/src/content/conversion/import/docx/rest-api.mdx
@@ -6,9 +6,9 @@ tags:
   - type: version
     label: v2.25.0
 meta:
-    title: Import DOCX REST API | Tiptap Conversion
-    description: Learn how to import .docx files into Tiptap JSON format via the Conversion REST API.
-    category: Conversion
+  title: Import DOCX REST API | Tiptap Conversion
+  description: Learn how to import .docx files into Tiptap JSON format via the Conversion REST API.
+  category: Conversion
 ---
 
 import { Callout } from '@/components/ui/Callout'
@@ -18,12 +18,14 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 <EnterpriseCalloutAuto variant="docx" renderMode="sidebar" disableWaitlist />
 
 <Requirements>
-    <RequirementItem label="1. Activate trial or subscribe">
-        Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start plan](https://cloud.tiptap.dev/v2/billing) in your account.
-    </RequirementItem>
-    <RequirementItem label="2. Configure Convert app">
-       To use the Convert REST API retrieve your App ID and Convert secret from [your dashboard](https://cloud.tiptap.dev/v2/cloud/convert).
-    </RequirementItem>
+  <RequirementItem label="1. Activate trial or subscribe">
+    Start a [free trial](https://cloud.tiptap.dev/v2?trial=true) or [subscribe to the Start
+    plan](https://cloud.tiptap.dev/v2/billing) in your account.
+  </RequirementItem>
+  <RequirementItem label="2. Configure Convert app">
+    To use the Convert REST API retrieve your App ID and Convert secret from [your
+    dashboard](https://cloud.tiptap.dev/v2/cloud/convert).
+  </RequirementItem>
 </Requirements>
 
 The DOCX import API converts `.docx` files into Tiptap's JSON format. It uses the same conversion service as the [editor extension](/conversion/import/docx/editor-extension) and produces identical content output.
@@ -31,10 +33,9 @@ The DOCX import API converts `.docx` files into Tiptap's JSON format. It uses th
 The REST API is the better choice when you need server-side processing, access to footnote or endnote data (which the extension does not surface), or raw JSON without schema filtering. If you want the content loaded directly into a Tiptap editor with headers and footers auto-applied, use the [editor extension](/conversion/import/docx/editor-extension) instead.
 
 <Callout title="Review the postman collection" variant="hint">
-    You can also experiment with the Document Conversion API by heading over to our [Postman
-    Collection](https://www.postman.com/tiptap-platform/workspace/tiptap-workspace/collection/33042171-bcc93ecb-8bad-4484-8cb0-d995ee23ae60).
+  You can also experiment with the Document Conversion API by heading over to our [Postman
+  Collection](https://www.postman.com/tiptap-platform/workspace/tiptap-workspace/collection/33042171-bcc93ecb-8bad-4484-8cb0-d995ee23ae60).
 </Callout>
-
 
 ## Import DOCX
 
@@ -43,6 +44,7 @@ The REST API is the better choice when you need server-side processing, access t
 The `/v2/convert/import/docx` endpoint converts `docx` files into Tiptap's JSON format. Users can `POST` documents to this endpoint and use various parameters to customize how different document elements are handled during the conversion process.
 
 ### Example (cURL)
+
 ```bash
 curl -X POST "https://api.tiptap.dev/v2/convert/import/docx" \
     -H "Authorization: Bearer YOUR_TOKEN" \
@@ -54,7 +56,8 @@ curl -X POST "https://api.tiptap.dev/v2/convert/import/docx" \
 ```
 
 <Callout title="Subscription required" variant="warning">
-    This endpoint requires a valid Tiptap subscription. For more details review our [pricing page](https://tiptap.dev/pricing).
+  This endpoint requires a valid Tiptap subscription. For more details review our [pricing
+  page](https://tiptap.dev/pricing).
 </Callout>
 
 ### Required headers
@@ -66,15 +69,16 @@ curl -X POST "https://api.tiptap.dev/v2/convert/import/docx" \
 
 ### Body
 
-| Name                     | Type     | Description                                                                                                                  |
-| ------------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `file`                   | `File`   | The file to convert                                                                                                          |
-| `imageUploadConfig`      | `JSON string` | A JSON object configuring image uploads. Contains `url` (required), and optionally `headers`, `method`, and `queryParams`. See the [editor extension docs](/conversion/import/docx/editor-extension#image-upload-configuration) for the full schema. |
-| `prosemirrorNodes`       | `Object string` | Custom node mapping for the conversion, [see more info](/conversion/import/docx/custom-node-mapping).       |
-| `prosemirrorMarks`       | `Object string` | Custom mark mapping for the conversion, [see more info](/conversion/import/docx/custom-mark-mapping)        |
-| `verbose` | `string \| number` | A configuration property to help you control the level of diagnostic output during the import process. This is especially useful for debugging or for getting more insight into what happens during conversion. See more at [Verbose output](#import-verbose-output) |
-| `extractCssStyles` | `"true" \| "false"` | **Experimental.** When `"true"`, the response includes a `cssStyles` field with the DOCX style catalog translated to CSS-compatible key/value pairs. Defaults to `"false"`. See [CSS style extraction](#css-style-extraction-experimental) for the output shape and caveats. |
-| `placeholders` | `JSON string` | Opt-in translation of Word `PAGE` / `NUMPAGES` field codes in headers and footers to canonical `{page}` / `{numpages}` text tokens. Send `{}` (empty object) to enable with wire defaults, `{ "page"?: string, "total"?: string }` to enable with a rename map (e.g. `{"total":"pages"}` makes `NUMPAGES` come back as `{pages}`), or `false` to explicitly disable. Omitted (default) keeps Word's cached display value as plain text. Mirrors the editor's `Pages.configure({ placeholders })` option; the editor extension forwards it here automatically. See [Page-number fields](#page-number-fields). |
+| Name                | Type                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| ------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `file`              | `File`              | The file to convert                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `imageUploadConfig` | `JSON string`       | A JSON object configuring image uploads. Contains `url` (required), and optionally `headers`, `method`, and `queryParams`. See the [editor extension docs](/conversion/import/docx/editor-extension#image-upload-configuration) for the full schema.                                                                                                                                                                                                                                                                                                                                                         |
+| `prosemirrorNodes`  | `Object string`     | Custom node mapping for the conversion, [see more info](/conversion/import/docx/custom-node-mapping).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `prosemirrorMarks`  | `Object string`     | Custom mark mapping for the conversion, [see more info](/conversion/import/docx/custom-mark-mapping)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `verbose`           | `string \| number`  | A configuration property to help you control the level of diagnostic output during the import process. This is especially useful for debugging or for getting more insight into what happens during conversion. See more at [Verbose output](#import-verbose-output)                                                                                                                                                                                                                                                                                                                                         |
+| `extractCssStyles`  | `"true" \| "false"` | **Experimental.** When `"true"`, the response includes a `cssStyles` field with the DOCX style catalog translated to CSS-compatible key/value pairs. Defaults to `"false"`. See [CSS style extraction](#css-style-extraction-experimental) for the output shape and caveats.                                                                                                                                                                                                                                                                                                                                 |
+| `placeholders`      | `JSON string`       | Opt-in translation of Word `PAGE` / `NUMPAGES` field codes in headers and footers to canonical `{page}` / `{numpages}` text tokens. Send `{}` (empty object) to enable with wire defaults, `{ "page"?: string, "total"?: string }` to enable with a rename map (e.g. `{"total":"pages"}` makes `NUMPAGES` come back as `{pages}`), or `false` to explicitly disable. Omitted (default) keeps Word's cached display value as plain text. Mirrors the editor's `Pages.configure({ placeholders })` option; the editor extension forwards it here automatically. See [Page-number fields](#page-number-fields). |
+| `documentName`      | `String`            | Target Tiptap Collaboration document name. When provided on a request whose token grants `Documents:Write` on it, the service reconciles imported comment threads against the Document Server so they are live on import. See [Comments](#comments-in-the-response). Optional; ignored when the token lacks the permission or the environment has no Document Server.                                                                                                                                                                                                                                        |
 
 ### Import verbose output
 
@@ -83,13 +87,14 @@ The DOCX import extension provides a `verbose` configuration property to help yo
 The `verbose` property is a bitmask number that determines which types of log messages are emitted. The extension uses the following levels:
 
 | Value | Level   | Description                |
-|-------|---------|----------------------------|
+| ----- | ------- | -------------------------- |
 | 1     | `log`   | General informational logs |
 | 2     | `warn`  | Warnings                   |
 | 4     | `error` | Errors                     |
 
 <Callout title="Verbose bitmask">
-  You can combine levels by adding their values together. For example, `verbose: 3` will enable both `log` (1) and `warn` (2) messages.
+  You can combine levels by adding their values together. For example, `verbose: 3` will enable both
+  `log` (1) and `warn` (2) messages.
 </Callout>
 
 The verbose output will give you, along the `data` property, one more property called `logs`, which will contain `info`, `warn`, and `error` properties, each of them being an array with all of the information related to that specific verbosity.
@@ -129,17 +134,17 @@ The import API extracts headers and footers from `.docx` files. When the documen
 
 ### Response fields
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `content` | `Object` | The main document body as Tiptap JSON |
-| `header` | `Object \| null` | Default header content as Tiptap JSON |
-| `footer` | `Object \| null` | Default footer content as Tiptap JSON |
-| `headerFirstPage` | `Object \| null` | First page header (when "Different First Page" is enabled in Word) |
-| `footerFirstPage` | `Object \| null` | First page footer (when "Different First Page" is enabled in Word) |
-| `headerOdd` | `Object \| null` | Odd page header (when "Different Odd & Even Pages" is enabled in Word) |
-| `footerOdd` | `Object \| null` | Odd page footer (when "Different Odd & Even Pages" is enabled in Word) |
-| `headerEven` | `Object \| null` | Even page header (when "Different Odd & Even Pages" is enabled in Word) |
-| `footerEven` | `Object \| null` | Even page footer (when "Different Odd & Even Pages" is enabled in Word) |
+| Field             | Type             | Description                                                             |
+| ----------------- | ---------------- | ----------------------------------------------------------------------- |
+| `content`         | `Object`         | The main document body as Tiptap JSON                                   |
+| `header`          | `Object \| null` | Default header content as Tiptap JSON                                   |
+| `footer`          | `Object \| null` | Default footer content as Tiptap JSON                                   |
+| `headerFirstPage` | `Object \| null` | First page header (when "Different First Page" is enabled in Word)      |
+| `footerFirstPage` | `Object \| null` | First page footer (when "Different First Page" is enabled in Word)      |
+| `headerOdd`       | `Object \| null` | Odd page header (when "Different Odd & Even Pages" is enabled in Word)  |
+| `footerOdd`       | `Object \| null` | Odd page footer (when "Different Odd & Even Pages" is enabled in Word)  |
+| `headerEven`      | `Object \| null` | Even page header (when "Different Odd & Even Pages" is enabled in Word) |
+| `footerEven`      | `Object \| null` | Even page footer (when "Different Odd & Even Pages" is enabled in Word) |
 
 ### Example response
 
@@ -234,10 +239,10 @@ The import API extracts footnotes and endnotes from `.docx` files. When the docu
 
 ### Response fields
 
-| Field | Type | Description |
-|-------|------|-------------|
+| Field       | Type     | Description                                                                                                    |
+| ----------- | -------- | -------------------------------------------------------------------------------------------------------------- |
 | `footnotes` | `Object` | An object keyed by footnote ID, where each value is a Tiptap JSON document (`{ type: "doc", content: [...] }`) |
-| `endnotes` | `Object` | An object keyed by endnote ID, where each value is a Tiptap JSON document (`{ type: "doc", content: [...] }`) |
+| `endnotes`  | `Object` | An object keyed by endnote ID, where each value is a Tiptap JSON document (`{ type: "doc", content: [...] }`)  |
 
 Documents without footnotes or endnotes return empty objects (`{}`), so existing integrations are unaffected.
 
@@ -297,14 +302,90 @@ Inline references in the document body are represented as `footnoteReference` an
 }
 ```
 
+## Comments in the response
+
+The import API extracts comment threads from `.docx` files. When the document contains comments, the response `data` object includes a `commentThreads` array. The document body carries `inlineThread` marks (and `blockThread` nodes) whose `data-thread-id` matches each thread's `id`, so you can wire each thread back to the text it annotates.
+
+### Response fields
+
+| Field                        | Type      | Description                                                                                          |
+| ---------------------------- | --------- | ---------------------------------------------------------------------------------------------------- |
+| `commentThreads`             | `Array`   | One entry per comment thread. Empty (or omitted) when the document has no comments.                  |
+| `commentThreads[].id`        | `String`  | Thread id. Matches the `data-thread-id` on the thread's `inlineThread` / `blockThread` in `content`. |
+| `commentThreads[].durableId` | `String`  | Word-stable durable id, when present.                                                                |
+| `commentThreads[].resolved`  | `Boolean` | Whether the thread is resolved.                                                                      |
+| `commentThreads[].messages`  | `Array`   | The thread's messages, root first, then replies by date ascending.                                   |
+| `messages[].wId`             | `String`  | Raw DOCX `w:id` of the comment.                                                                      |
+| `messages[].id`              | `String`  | Document Server-minted comment id. Present only after reconciliation (see below).                    |
+| `messages[].durableId`       | `String`  | Normalized durable id, when present.                                                                 |
+| `messages[].body`            | `Object`  | The message body as Tiptap JSON.                                                                     |
+| `messages[].data`            | `Object`  | Author and date metadata: `author`, `initials?`, `providerId?`, `userId?`, `dateIso?`, `dateUtc?`.   |
+
+Documents without comments return an empty `commentThreads` array, so existing integrations are unaffected. Both `/import/docx` and the generic `/import` return the same data.
+
+### Reconciliation against the Document Server
+
+By default the returned thread and message ids are derived from the DOCX, and the thread `id` lines up with the `data-thread-id` markers in `content` so a client can persist the threads itself.
+
+Pass `documentName` on a request whose token grants `Documents:Write` on that document to have the service reconcile the imported comments against the Document Server: it creates or updates the threads there, then rewrites both the returned `commentThreads` and the body markers to the server-minted ids. The result is live comments on import, with `messages[].id` populated. Reconciliation is skipped (and the DOCX-derived ids returned unchanged) when `documentName` is absent, the token lacks `Documents:Write`, or the environment exposes no Document Server.
+
+### Example response
+
+```json
+{
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "paragraph",
+          "content": [
+            {
+              "type": "text",
+              "text": "Reviewed text",
+              "marks": [{ "type": "inlineThread", "attrs": { "data-thread-id": "abc123" } }]
+            }
+          ]
+        }
+      ]
+    },
+    "commentThreads": [
+      {
+        "id": "abc123",
+        "resolved": false,
+        "messages": [
+          {
+            "wId": "0",
+            "body": {
+              "type": "doc",
+              "content": [
+                {
+                  "type": "paragraph",
+                  "content": [{ "type": "text", "text": "Please cite a source." }]
+                }
+              ]
+            },
+            "data": {
+              "author": "Ada Lovelace",
+              "initials": "AL",
+              "dateIso": "2026-01-01T10:30:00Z",
+              "dateUtc": "2026-01-01T10:30:00Z"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
 ## CSS style extraction (experimental)
 
 <Callout title="Experimental feature" variant="warning">
-  `extractCssStyles` is opt-in and experimental. The shape of the response may
-  change without notice. Pin exact client versions if you depend on it, and
-  read the [CSS injection documentation](/conversion/import/docx/css-injection)
-  for the full list of supported selectors, CSS properties, and known
-  limitations.
+  `extractCssStyles` is opt-in and experimental. The shape of the response may change without
+  notice. Pin exact client versions if you depend on it, and read the [CSS injection
+  documentation](/conversion/import/docx/css-injection) for the full list of supported selectors,
+  CSS properties, and known limitations.
 </Callout>
 
 Pass `extractCssStyles=true` on the request to have the response include a `cssStyles` field. The field contains the DOCX default-style catalog translated to CSS-compatible key/value pairs, keyed by CSS selector.
@@ -321,8 +402,8 @@ curl -X POST "https://api.tiptap.dev/v2/convert/import/docx" \
 
 ### Response field
 
-| Field | Type | Description |
-|-------|------|-------------|
+| Field       | Type     | Description                                                                                                                                                                                                                                             |
+| ----------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `cssStyles` | `Object` | An object keyed by CSS selector, where each value is an object of CSS properties. Empty (`{}`) when the document has no extractable default styles. The field is omitted from the response entirely when `extractCssStyles` is not set or is `"false"`. |
 
 ### Supported selectors
@@ -395,35 +476,35 @@ You can similarly adjust headings, lists, marks like bold or italic, and more.
 
 #### Default nodes
 
-| Name             | Description                                                          |
-| ---------------- | -------------------------------------------------------------------- |
-| `paragraph`      | Defines which ProseMirror type is used for paragraph conversion      |
-| `heading`        | Defines which ProseMirror type is used for heading conversion        |
-| `blockquote`     | Defines which ProseMirror type is used for blockquote conversion     |
-| `codeblock`      | Defines which ProseMirror type is used for codeblock conversion      |
-| `bulletlist`     | Defines which ProseMirror type is used for bulletList conversion     |
-| `orderedlist`    | Defines which ProseMirror type is used for orderedList conversion    |
-| `listitem`       | Defines which ProseMirror type is used for listItem conversion       |
-| `hardbreak`      | Defines which ProseMirror type is used for hardbreak conversion      |
-| `horizontalrule` | Defines which ProseMirror type is used for horizontalRule conversion |
-| `table`          | Defines which ProseMirror type is used for table conversion          |
-| `tablecell`      | Defines which ProseMirror type is used for tableCell conversion      |
-| `tableheader`    | Defines which ProseMirror type is used for tableHeader conversion    |
-| `tablerow`       | Defines which ProseMirror type is used for tableRow conversion       |
-| `image`          | Defines which ProseMirror mark is used for image conversion          |
+| Name                | Description                                                              |
+| ------------------- | ------------------------------------------------------------------------ |
+| `paragraph`         | Defines which ProseMirror type is used for paragraph conversion          |
+| `heading`           | Defines which ProseMirror type is used for heading conversion            |
+| `blockquote`        | Defines which ProseMirror type is used for blockquote conversion         |
+| `codeblock`         | Defines which ProseMirror type is used for codeblock conversion          |
+| `bulletlist`        | Defines which ProseMirror type is used for bulletList conversion         |
+| `orderedlist`       | Defines which ProseMirror type is used for orderedList conversion        |
+| `listitem`          | Defines which ProseMirror type is used for listItem conversion           |
+| `hardbreak`         | Defines which ProseMirror type is used for hardbreak conversion          |
+| `horizontalrule`    | Defines which ProseMirror type is used for horizontalRule conversion     |
+| `table`             | Defines which ProseMirror type is used for table conversion              |
+| `tablecell`         | Defines which ProseMirror type is used for tableCell conversion          |
+| `tableheader`       | Defines which ProseMirror type is used for tableHeader conversion        |
+| `tablerow`          | Defines which ProseMirror type is used for tableRow conversion           |
+| `image`             | Defines which ProseMirror mark is used for image conversion              |
 | `footnoteReference` | Defines which ProseMirror type is used for footnote reference conversion |
 | `endnoteReference`  | Defines which ProseMirror type is used for endnote reference conversion  |
 
 #### Default marks
 
-| Name             | Description                                                          |
-| ---------------- | -------------------------------------------------------------------- |
-| `bold`           | Defines which ProseMirror mark is used for bold conversion           |
-| `italic`         | Defines which ProseMirror mark is used for italic conversion         |
-| `underline`      | Defines which ProseMirror mark is used for underline conversion      |
-| `strikethrough`  | Defines which ProseMirror mark is used for strikethrough conversion  |
-| `link`           | Defines which ProseMirror mark is used for link conversion           |
-| `code`           | Defines which ProseMirror mark is used for code conversion           |
+| Name            | Description                                                         |
+| --------------- | ------------------------------------------------------------------- |
+| `bold`          | Defines which ProseMirror mark is used for bold conversion          |
+| `italic`        | Defines which ProseMirror mark is used for italic conversion        |
+| `underline`     | Defines which ProseMirror mark is used for underline conversion     |
+| `strikethrough` | Defines which ProseMirror mark is used for strikethrough conversion |
+| `link`          | Defines which ProseMirror mark is used for link conversion          |
+| `code`          | Defines which ProseMirror mark is used for code conversion          |
 
 ## Support & Limitations
 


### PR DESCRIPTION
Documents two existing-but-undocumented comment capabilities of the DOCX import REST API (`POST /v2/convert/import/docx` and the generic `/import`).

## Changes
- Added `documentName` to the request **Body** table (optional; enables comment reconciliation; requires a token with `Documents:Write` on the target document).
- New **Comments in the response** section:
  - `data.commentThreads` shape (`id`, `durableId?`, `resolved`, `messages[]` with `wId`, `id?`, `durableId?`, `body`, `data`).
  - How thread `id` lines up with the body's `inlineThread` / `blockThread` `data-thread-id`.
  - Reconciliation behavior (server-minted ids when `documentName` + `Documents:Write` are present; DOCX-derived ids otherwise).
  - JSON example.

These document existing service behavior; complements the export `comments` docs (#867) and the Convert export work (TT-692, MR !181).