### PR TITLE
feat: expand Hocuspocus documentation with v4 updates

### DIFF
--- a/src/content/hocuspocus/provider/configuration.mdx
+++ b/src/content/hocuspocus/provider/configuration.mdx
@@ -20,6 +20,7 @@ meta:
 | `awareness`         | Awareness object, by default attached to the passed Y.js document.                                                | `new Awareness()`                   |
 | `forceSyncInterval` | Ask the server every x ms for updates.                                                                            | `false`                             |
 | `sessionAwareness`  | Embed a unique `sessionId` in the document name of every message, allowing multiple providers with the same document name on one WebSocket. Keep `false` when connecting to a v3 server. Requires a v4 server. | `false`                             |
+| `flushDelay`        | Batch outgoing document and awareness updates over a short window (in ms) instead of sending one message per change. Reduces websocket traffic during heavy editing. The added latency is capped at `flushDelay`, so keep it small (e.g. `500`). Set to `false` to send every change immediately. See [Batching outgoing updates](#batching-outgoing-updates). | `false`                             |
 
 ### HocuspocusProviderWebsocket
 
@@ -41,3 +42,21 @@ meta:
 ## Usage
 
 There is not much required to set up the provider, a simple example can be found in [Getting started](/hocuspocus/provider/install)
+
+## Batching outgoing updates
+
+By default the provider sends one websocket message per change. During heavy editing — fast typing, large pastes, or rapid cursor movement — this can produce a lot of small messages. Set `flushDelay` to a number of milliseconds to batch outgoing document and awareness updates over a short window:
+
+```js
+import { HocuspocusProvider } from '@hocuspocus/provider'
+
+const provider = new HocuspocusProvider({
+  url: 'ws://127.0.0.1:1234',
+  name: 'example-document',
+  flushDelay: 500,
+})
+```
+
+Within each window, buffered Yjs updates are merged with `Y.mergeUpdates` into a single message, and awareness collapses to the latest state of each changed client. The window is a fixed batch rather than a resetting debounce, so the added latency is capped at `flushDelay` even while the user keeps typing — keep it small (e.g. `500`) to avoid delaying what other clients see.
+
+You can force everything buffered for the current window to be sent immediately by calling `provider.flushPendingUpdates()`.

--- a/src/content/hocuspocus/provider/react.mdx
+++ b/src/content/hocuspocus/provider/react.mdx
@@ -83,6 +83,8 @@ Creates a document-specific `HocuspocusProvider` that attaches to the shared Web
 | `name`     | `string`                                                            | Document name. Required.                                                                                |
 | `document` | `Y.Doc`                                                             | Optional — bring your own Y.Doc. If omitted, one is created for you.                                    |
 | `token`    | `string \| (() => string) \| (() => Promise<string>)`               | JWT (or async resolver) sent to the server for authentication.                                          |
+| `sessionAwareness` | `boolean`                                                   | Enable session-aware multiplexing so multiple rooms with the same document name can share one WebSocket. Only set `true` when connecting to a v4 server. Default `false`. See [`sessionAwareness`](/hocuspocus/provider/configuration). |
+| `flushDelay` | `false \| number`                                                 | Batch outgoing document and awareness updates over a short window (in ms) to reduce websocket traffic during heavy editing. Default `false`. See [Batching outgoing updates](/hocuspocus/provider/configuration#batching-outgoing-updates). |
 | `onOpen`, `onConnect`, `onClose`, `onDisconnect`, `onStatus`, `onSynced`, `onUnsyncedChanges`, `onMessage`, `onOutgoingMessage`, `onStateless`, `onAuthenticated`, `onAuthenticationFailed`, `onAwarenessUpdate`, `onAwarenessChange`, `onDestroy` | Function | Optional handlers for each [provider event](/hocuspocus/provider/events). |
 
 Changing `name`, `document`, `token`, or the upstream websocket provider recreates the underlying provider. Everything else is kept stable.

--- a/src/content/hocuspocus/server/configuration.mdx
+++ b/src/content/hocuspocus/server/configuration.mdx
@@ -21,6 +21,9 @@ There are only a few settings to pass for now. Most things are controlled throug
 | `maxDebounce`      | Makes sure to call onStoreDocument at least in the given amount of time (ms).                                                        | `10000 (= 10s)` |
 | `quiet`            | By default, the servers show a start screen. If passed false, the server will start quietly.                                         | `false`         |
 | `websocketOptions` | Options forwarded to the underlying WebSocket server (e.g. `{ maxPayload: 1024 * 1024 }`). Moved inside the config object in v4.     | `{}`            |
+| `maxUnauthenticatedQueueSize`     | Maximum number of bytes buffered (across all documents) for a single connection while it is still unauthenticated. The connection is closed when exceeded. See [Pre-authentication resource limits](#pre-authentication-resource-limits). | `5242880 (= 5 MiB)` |
+| `maxUnauthenticatedQueueMessages` | Maximum number of messages buffered (across all documents) for a single connection while it is still unauthenticated. The connection is closed when exceeded.                                                                            | `1000`              |
+| `maxPendingDocuments`             | Maximum number of distinct documents a single connection may open before any of them is authenticated. The connection is closed when exceeded.                                                                                          | `100`               |
 
 ## Usage
 
@@ -65,3 +68,25 @@ const server = new Server<MyContext>({
 ```
 
 The generic defaults to `any`, so existing code without explicit typing continues to work.
+
+## Pre-authentication resource limits
+
+Messages received before authentication completes are buffered in memory per connection. Without a bound, an unauthenticated client could exhaust server memory (see [GHSA-xwhh-v746-pj9m](https://github.com/ueberdosis/hocuspocus/security/advisories/GHSA-xwhh-v746-pj9m)). Three settings cap this buffering, and the connection is closed as soon as any limit is exceeded:
+
+- `maxUnauthenticatedQueueSize` (default 5 MiB) — total buffered bytes per connection.
+- `maxUnauthenticatedQueueMessages` (default 1000) — total buffered messages per connection.
+- `maxPendingDocuments` (default 100) — distinct not-yet-authenticated documents a single connection may have open at once. Each pending document holds its own queue and hook payload, so this stops a client from fanning out across many document names while staying under the per-connection queue limits.
+
+In addition, the idle `timeout` is enforced as an *absolute* pre-authentication deadline (measured from when the connection was established and not refreshed by inbound traffic) until the connection authenticates its first document. After the first successful authentication, `timeout` reverts to the normal idle behavior for the rest of the socket's life.
+
+```js
+import { Server } from '@hocuspocus/server'
+
+const server = new Server({
+  maxUnauthenticatedQueueSize: 5 * 1024 * 1024, // 5 MiB
+  maxUnauthenticatedQueueMessages: 1000,
+  maxPendingDocuments: 100,
+})
+
+server.listen()
+```

--- a/src/content/hocuspocus/server/examples.mdx
+++ b/src/content/hocuspocus/server/examples.mdx
@@ -423,3 +423,13 @@ await docConnection.transact((doc) => {
 
 await docConnection.disconnect()
 ```
+
+### Keeping the document warm after disconnect
+
+By default `disconnect()` persists the document immediately and unloads it from memory once it resolves. If you expect to open another direct connection to the same document shortly after, pass `unloadImmediately: false`. The store is then scheduled via the debounce timer and the document is kept warm in memory, so the follow-up connection reuses it and repeated writes coalesce — mirroring how WebSocket connections behave on close.
+
+```typescript
+await docConnection.disconnect({ unloadImmediately: false })
+```
+
+Note that with `unloadImmediately: false`, persistence is no longer guaranteed to have completed by the time `disconnect()` resolves.

--- a/src/content/hocuspocus/server/hooks.mdx
+++ b/src/content/hocuspocus/server/hooks.mdx
@@ -34,6 +34,7 @@ By way of illustration, if a user isn’t allowed to connect: Just throw an erro
 | Hook                       | Description                               | Link                                                  |
 | -------------------------- |-------------------------------------------|-------------------------------------------------------|
 | `beforeHandleMessage`      | Before handling a message                 | [Read more](/hocuspocus/server/hooks#before-handle-message)      |
+| `afterHandleMessage`       | After an inbound message has been handled | [Read more](/hocuspocus/server/hooks#after-handle-message)       |
 | `beforeHandleAwareness`    | Before applying an inbound awareness update | [Read more](/hocuspocus/server/hooks#before-handle-awareness)  |
 | `onConnect`                | When a connection is established          | [Read more](/hocuspocus/server/hooks#on-connect)                 |
 | `connected`                | After a connection has been establied     | [Read more](/hocuspocus/server/hooks#connected)                  |
@@ -127,6 +128,51 @@ const server = new Server({
 
       throw error;
     }
+  },
+});
+
+server.listen();
+```
+
+### afterHandleMessage
+
+The `afterHandleMessage` hooks are called after an inbound message has been handled — that is, after the Yjs update has been applied to the document. It is the counterpart to `beforeHandleMessage`. The hook fires whether the apply resolved or threw, but it does **not** fire when `beforeHandleMessage` rejected the message (in that case the message is never applied).
+
+Use it to react to applied updates, e.g. for metrics, logging, or triggering side effects once the document state has changed.
+
+**Hook payload**
+
+The `data` passed to the `afterHandleMessage` hook has the following attributes:
+
+```js
+import { URLSearchParams } from "url";
+import { Doc } from "yjs";
+import type { Connection } from "@hocuspocus/server";
+
+const data = {
+  clientsCount: number,
+  context: any,
+  document: Doc,
+  documentName: string,
+  instance: Hocuspocus,
+  requestHeaders: Headers,
+  requestParameters: URLSearchParams,
+  update: Uint8Array,
+  socketId: string,
+  connection: Connection,
+};
+```
+
+Context contains the data provided in former `onConnect` hooks.
+
+**Example**
+
+```js
+import { Server } from "@hocuspocus/server";
+
+const server = new Server({
+  async afterHandleMessage({ documentName, context }) {
+    console.log(`Applied an update to "${documentName}" for ${context.user?.name}`);
   },
 });
 


### PR DESCRIPTION
- Document `unloadImmediately` option for `disconnect()` in server examples.
- Add pre-authentication resource limits (`maxUnauthenticatedQueueSize`, `maxUnauthenticatedQueueMessages`, `maxPendingDocuments`) in server configuration.
- Introduce `afterHandleMessage` hook with usage examples.
- Add provider options `sessionAwareness` and `flushDelay` for batch updates in v4.