### PR TITLE
Remove invalid property name

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
@@ -248,8 +248,7 @@ Reads document content and returns workflow-ready content.
 Request body:
 
 - `range?` (`{ from: number, to: number }`, optional, default: entire document)
-- `editorContext` (`EditorContext`, required unless `schemaAwarenessData` is provided)
-- `schemaAwarenessData?` (`SchemaAwarenessData`, optional, deprecated): Use `editorContext` instead. Supported for backward compatibility.
+- `schemaAwarenessData` (`SchemaAwarenessData`, required)
 - `format?` (`'json' | 'shorthand'`, optional, default: `'json'`)
 - `chunkSize?` (`number`, optional, default: `32000`)
 - `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/server-ai-toolkit/api-reference/review-options), optional, default: `{ mode: 'disabled' }`)
@@ -274,7 +273,7 @@ curl --location 'BASE_URL/v3/ai/toolkit/read/read-document' \
   --header 'Authorization: Bearer YOUR_JWT_TOKEN' \
   --header 'X-App-Id: YOUR_APP_ID' \
   --data '{
-    "editorContext": { /* editor context data */ },
+    "schemaAwarenessData": { /* schema awareness data */ },
     "format": "shorthand",
     "reviewOptions": {
       "mode": "disabled"
@@ -297,8 +296,7 @@ Reads the selection and returns either a selection payload or an explicit empty 
 Request body:
 
 - `range` (`{ from: number, to: number }`, required)
-- `editorContext` (`EditorContext`, required unless `schemaAwarenessData` is provided)
-- `schemaAwarenessData?` (`SchemaAwarenessData`, optional, deprecated): Use `editorContext` instead. Supported for backward compatibility.
+- `schemaAwarenessData` (`SchemaAwarenessData`, required)
 - `format?` (`'json' | 'shorthand'`, optional, default: `'json'`)
 - `chunkSize?` (`number`, optional, default: `32000`)
 - `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/server-ai-toolkit/api-reference/review-options), optional, default: `{ mode: 'disabled' }`)
@@ -328,7 +326,7 @@ curl --location 'BASE_URL/v3/ai/toolkit/read/read-selection' \
   --header 'Authorization: Bearer YOUR_JWT_TOKEN' \
   --header 'X-App-Id: YOUR_APP_ID' \
   --data '{
-    "editorContext": { /* editor context data */ },
+    "schemaAwarenessData": { /* schema awareness data */ },
     "range": { "from": 10, "to": 42 },
     "format": "shorthand",
     "experimental_documentOptions": {
@@ -347,8 +345,7 @@ Reads all threads and comments for a Tiptap Cloud document.
 
 Request body:
 
-- `editorContext` (`EditorContext`, required unless `schemaAwarenessData` is provided)
-- `schemaAwarenessData?` (`SchemaAwarenessData`, optional, deprecated): Use `editorContext` instead. Supported for backward compatibility.
+- `schemaAwarenessData` (`SchemaAwarenessData`, required)
 - `format` (`'json' | 'shorthand'`, required)
 - `experimental_documentOptions` (`{ documentId: string, userId?: string, field?: string | null }`, required)
 
@@ -368,7 +365,7 @@ curl --location 'BASE_URL/v3/ai/toolkit/read/threads' \
   --header 'Authorization: Bearer YOUR_JWT_TOKEN' \
   --header 'X-App-Id: YOUR_APP_ID' \
   --data '{
-    "editorContext": { /* editor context data */ },
+    "schemaAwarenessData": { /* schema awareness data */ },
     "format": "shorthand",
     "experimental_documentOptions": {
       "documentId": "your-document-id",
@@ -387,8 +384,7 @@ Request body:
 
 - `input` (`unknown`, required): Generated insert-content payload
 - `range?` (`{ from: number, to: number }`, optional)
-- `editorContext` (`EditorContext`, required unless `schemaAwarenessData` is provided)
-- `schemaAwarenessData?` (`SchemaAwarenessData`, optional, deprecated): Use `editorContext` instead. Supported for backward compatibility.
+- `schemaAwarenessData` (`SchemaAwarenessData`, required)
 - `format?` (`'json' | 'shorthand'`, optional, default: `'json'`)
 - `chunkSize?` (`number`, optional, default: `32000`)
 - `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/server-ai-toolkit/api-reference/review-options), optional, default: `{ mode: 'disabled' }`)
@@ -412,7 +408,7 @@ curl --location 'BASE_URL/v3/ai/toolkit/execute-workflow/insert-content' \
   --header 'Authorization: Bearer YOUR_JWT_TOKEN' \
   --header 'X-App-Id: YOUR_APP_ID' \
   --data '{
-    "editorContext": { /* editor context data */ },
+    "schemaAwarenessData": { /* schema awareness data */ },
     "input": "This is the replacement content.",
     "range": { "from": 10, "to": 42 },
     "format": "shorthand",
@@ -435,8 +431,7 @@ POST /v3/ai/toolkit/execute-workflow/tiptap-edit
 Request body:
 
 - `input` (`object`, required): Edit workflow operations
-- `editorContext` (`EditorContext`, required unless `schemaAwarenessData` is provided)
-- `schemaAwarenessData?` (`SchemaAwarenessData`, optional, deprecated): Use `editorContext` instead. Supported for backward compatibility.
+- `schemaAwarenessData` (`SchemaAwarenessData`, required)
 - `format?` (`'json' | 'shorthand'`, optional, default: `'json'`)
 - `chunkSize?` (`number`, optional, default: `32000`)
 - `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/server-ai-toolkit/api-reference/review-options), optional, default: `{ mode: 'disabled' }`)
@@ -461,7 +456,7 @@ curl --location 'BASE_URL/v3/ai/toolkit/execute-workflow/tiptap-edit' \
   --header 'Authorization: Bearer YOUR_JWT_TOKEN' \
   --header 'X-App-Id: YOUR_APP_ID' \
   --data '{
-    "editorContext": { /* editor context data */ },
+    "schemaAwarenessData": { /* schema awareness data */ },
     "input": {
       "operations": [
         {
@@ -491,8 +486,7 @@ POST /v3/ai/toolkit/execute-workflow/proofreader
 Request body:
 
 - `input` (`object`, required): Proofreader operations
-- `editorContext` (`EditorContext`, required unless `schemaAwarenessData` is provided)
-- `schemaAwarenessData?` (`SchemaAwarenessData`, optional, deprecated): Use `editorContext` instead. Supported for backward compatibility.
+- `schemaAwarenessData` (`SchemaAwarenessData`, required)
 - `format` (`'shorthand'`, required)
 - `chunkSize?` (`number`, optional, default: `32000`)
 - `reviewOptions?` ([`ReviewOptions`](/content-ai/capabilities/server-ai-toolkit/api-reference/review-options), optional, default: `{ mode: 'disabled' }`)
@@ -515,7 +509,7 @@ curl --location 'BASE_URL/v3/ai/toolkit/execute-workflow/proofreader' \
   --header 'Authorization: Bearer YOUR_JWT_TOKEN' \
   --header 'X-App-Id: YOUR_APP_ID' \
   --data '{
-    "editorContext": { /* editor context data */ },
+    "schemaAwarenessData": { /* schema awareness data */ },
     "input": {
       "operations": []
     },
@@ -541,8 +535,7 @@ POST /v3/ai/toolkit/execute-workflow/threads
 Request body:
 
 - `input` (`object`, required): Thread operations
-- `editorContext` (`EditorContext`, required unless `schemaAwarenessData` is provided)
-- `schemaAwarenessData?` (`SchemaAwarenessData`, optional, deprecated): Use `editorContext` instead. Supported for backward compatibility.
+- `schemaAwarenessData` (`SchemaAwarenessData`, required)
 - `format?` (`'json' | 'shorthand'`, optional, default: `'json'`)
 - `experimental_documentOptions` (`{ documentId: string, userId?: string, field?: string | null }`, required)
 - `experimental_commentsOptions?` (`{ threadData?: Record<string, unknown>, commentData?: Record<string, unknown> }`, optional): Metadata attached to new threads and comments created by the workflow.
@@ -563,7 +556,7 @@ curl --location 'BASE_URL/v3/ai/toolkit/execute-workflow/threads' \
   --header 'Authorization: Bearer YOUR_JWT_TOKEN' \
   --header 'X-App-Id: YOUR_APP_ID' \
   --data '{
-    "editorContext": { /* editor context data */ },
+    "schemaAwarenessData": { /* schema awareness data */ },
     "input": {
       "operations": [
         {


### PR DESCRIPTION
Workflow endpoints the legacy workflow and points do not have the `editorContext` property: the documentation was incorrect. This pull request removes the `editorContext` property. 