### PR TITLE
fix(docs): repair broken HTML utility link in Hocuspocus hooks

### DIFF
--- a/.changeset/strict-worms-happen.md
+++ b/.changeset/strict-worms-happen.md
@@ -1,0 +1,5 @@
+---
+"tiptap-docs": patch
+---
+
+Fix broken HTML utility link in Hocuspocus server hooks documentation.

--- a/src/content/hocuspocus/server/hooks.mdx
+++ b/src/content/hocuspocus/server/hooks.mdx
@@ -737,7 +737,7 @@ const ydoc = TiptapTransformer.toYdoc(
 );
 ```
 
-If you want to import HTML, you have to [convert it to Tiptap-compatible JSON first](https://tiptap.dev/api/utilities/html/#generate-json-from-html)
+If you want to import HTML, you have to [convert it to Tiptap-compatible JSON first](/editor/api/utilities/html#generating-json-from-html)
 
 However, we expect you to return a Y.js document (or a raw `Uint8Array` Yjs update, since v4) from the `onLoadDocument` hook, no matter where it’s from.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the broken link reported on the Hocuspocus server hooks page.

- Updated the "convert it to Tiptap-compatible JSON first" link in `src/content/hocuspocus/server/hooks.mdx` from the legacy absolute URL `https://tiptap.dev/api/utilities/html/#generate-json-from-html` to the current docs path `/editor/api/utilities/html#generating-json-from-html`.

## Other reported broken links

### Font family combobox (`/docs/ui-components/components/font-family-combobox`)

This link appears in the UI Components sidebar rendered on the getting-started overview page. The target page and sidebar entry were added together in #866 and are already present on `main`. Production now returns `200` for this URL, so no link change is required in this repository.

### Hocuspocus blog link (`https://tiptap.dev/hocuspocus/`)

The broken link on [Tiptap Roundhouse Kick 2023](https://tiptap.dev/blog/release-notes/tiptap-roundhous-kick-2023) points to the main website path `https://tiptap.dev/hocuspocus/`, which redirects to Webflow and 404s. Blog content is not managed in `tiptap-docs`; it should be updated in the website CMS to point to `https://tiptap.dev/docs/hocuspocus/getting-started/overview`.

## Test plan

- [x] Verified `/editor/api/utilities/html#generating-json-from-html` resolves locally
- [x] Confirmed the old URL `https://tiptap.dev/api/utilities/html/` returns 404
- [x] Confirmed `/docs/ui-components/components/font-family-combobox` returns 200 on production
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-547ffba6-863c-4b5d-add5-89912fc334a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-547ffba6-863c-4b5d-add5-89912fc334a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

