### PR TITLE
fix: ad proper link to docx template in learn more callout

### DIFF
--- a/src/content/pages/getting-started/live-demo.mdx
+++ b/src/content/pages/getting-started/live-demo.mdx
@@ -38,6 +38,14 @@ This demo shows Tiptap Pages in a real word processor. It combines pagination, c
         Full screen
         <Expand className="size-3" />
       </a>
+      <span className="text-grayAlpha-300">|</span>
+      <Link
+        href="https://tiptap.dev/docs/ui-components/templates/docx-editor"
+        className="flex items-center gap-1 text-grayAlpha-600 hover:text-grayAlpha-800 font-medium whitespace-nowrap"
+      >
+        Learn more
+        <ExternalLinkIcon className="size-3" />
+      </Link>
     </>
   }
 />

--- a/src/content/pages/getting-started/overview.mdx
+++ b/src/content/pages/getting-started/overview.mdx
@@ -40,7 +40,7 @@ Tiptap Pages is a paginated editing layer for Tiptap. It adds page boundaries, p
       </a>
       <span className="text-grayAlpha-300">|</span>
       <Link
-        href="/pages/getting-started/live-demo"
+        href="https://tiptap.dev/docs/ui-components/templates/docx-editor"
         className="flex items-center gap-1 text-grayAlpha-600 hover:text-grayAlpha-800 font-medium whitespace-nowrap"
       >
         Learn more


### PR DESCRIPTION
This pull request updates the "Learn more" links in the Tiptap Pages documentation to point to the official DOCX Editor template documentation on the Tiptap website, ensuring users are directed to the most relevant and up-to-date resource.

**Documentation link updates:**

* Changed the "Learn more" link in `src/content/pages/getting-started/overview.mdx` to point to the external DOCX Editor template documentation instead of the internal live demo page.
* Added a "Learn more" link to the external DOCX Editor template documentation in `src/content/pages/getting-started/live-demo.mdx`.