### PR TITLE
Warn about extension name conflicts in Starter Kit Extension

### DIFF
--- a/src/content/editor/extensions/functionality/starterkit.mdx
+++ b/src/content/editor/extensions/functionality/starterkit.mdx
@@ -105,3 +105,26 @@ const editor = new Editor({
   ],
 })
 ```
+
+Tiptap does not allow two extensions with the same `name` property. If a custom extension has the same name as one of the extensions included in StarterKit, disable it:
+
+```js
+import { Editor, Mark } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import { Link } from '@tiptap/link'
+
+const CustomLinkExtension = Mark.create({
+  name: 'link',
+})
+
+const editor = new Editor({
+  extensions: [
+    StarterKit.configure({
+      // Disable the Link extension
+      // so it does not conflict with CustomLinkExtension
+      link: false,
+    }),
+    CustomLinkExtension,
+  ],
+})
+```

--- a/src/content/editor/extensions/functionality/starterkit.mdx
+++ b/src/content/editor/extensions/functionality/starterkit.mdx
@@ -111,7 +111,7 @@ Tiptap does not allow two extensions with the same `name` property. If a custom 
 ```js
 import { Editor, Mark } from '@tiptap/core'
 import StarterKit from '@tiptap/starter-kit'
-import { Link } from '@tiptap/link'
+import { Link } from '@tiptap/extension-link'
 
 const CustomLinkExtension = Mark.create({
   name: 'link',

--- a/src/content/editor/extensions/functionality/starterkit.mdx
+++ b/src/content/editor/extensions/functionality/starterkit.mdx
@@ -111,7 +111,7 @@ Tiptap does not allow two extensions with the same `name` property. If a custom 
 ```js
 import { Editor, Mark } from '@tiptap/core'
 import StarterKit from '@tiptap/starter-kit'
-import { Link } from '@tiptap/extension-link'
+import Link from '@tiptap/extension-link'
 
 const CustomLinkExtension = Mark.create({
   name: 'link',


### PR DESCRIPTION
Completes the work started in https://github.com/ueberdosis/tiptap-docs/pull/362

Instead of adding the warning to the link extension, add the warning to the Starter Kit extension because it applies to any extension that conflicts with the Starter Kit extension. 