### PR TITLE
feat: extend REST API docs with new endpoints and additional functionality

### DIFF
--- a/src/content/collaboration/documents/content-injection.mdx
+++ b/src/content/collaboration/documents/content-injection.mdx
@@ -75,12 +75,13 @@ This endpoint accepts a Yjs update message and applies it to the specified docum
 | `checksum` | `string` | — | Only apply the update if the document's current state matches this checksum (returned as `x-FRAGMENTNAME-checksum` in the get document response). Returns `409 Checksum mismatch` otherwise. |
 | `user` | `string` | — | User ID to associate with the change. |
 | `skipVersioning` | `1` | — | If passed, auto versioning won't be triggered by this change. |
+| `upsert` | `0` \| `1` | `0` | When `1`, the document is created if it doesn't exist yet, instead of returning `404`. |
 | `fragment` | `string` | `default` | Yjs fragment to update. You can update multiple fragments with the same content (when `format=json`) by passing multiple values: `?fragment=a&fragment=b`. |
 | `multi` | `0` \| `1` | `0` | Only used with `format=json`. When `1`, the request body is a JSON object keyed by fragment name, updating multiple fragments with different content in a single request. Only compatible with the default mode. See [Update multiple fragments with different content](#update-multiple-fragments-with-different-content). |
 | `mergeAttributes` | `0` \| `1` | `0` | Only used with `mode=attrs`. When `1`, attributes not included in the request payload are preserved. When `0` (default), missing attributes are deleted. |
 | `multiUpdates` | `true` | — | Only used with `mode=attrs` and `format=json`. Enables updating multiple nodes with different attribute values in a single request. The request body must be a JSON array of `{ where, attrs }` objects. See [Multi updates](#multi-updates). |
 
-Upon successful update, the server will return HTTP status `204`. If the document does not exist, it will return `404`, and if the payload is invalid or the update cannot be applied, it will return `422`.
+Upon successful update, the server will return HTTP status `204`. If the document does not exist, it will return `404` (unless `upsert=1` is passed, in which case the document is created), and if the payload is invalid or the update cannot be applied, it will return `422`.
 
 **Example:** `curl` command to update a document
 

--- a/src/content/collaboration/documents/content-injection.mdx
+++ b/src/content/collaboration/documents/content-injection.mdx
@@ -76,6 +76,7 @@ This endpoint accepts a Yjs update message and applies it to the specified docum
 | `user` | `string` | — | User ID to associate with the change. |
 | `skipVersioning` | `1` | — | If passed, auto versioning won't be triggered by this change. |
 | `fragment` | `string` | `default` | Yjs fragment to update. You can update multiple fragments with the same content (when `format=json`) by passing multiple values: `?fragment=a&fragment=b`. |
+| `multi` | `0` \| `1` | `0` | Only used with `format=json`. When `1`, the request body is a JSON object keyed by fragment name, updating multiple fragments with different content in a single request. Only compatible with the default mode. See [Update multiple fragments with different content](#update-multiple-fragments-with-different-content). |
 | `mergeAttributes` | `0` \| `1` | `0` | Only used with `mode=attrs`. When `1`, attributes not included in the request payload are preserved. When `0` (default), missing attributes are deleted. |
 | `multiUpdates` | `true` | — | Only used with `mode=attrs` and `format=json`. Enables updating multiple nodes with different attribute values in a single request. The request body must be a JSON array of `{ where, attrs }` objects. See [Multi updates](#multi-updates). |
 
@@ -252,6 +253,34 @@ curl --location --request PATCH 'https://YOUR_APP_ID.collab.tiptap.cloud/api/doc
       "content": [{ "type": "text", "text": "Shared content" }]
     }
   ]
+}'
+```
+
+#### Update multiple fragments with different content
+
+To update several fragments with **different** content in a single request, pass `multi=1` (with `format=json`) and send a JSON object keyed by fragment name. Each value is the full Tiptap JSON content for that fragment, and is merged into that fragment using the default mode.
+
+Unlike `?fragment=a&fragment=b` (which applies the *same* payload to each listed fragment), `multi=1` lets you send distinct content per fragment.
+
+`multi=1` only works with the default mode. It cannot be combined with `mode`, `nodeAttributeName`/`nodeAttributeValue`, `checksum`, or `multiUpdates` — doing so returns `400`. It can be combined with `user`, `skipVersioning`, and `upsert`.
+
+```bash
+curl --location --request PATCH 'https://YOUR_APP_ID.collab.tiptap.cloud/api/documents/my-doc?format=json&multi=1' \
+--header 'Authorization: YOUR_SECRET' \
+--header 'Content-Type: application/json' \
+--data '{
+  "default": {
+    "type": "doc",
+    "content": [
+      { "type": "paragraph", "content": [{ "type": "text", "text": "Text in fragment default" }] }
+    ]
+  },
+  "otherFragment": {
+    "type": "doc",
+    "content": [
+      { "type": "paragraph", "content": [{ "type": "text", "text": "Text in fragment otherFragment" }] }
+    ]
+  }
 }'
 ```
 

--- a/src/content/collaboration/documents/rest-api.mdx
+++ b/src/content/collaboration/documents/rest-api.mdx
@@ -65,7 +65,7 @@ Access the Collaboration Management API to manage your documents efficiently. Fo
 | Update Version     | PATCH      | `/api/documents/:identifier/versions/:versionId` | Update a version's name or metadata.                                                     |
 | Revert to Version  | POST       | `/api/documents/:identifier/versions/:versionId/revertTo` | Revert a document to an older version.                                        |
 | Update Document    | PATCH      | `/api/documents/:identifier`                 | Apply a Yjs update message to an existing document.                                          |
-| Replace Document   | PUT        | `/api/documents/:identifier`                 | Replace a document with a Yjs update message (same semantics as `PATCH`).                    |
+| Update Document (PUT alias) | PUT | `/api/documents/:identifier`                | Alias of the `PATCH` endpoint&mdash;applies a Yjs update message with identical behavior.    |
 | Check Document Exists | HEAD    | `/api/documents/:identifier`                 | Check whether a document exists (no response body).                                          |
 | Delete Document    | DELETE     | `/api/documents/:identifier`                 | Delete a document from the server.                                                           |
 | Delete Version     | DELETE     | `/api/documents/:identifier/versions/:versionId` | Delete a specific version of a document.                                                 |
@@ -437,13 +437,16 @@ curl --location 'https://YOUR_APP_ID.collab.tiptap.cloud/api/documents/DOCUMENT_
 POST /api/documents/:identifier/import
 ```
 
-This call imports a document (and its versions) from an archive previously created with the export endpoint. Send the archive as the raw request body. The target `:identifier` must not already exist.
+This call imports a document (and its versions) from an archive previously created with the export endpoint. Send the archive as the raw request body&mdash;the server reads the raw bytes and does not require a specific `Content-Type` header. The target `:identifier` must not already exist.
 
-The endpoint streams newline-delimited JSON (NDJSON) progress events while it works and finishes with a `done` event carrying the final status: `201` on success, `409` if a document with the target identifier already exists, `400` if the archive is malformed, or `413` if the archive exceeds the maximum allowed body size.
+Requests that fail validation are rejected with a regular HTTP status before the import starts: `409` if a document with the target identifier already exists, `413` if the archive exceeds the maximum allowed body size, or `400` if the archive is malformed.
+
+Once the import starts, the endpoint responds with HTTP status `200` (`Content-Type: application/x-ndjson`) and streams newline-delimited JSON (NDJSON) progress events while it works. The stream finishes with a `done` event whose `status` field reports the final result: `201` on success, or `409` if a conflicting document was created while the import was running. If the import fails midway, the stream ends with an `error` event carrying status `422`.
 
 ```bash
 curl --location 'https://YOUR_APP_ID.collab.tiptap.cloud/api/documents/DOCUMENT_NAME/import' \
 --header 'Authorization: YOUR_SECRET_FROM_SETTINGS_AREA' \
+--header 'Content-Type: application/zip' \
 --data-binary '@export.zip'
 ```
 

--- a/src/content/collaboration/documents/rest-api.mdx
+++ b/src/content/collaboration/documents/rest-api.mdx
@@ -65,7 +65,13 @@ Access the Collaboration Management API to manage your documents efficiently. Fo
 | Update Version     | PATCH      | `/api/documents/:identifier/versions/:versionId` | Update a version's name or metadata.                                                     |
 | Revert to Version  | POST       | `/api/documents/:identifier/versions/:versionId/revertTo` | Revert a document to an older version.                                        |
 | Update Document    | PATCH      | `/api/documents/:identifier`                 | Apply a Yjs update message to an existing document.                                          |
+| Replace Document   | PUT        | `/api/documents/:identifier`                 | Replace a document with a Yjs update message (same semantics as `PATCH`).                    |
+| Check Document Exists | HEAD    | `/api/documents/:identifier`                 | Check whether a document exists (no response body).                                          |
 | Delete Document    | DELETE     | `/api/documents/:identifier`                 | Delete a document from the server.                                                           |
+| Delete Version     | DELETE     | `/api/documents/:identifier/versions/:versionId` | Delete a specific version of a document.                                                 |
+| Export Document    | GET        | `/api/documents/:identifier/export`          | Export a document and all its versions as a `.zip` archive.                                  |
+| Import Document    | POST       | `/api/documents/:identifier/import`          | Import a document (and its versions) from an exported `.zip` archive.                        |
+| Send Stateless Message | POST   | `/api/documents/:identifier/stateless`       | Broadcast a stateless message to all connected clients of a document.                        |
 
 Take a look at the [metrics and statistics endpoints](/collaboration/operations/metrics) as well!
 
@@ -331,6 +337,21 @@ This call lets you update a version's name or metadata. You can use this to rena
 
 For available request body parameters and examples, see the [Postman Collection](https://www.postman.com/tiptap-platform/workspace/tiptap-workspace/folder/33042171-a6e8aa7e-c077-46ee-a2a3-241f8efd5d25?action=share&creator=33042171&active-environment=33042171-378cfb31-9c16-40f0-95b8-b9f0d3c7d2ab).
 
+### Delete a version
+
+```bash
+DELETE /api/documents/:identifier/versions/:versionId
+```
+
+This call deletes a single version of a document. The `:versionId` is the version number returned by the list/get version endpoints.
+
+The endpoint returns HTTP status `204` if the version was deleted successfully, or `404` if the document or version is not found.
+
+```bash
+curl --location --request DELETE 'https://YOUR_APP_ID.collab.tiptap.cloud/api/documents/DOCUMENT_NAME/versions/VERSION_ID' \
+--header 'Authorization: YOUR_SECRET_FROM_SETTINGS_AREA'
+```
+
 
 ## Update a document
 
@@ -339,6 +360,8 @@ PATCH /api/documents/:identifier
 ```
 
 This call accepts a Yjs update message and applies it to the existing document on the server.
+
+The same endpoint is also available as `PUT /api/documents/:identifier`, which behaves identically to `PATCH` (same body and query parameters).
 
 The endpoint returns the HTTP status `204` if the document was updated successfully, `404` if
 the document does not exist, or `422` if the payload is invalid or the update cannot be applied.
@@ -372,3 +395,70 @@ curl --location --request DELETE 'https://YOUR_APP_ID.collab.tiptap.cloud/api/do
 <Callout title="Document persists after deletion" variant="hint">
   If the endpoint returns `204` but the document still exists, make sure that no user is re-creating the document from the provider. We close all connections before deleting a document, but your error handling might recreate the provider, thus creating the document again.
 </Callout>
+
+## Check if a document exists
+
+```bash
+HEAD /api/documents/:identifier
+```
+
+This call checks whether a document with the given identifier exists, without transferring its content. The response has no body.
+
+It returns HTTP status `200` if the document exists, or `404` if it does not. Existence is independent of the document's active/inactive state.
+
+```bash
+curl --location --head 'https://YOUR_APP_ID.collab.tiptap.cloud/api/documents/DOCUMENT_NAME' \
+--header 'Authorization: YOUR_SECRET_FROM_SETTINGS_AREA'
+```
+
+## Export and import a document
+
+Use these endpoints to move a document&mdash;together with all of its versions&mdash;between servers or to create a portable backup. Unlike [duplicating a document](#duplicate-a-document), the export archive preserves the document's version history.
+
+### Export a document
+
+```bash
+GET /api/documents/:identifier/export
+```
+
+This call exports the current document and all of its versions as a `.zip` archive (`Content-Type: application/zip`). The archive can later be imported again with the import endpoint.
+
+It returns HTTP status `200` with the archive as the response body, or `404` if the document does not exist.
+
+```bash
+curl --location 'https://YOUR_APP_ID.collab.tiptap.cloud/api/documents/DOCUMENT_NAME/export' \
+--header 'Authorization: YOUR_SECRET_FROM_SETTINGS_AREA' \
+--output export.zip
+```
+
+### Import a document
+
+```bash
+POST /api/documents/:identifier/import
+```
+
+This call imports a document (and its versions) from an archive previously created with the export endpoint. Send the archive as the raw request body. The target `:identifier` must not already exist.
+
+The endpoint streams newline-delimited JSON (NDJSON) progress events while it works and finishes with a `done` event carrying the final status: `201` on success, `409` if a document with the target identifier already exists, `400` if the archive is malformed, or `413` if the archive exceeds the maximum allowed body size.
+
+```bash
+curl --location 'https://YOUR_APP_ID.collab.tiptap.cloud/api/documents/DOCUMENT_NAME/import' \
+--header 'Authorization: YOUR_SECRET_FROM_SETTINGS_AREA' \
+--data-binary '@export.zip'
+```
+
+## Send a stateless message
+
+```bash
+POST /api/documents/:identifier/stateless
+```
+
+This call broadcasts a custom payload to all clients currently connected to the document. Clients receive it as a [stateless message](/collaboration/provider/events), which you can handle with the provider's `onStateless` callback or by listening to the `stateless` event.
+
+The request body is sent verbatim as the stateless payload. The endpoint returns HTTP status `204` once the message has been broadcast.
+
+```bash
+curl --location 'https://YOUR_APP_ID.collab.tiptap.cloud/api/documents/DOCUMENT_NAME/stateless' \
+--header 'Authorization: YOUR_SECRET_FROM_SETTINGS_AREA' \
+--header 'Content-Type: application/json' \
+--data '{ "type": "ping", "payload": "hello" }'

--- a/src/content/collaboration/operations/configure.mdx
+++ b/src/content/collaboration/operations/configure.mdx
@@ -53,7 +53,7 @@ curl --location --request PUT 'https://YOUR_APP_ID.collab.tiptap.cloud/api/admin
 -d 'your value'
 ```
 
-This endpoint accepts `PUT`, `PATCH`, and `POST` interchangeably&mdash;all three create the setting if it doesn't exist or overwrite it if it does.
+This endpoint accepts `PUT`, `PATCH`, and `POST` interchangeably. All three create the setting if it doesn't exist, or overwrite the existing value if it does.
 
 ### List current settings
 

--- a/src/content/collaboration/operations/configure.mdx
+++ b/src/content/collaboration/operations/configure.mdx
@@ -53,6 +53,8 @@ curl --location --request PUT 'https://YOUR_APP_ID.collab.tiptap.cloud/api/admin
 -d 'your value'
 ```
 
+This endpoint accepts `PUT`, `PATCH`, and `POST` interchangeably&mdash;all three create the setting if it doesn't exist or overwrite it if it does.
+
 ### List current settings
 
 Use this call to retrieve a list of all current settings:


### PR DESCRIPTION
- Add documentation for new REST API actions: deleting document versions, replacing documents, exporting/importing documents, checking document existence, and broadcasting stateless messages.
- Introduce `multi` parameter for updating multiple fragments with distinct content.
- Update examples and usage for relevant endpoints.