### PR TITLE
Document pt/rem/em font size support on DOCX export

### DIFF
--- a/src/content/conversion/content-types/text-and-formatting/font-family-size.mdx
+++ b/src/content/conversion/content-types/text-and-formatting/font-family-size.mdx
@@ -31,11 +31,11 @@ new Editor({ extensions: [ConvertKit] })
 
 ## Support overview
 
-|                | Import                                      | Editor                                                                  | Export                               |
-| -------------- | ------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------ |
-| Font family    | Supported (`textStyle.fontFamily`)          | Supported (FontFamily)                                                  | Supported (first font only)          |
-| Font size      | Supported (`textStyle.fontSize` in px)      | Supported (FontSize)                                                    | Supported (converted to half-points) |
-| Letter spacing | Supported (`textStyle.letterSpacing` in px) | Requires extending TextStyle (not bundled in ConvertKit / TextStyleKit) | Not supported                        |
+|                | Import                                      | Editor                                                                  | Export                      |
+| -------------- | ------------------------------------------- | ----------------------------------------------------------------------- | --------------------------- |
+| Font family    | Supported (`textStyle.fontFamily`)          | Supported (FontFamily)                                                  | Supported (first font only) |
+| Font size      | Supported (`textStyle.fontSize` in px)      | Supported (FontSize)                                                    | Supported (px, pt, rem, em) |
+| Letter spacing | Supported (`textStyle.letterSpacing` in px) | Requires extending TextStyle (not bundled in ConvertKit / TextStyleKit) | Not supported               |
 
 ## Import
 
@@ -76,10 +76,17 @@ On export, font family values are sanitized: quotes are stripped and only the fi
   affected.
 </Callout>
 
-Font size converts back from pixels to half-points:
+Font size is unit-aware. A value with no unit, or a `px` value, is treated as pixels and converted to half-points:
 
 ```
 halfPoints = pixels * 1.5
 ```
 
-Values that were imported from DOCX will produce the same half-point value on export, provided the original half-point value converts to an exact integer pixel. When `Math.round()` alters the pixel value during import (e.g., 14pt becomes 18.67px, rounded to 19px), the exported half-point value will differ from the original (19px exports as 28.5 half-points instead of the original 28). Non-numeric font size values (if any) are skipped with a console warning.
+A value that carries a unit is honored rather than being read as pixels:
+
+- `pt` maps straight to points, so `12pt` exports as 12pt (24 half-points).
+- `rem` and `em` resolve against a 16px base (for example `1rem` is 16px).
+
+A bare number stays pixels, so content imported from DOCX (which stores `textStyle.fontSize` in px) round-trips unchanged.
+
+Values that were imported from DOCX will produce the same half-point value on export, provided the original half-point value converts to an exact integer pixel. When `Math.round()` alters the pixel value during import (e.g., 14pt becomes 18.67px, rounded to 19px), the exported half-point value will differ from the original (19px exports as 28.5 half-points instead of the original 28). A font size that cannot be parsed is skipped with a console warning.


### PR DESCRIPTION
## Why

The font family and size page described DOCX export font size as pixels-only (`halfPoints = pixels * 1.5`). Export now honors units, so the page understated what is supported. This documents the behavior from the TT-721 fix (tiptap-pro #913).

## What

- Support overview: the Export cell for font size now reads "Supported (px, pt, rem, em)".
- Export section: explains that font size is unit-aware. A value with no unit or a `px` value is pixels; `pt` maps straight to points (`12pt` exports as 12pt); `rem` / `em` resolve against a 16px base. A bare number stays pixels, so DOCX-imported content round-trips unchanged.

## Notes

- Describes behavior shipping in the export engine via tiptap-pro #913; the REST/conversion service picks it up once that releases and the dependency bumps.
- Prettier clean; scoped to the one page.
