### PR TITLE
Document fixed unit-based line height support on DOCX export

### DIFF
--- a/src/content/conversion/content-types/text-and-formatting/paragraphs.mdx
+++ b/src/content/conversion/content-types/text-and-formatting/paragraphs.mdx
@@ -18,7 +18,7 @@ Paragraphs are the most fundamental content type in any document. In Word they c
 - **Configuration:** None required.
 
 <Callout title="Paragraph formatting needs ConvertKit's custom Paragraph" variant="hint">
-  Text content and alignment round-trip with any paragraph node. Paragraph-level spacing, indentation, line height, and contextual spacing are extracted during import and rendered as inline CSS by ConvertKit's custom Paragraph. If you swap ConvertKit's Paragraph for a stock one (or disable the slot), those attributes stay in the JSON but are stripped on `setEditorContent()`. The [Styling converted content](/conversion/getting-started/guides/styling-converted-content) guide covers how to extend the schema for additional attributes. Paragraph spacing, indentation, contextual spacing, and proportional line height now round-trip on export; see the support overview below.
+  Text content and alignment round-trip with any paragraph node. Paragraph-level spacing, indentation, line height, and contextual spacing are extracted during import and rendered as inline CSS by ConvertKit's custom Paragraph. If you swap ConvertKit's Paragraph for a stock one (or disable the slot), those attributes stay in the JSON but are stripped on `setEditorContent()`. The [Styling converted content](/conversion/getting-started/guides/styling-converted-content) guide covers how to extend the schema for additional attributes. Paragraph spacing, indentation, contextual spacing, and line height (both proportional and fixed) now round-trip on export; see the support overview below.
 </Callout>
 
 ## Support overview
@@ -27,7 +27,7 @@ Paragraphs are the most fundamental content type in any document. In Word they c
 | --- | --- | --- | --- |
 | Text content | Supported | Supported | Supported |
 | Text alignment | Supported | Supported (TextAlign) | Supported |
-| Line height | Supported (paragraph attr) | Supported (`line-height: <value>`) | Proportional values round-trip (unitless multiple or percentage); fixed `px`/`pt` line heights are not preserved |
+| Line height | Supported (paragraph attr) | Supported (`line-height: <value>`) | Supported (proportional values as a relative line, fixed `px`/`pt` as an exact line) |
 | Paragraph spacing (before/after) | Supported (`spacingBefore`, `spacingAfter` attrs) | Supported (`margin-top` / `margin-bottom`) | Supported |
 | Indentation | Supported (`indent`, `firstLineIndent` attrs) | Supported (`padding-left` / `text-indent`) | Supported (a negative first-line indent becomes a hanging indent) |
 | Contextual spacing | Supported (`contextualSpacing` attr) | Supported (`data-contextual-spacing` + injected CSS rule) | Supported |
@@ -86,8 +86,15 @@ During DOCX export, each `paragraph` node is written as a Word paragraph with th
 
 - All text content and inline marks
 - Text alignment is read from the paragraph node attributes and mapped to Word alignment
-- Line height is read from the `lineHeight` paragraph attribute (a block-level `textStyle` mark still takes precedence). Proportional values (a unitless multiple such as `1.5` or a percentage such as `150%`) are written as Word line spacing; fixed `px`/`pt` line heights have no proportional equivalent and are not preserved.
+- Line height is read from the `lineHeight` paragraph attribute (a block-level `textStyle` mark still takes precedence). A proportional value (a unitless multiple such as `1.5`, or a percentage such as `150%`) is written as a relative line spacing that scales with the font size. A fixed value carrying an absolute unit (`24px`, `18pt`, `1cm`) is written as an exact line height, so the spacing set in the editor is kept. Font-relative units such as `em` and `rem` have no absolute value on their own and are left to the document default.
 - Paragraph spacing (`spacingBefore` / `spacingAfter`), left and first-line indentation (`indent` / `firstLineIndent`), and contextual spacing (`contextualSpacing`) are read from the paragraph node attributes. A negative first-line indent is written as a hanging indent. These attributes also apply to styled paragraphs such as blockquotes.
+
+<Callout title="Line spacing is preserved, exact rendering is not" variant="info">
+  Line spacing carries over, but the exported document will not match the editor pixel for pixel.
+  A word processor and a web browser measure fonts and lay out lines differently, so the same line
+  height can occupy a slightly different amount of vertical space in each. This applies to
+  proportional and fixed line heights alike.
+</Callout>
 
 ### What is not exported
 

--- a/src/content/conversion/getting-started/feature-support-matrix.mdx
+++ b/src/content/conversion/getting-started/feature-support-matrix.mdx
@@ -76,7 +76,7 @@ The import service extracts paragraph-level styling attributes like spacing, ind
 
 **\*** Letter spacing is extracted as `textStyle.letterSpacing` but no bundled extension renders it. To render imported letter spacing, [extend TextStyle](/conversion/getting-started/guides/styling-converted-content#extending-extensions-for-unsupported-attributes).<br />
 **\*\*** Word's named-style typography is not applied by default. Use [CSS injection](/conversion/import/docx/css-injection) to extract it as scoped CSS.<br />
-**\*\*\*** Only proportional line spacing round-trips on export: a unitless multiple such as `1.5` or a percentage such as `150%`. Fixed line heights carrying a unit (e.g. `24px`, `18pt`) have no proportional DOCX equivalent and are not preserved.
+**\*\*\*** Line spacing round-trips on export. A proportional value (a unitless multiple such as `1.5` or a percentage such as `150%`) is written as a relative line that scales with the font size; a fixed value carrying an absolute unit (`24px`, `18pt`, `1cm`) is written as an exact line height. Font-relative units such as `em` and `rem` are left to the document default.
 
 ## Lists
 


### PR DESCRIPTION
Documents the behavior shipping in tiptap-pro (fixed `px`/`pt` line heights now round-trip on DOCX export) and the matching convert import change.

## Changes

- `content-types/text-and-formatting/paragraphs.mdx`
  - Support overview and export section: fixed `px`/`pt` line heights are now preserved (written as an exact line), alongside the existing proportional handling. Font-relative `em`/`rem` are left to the document default.
  - New note that line spacing is preserved but exact pixel rendering is not guaranteed, since a word processor and a browser lay out lines with different font metrics.
- `getting-started/feature-support-matrix.mdx`: updated the line-spacing footnote to match.

Ships together with tiptap-pro #914 (export) and the convert import change; convert inherits the export behavior once the pro package is released and pinned.