### PR TITLE
Revert simple image alignment on DOCX export docs

### DIFF
--- a/src/content/conversion/content-types/structures-and-media/images.mdx
+++ b/src/content/conversion/content-types/structures-and-media/images.mdx
@@ -27,7 +27,6 @@ Images in DOCX documents are extracted during import, rendered in the editor, an
 | Feature | Import | Editor | Export | Notes |
 | --- | --- | --- | --- | --- |
 | Inline images | Supported | Supported | Supported | Requires imageUploadConfig on import |
-| Simple alignment (left/center/right) | Supported | Supported | Supported | Inline images inherit their paragraph's alignment. A block image node exports aligned when it carries an `align` or `textAlign` attribute. |
 | Floating/wrapped images | Partial | Not supported | Not supported | Anchor images are converted but wrap type is not tracked. All images become inline. Background/watermark images (`behindDoc`) are skipped. |
 | Image dimensions | Supported | Supported | Supported | Width and height are extracted from EMU values and passed as pixel attributes on the image node. Export reads width/height attrs. |
 | Alt text | Supported | Supported | Supported | `descr` and `title` from `wp:docPr` are extracted on import. Alt from editor node maps to DOCX alt text on export. |
@@ -98,11 +97,3 @@ On export, each image node's `src` URL is fetched and the binary data is embedde
 If the node has `width` and `height` attributes (in pixels), those values are converted to points (1px = 0.75pt). If no dimensions are set, the exporter detects intrinsic size automatically. If detection fails, images default to 800x400 pixels.
 
 The `alt` attribute on the image node is mapped to the DOCX image's alt text fields.
-
-### Simple alignment
-
-An image that sits inside a paragraph is aligned by that paragraph, so a centered or right-aligned paragraph carries its image along with it. For a standalone (block) image node that has no surrounding paragraph, the exporter reads a simple alignment hint from the node itself: an `align` attribute (or `textAlign` as a fallback) set to `left`, `center`, `right`, or `justify` aligns the paragraph the image is wrapped in. Any other value, or no value, leaves the image at the document default.
-
-Only simple alignment is supported. Floating, absolute positioning, and text wrapping are intentionally left out, because content flows too differently between a browser and a Word or PDF document for that positioning to carry over reliably.
-
-The base `@tiptap/extension-image` node does not declare an alignment attribute, so this applies when your content already carries one (for example JSON sent to the REST API, or a custom Image extension that adds `align` to its schema).


### PR DESCRIPTION
Reverts #886.

The export-docx change it documented (ueberdosis/tiptap-pro#915, TT-725) was closed and will not ship. Aligning images already works the standard way: make the image inline and align its paragraph, which round-trips through import and export. The reverted section described a block-image `align`/`textAlign` attribute that the Image schema does not define and nothing in the pipeline produces, so the page was documenting behavior that does not exist.

This restores the Images page to its prior state.