### PR TITLE
Provisionally add Server AI Toolkit permission

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot.mdx
@@ -146,7 +146,7 @@ export async function getToolDefinitions(editorContext: unknown): Promise<{
 
 #### Execute tool
 
-This function executes a tool via the Server AI Toolkit API. It sends the tool name, input parameters, document ID, and editor context data to the API. The server automatically fetches and saves the Tiptap Cloud document when the JWT includes `Documents:Write` permission for that document.
+This function executes a tool via the Server AI Toolkit API. It sends the tool name, input parameters, document ID, and editor context data to the API. The server automatically fetches and saves the Tiptap Cloud document when the JWT includes `Documents:Api:All` and `Documents:Write` permissions for that document.
 
 ```ts
 // lib/server-ai-toolkit/execute-tool.ts

--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
@@ -132,7 +132,7 @@ curl --location 'BASE_URL/v4/ai/toolkit/fetch-tools' \
   }'
 ```
 
-Error responses:
+#### Error responses
 
 HTTP errors return:
 
@@ -224,7 +224,7 @@ curl --location 'BASE_URL/v4/ai/toolkit/execute-tool' \
   }'
 ```
 
-Error responses:
+#### Error responses
 
 HTTP errors return:
 
@@ -323,7 +323,7 @@ Response:
   updated `document`.
 - Other tools: One final event with the same result shape as `execute-tool`.
 
-Error responses:
+#### Error responses
 
 Before streaming starts, HTTP errors use the same JSON shape as `execute-tool`:
 

--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
@@ -152,7 +152,7 @@ This endpoint can return:
 - `403` with `insufficient_permissions`: The JWT does not grant `AI:Toolkit`.
 - `403` with `origin_not_allowed`: The request `Origin` is not allowed for the environment.
 - `422` with `validation_failed`: The request body does not match the endpoint schema. The response
-  includes `error.issues`.
+  includes `error.issues`, a list of validation issues.
 - `429` with `rate_limited`: Access Control rate-limited authentication.
 - `429`: The server-side rate limiter blocked the request. This response uses a different top-level
   shape:
@@ -260,7 +260,7 @@ This endpoint can return:
 - `409` with `concurrent_edit_conflict`: The cloud document changed while the tool was executing.
   Retry the request with the latest document state.
 - `422` with `validation_failed`: The request body does not match the endpoint schema. The response
-  includes `error.issues`.
+  includes `error.issues`, a list of validation issues.
 - `429` with `rate_limited`: Access Control rate-limited authentication.
 - `429`: The server-side rate limiter blocked the request. This response uses a different top-level
   shape:

--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
@@ -47,7 +47,7 @@ Sign the token server-side with these settings:
 - Audience: `AI`
 - Permissions: `AI:Toolkit`
 
-To fetch and save Tiptap Cloud documents automatically, add the `Documents` audience and the `Documents:Write` permission. `Documents:Write` includes read and comment access.
+To fetch and save Tiptap Cloud documents automatically, add the `Documents` audience, the `Documents:Api:All` permission, and the `Documents:Write` permission. `Documents:Write` includes read and comment access.
 
 See [Authentication](/authentication) for how to create a key pair and sign tokens, and the [authorization guide](/content-ai/capabilities/server-ai-toolkit/install#set-up-authorization) for the full setup.
 
@@ -59,6 +59,7 @@ const privateKey = await importPKCS8(process.env.TIPTAP_PRIVATE_KEY, 'ES256')
 const JWT_TOKEN = await new SignJWT({
   permissions: [
     { action: 'AI:Toolkit', resource: '*' },
+    { action: 'Documents:Api:All', resource: '*' },
     { action: 'Documents:Write', resource: 'your-document-id' },
   ],
 })

--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
@@ -132,6 +132,38 @@ curl --location 'BASE_URL/v4/ai/toolkit/fetch-tools' \
   }'
 ```
 
+Error responses:
+
+HTTP errors return:
+
+- `error.message` (`string`): Human-readable error message.
+- `error.status` (`number`): HTTP status code.
+- `error.code` (`string`): Stable error code.
+- `error.data` (`object`, optional): Sanitized structured context.
+
+This endpoint can return:
+
+- `401` with `access_control_auth_required` or `missing_token`: The request did not include a
+  Tiptap Access Control JWT.
+- `401` with an access-control code such as `token_expired` or `signature_invalid`: The JWT was
+  rejected by Access Control.
+- `403` with `feature_not_available`: Server AI Toolkit is not enabled for the environment.
+- `403` with `insufficient_permissions`: The JWT does not grant `AI:Toolkit`.
+- `403` with `origin_not_allowed`: The request `Origin` is not allowed for the environment.
+- `422` with `validation_failed`: The request body does not match the endpoint schema. The response
+  includes `error.issues`.
+- `429` with `rate_limited`: Access Control rate-limited authentication.
+- `429`: The server-side rate limiter blocked the request. This response uses a different top-level
+  shape:
+  - `error` (`string`): Rate limit error message.
+  - `retryAfter` (`number`, optional): Seconds to wait before retrying.
+  - `limit` (`number`, optional): Request limit for the current window.
+  - `window` (`number`, optional): Rate-limit window in seconds.
+- `500` with `internal_server_error`: An unexpected server error occurred.
+- `500` with `missing_cloud_api_token`: The cloud service is missing internal authentication
+  configuration.
+- `503` with `service_unavailable`: Access Control was temporarily unavailable.
+
 ### Execute a tool
 
 ```txt
@@ -192,6 +224,64 @@ curl --location 'BASE_URL/v4/ai/toolkit/execute-tool' \
   }'
 ```
 
+Error responses:
+
+HTTP errors return:
+
+- `error.message` (`string`): Human-readable error message.
+- `error.status` (`number`): HTTP status code.
+- `error.code` (`string`): Stable error code.
+- `error.data` (`object`, optional): Sanitized structured context. Document and thread upstream
+  failures include fields such as `operation`, `upstreamStatus`, `upstreamUrl`, and
+  `upstreamMethod`.
+
+This endpoint can return:
+
+- `400` with `missing_document_credentials`: The request uses a cloud document, but the JWT does not
+  include document server credentials.
+- `400` with `missing_document_options`: `getThreads` or `editThreads` was executed against an
+  inline document. These tools require a cloud document.
+- `400` with a thread-store code such as `thread_not_found` or `comment_not_found`: A thread or
+  comment operation referenced data that does not exist.
+- `401` with `access_control_auth_required` or `missing_token`: The request did not include a
+  Tiptap Access Control JWT.
+- `401` with an access-control code such as `token_expired` or `signature_invalid`: The JWT was
+  rejected by Access Control.
+- `403` with `feature_not_available`: Server AI Toolkit is not enabled for the environment.
+- `403` with `insufficient_permissions`: The JWT does not grant `AI:Toolkit`, or it does not grant
+  access to the requested cloud document.
+- `403` with `origin_not_allowed`: The request `Origin` is not allowed for the environment.
+- `403` with `unsupported_tool_format`: The selected tool does not support the requested `format`.
+- `403` with `tracked_changes_unsupported_schema`: `reviewOptions.mode` is `trackedChanges`, but
+  the editor schema does not support tracked changes.
+- `403` with `thread_schema_not_supported`: The editor schema does not support comments or threads.
+- `409` with `concurrent_edit_conflict`: The cloud document changed while the tool was executing.
+  Retry the request with the latest document state.
+- `422` with `validation_failed`: The request body does not match the endpoint schema. The response
+  includes `error.issues`.
+- `429` with `rate_limited`: Access Control rate-limited authentication.
+- `429`: The server-side rate limiter blocked the request. This response uses a different top-level
+  shape:
+  - `error` (`string`): Rate limit error message.
+  - `retryAfter` (`number`, optional): Seconds to wait before retrying.
+  - `limit` (`number`, optional): Request limit for the current window.
+  - `window` (`number`, optional): Rate-limit window in seconds.
+- `500` with `document_save_failed`: The server could not save the cloud document after loading it,
+  or the save flow was called before a document was loaded.
+- `500` with `diff_worker_failed` or `diff_worker_invalid_result`: The internal diff worker failed
+  while preparing reviewable changes.
+- `500` with `internal_server_error` or `unknown_error`: An unexpected server error occurred.
+- `500` with `missing_cloud_api_token`: The cloud service is missing internal authentication
+  configuration.
+- `502` with `document_load_failed` or `document_save_failed`: Loading or saving the cloud document
+  failed upstream. Check `error.data.upstreamStatus` for the upstream HTTP status.
+- `502` with a thread or comment code such as `thread_list_failed`, `thread_create_failed`,
+  `thread_update_failed`, `thread_delete_failed`, `thread_resolve_failed`,
+  `thread_unresolve_failed`, `comment_create_failed`, `comment_update_failed`, or
+  `comment_delete_failed`: A comments API operation failed upstream.
+- `503` with `diff_worker_queue_timeout`: The diff worker queue was saturated or timed out.
+- `503` with `service_unavailable`: Access Control was temporarily unavailable.
+
 ### Stream a tool
 
 <Callout title="Alpha feature" variant="hint">
@@ -232,6 +322,65 @@ Response:
 - `tiptapEdit`: Incremental events while edits are applied, followed by a final event with the
   updated `document`.
 - Other tools: One final event with the same result shape as `execute-tool`.
+
+Error responses:
+
+Before streaming starts, HTTP errors use the same JSON shape as `execute-tool`:
+
+- `error.message` (`string`): Human-readable error message.
+- `error.status` (`number`): HTTP status code.
+- `error.code` (`string`): Stable error code.
+- `error.data` (`object`, optional): Sanitized structured context.
+
+After streaming starts, errors are sent as NDJSON events:
+
+- `version` (`number`): Stream protocol version.
+- `type` (`'error'`): Event type.
+- `code` (`string`): Stable error code.
+- `status` (`number`): HTTP-style status code.
+- `message` (`string`): Human-readable error message.
+
+This endpoint can return or emit:
+
+- `400` with `invalid_request`: The request has no body.
+- `400` with `missing_document_credentials`: The JWT does not include document server credentials.
+- `400` with `invalid_stream_message`: A stream message is not valid JSON, fails schema validation,
+  uses an unsupported protocol version, or the stream ends with an unterminated NDJSON line.
+- `400` with `duplicate_start`: More than one `start` message was sent.
+- `400` with `delta_before_start`: A `delta` message arrived before `start`.
+- `400` with `end_before_start`: An `end` message arrived before `start`.
+- `400` with `incomplete_stream`: The request ended before an `end` message arrived.
+- `400` with a thread-store code such as `thread_not_found` or `comment_not_found`: A buffered
+  thread or comment operation referenced data that does not exist.
+- `401` with `access_control_auth_required` or `missing_token`: The request did not include a
+  Tiptap Access Control JWT.
+- `401` with an access-control code such as `token_expired` or `signature_invalid`: The JWT was
+  rejected by Access Control.
+- `403` with `feature_not_available`: Server AI Toolkit is not enabled for the environment.
+- `403` with `insufficient_permissions`: The JWT does not grant `AI:Toolkit`.
+- `403` with `origin_not_allowed`: The request `Origin` is not allowed for the environment.
+- `403` with `tracked_changes_unsupported_schema`: `reviewOptions.mode` is `trackedChanges`, but
+  the editor schema does not support tracked changes.
+- `403` with `thread_schema_not_supported`: The editor schema does not support comments or threads.
+- `413` with `ndjson_line_too_long`: A single NDJSON line exceeded the maximum size.
+- `429` with `stream_rate_limit_exceeded`: Too many concurrent streams are open for the same client.
+- `429` with `rate_limited`: Access Control rate-limited authentication.
+- `429`: The server-side rate limiter blocked the request before streaming started. This response
+  uses a different top-level shape:
+  - `error` (`string`): Rate limit error message.
+  - `retryAfter` (`number`, optional): Seconds to wait before retrying.
+  - `limit` (`number`, optional): Request limit for the current window.
+  - `window` (`number`, optional): Rate-limit window in seconds.
+- `500` with `diff_worker_failed`, `diff_worker_invalid_result`, `stream_internal_error`, or
+  `unknown_error`: An unexpected server error occurred during stream processing.
+- `500` with `missing_cloud_api_token`: The cloud service is missing internal authentication
+  configuration.
+- `502` with document, thread, or comment upstream failure codes such as `document_load_failed`,
+  `document_save_failed`, `thread_list_failed`, or `comment_create_failed`: A cloud document or
+  comments API operation failed upstream.
+- `503` with `diff_worker_queue_timeout`: The diff worker queue was saturated or timed out.
+- `503` with `service_unavailable`: Access Control was temporarily unavailable.
+- `504` with `stream_request_timeout`: The stream exceeded the server request timeout.
 
 ## Available tools
 

--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
@@ -136,10 +136,11 @@ curl --location 'BASE_URL/v4/ai/toolkit/fetch-tools' \
 
 HTTP errors return:
 
-- `error.message` (`string`): Human-readable error message.
-- `error.status` (`number`): HTTP status code.
-- `error.code` (`string`): Stable error code.
-- `error.data` (`object`, optional): Sanitized structured context.
+- `error` (`object`): An object with these properties:
+  - `message` (`string`): Human-readable error message.
+  - `status` (`number`): HTTP status code.
+  - `code` (`string`): Stable error code.
+  - `data` (`object`, optional): Sanitized structured context.
 
 This endpoint can return:
 
@@ -228,12 +229,13 @@ curl --location 'BASE_URL/v4/ai/toolkit/execute-tool' \
 
 HTTP errors return:
 
-- `error.message` (`string`): Human-readable error message.
-- `error.status` (`number`): HTTP status code.
-- `error.code` (`string`): Stable error code.
-- `error.data` (`object`, optional): Sanitized structured context. Document and thread upstream
-  failures include fields such as `operation`, `upstreamStatus`, `upstreamUrl`, and
-  `upstreamMethod`.
+- `error` (`object`): An object with these properties:
+  - `message` (`string`): Human-readable error message.
+  - `status` (`number`): HTTP status code.
+  - `code` (`string`): Stable error code.
+  - `data` (`object`, optional): Sanitized structured context. Document and thread upstream
+    failures include fields such as `operation`, `upstreamStatus`, `upstreamUrl`, and
+    `upstreamMethod`.
 
 This endpoint can return:
 
@@ -327,10 +329,11 @@ Response:
 
 Before streaming starts, HTTP errors use the same JSON shape as `execute-tool`:
 
-- `error.message` (`string`): Human-readable error message.
-- `error.status` (`number`): HTTP status code.
-- `error.code` (`string`): Stable error code.
-- `error.data` (`object`, optional): Sanitized structured context.
+- `error` (`object`): An object with these properties:
+  - `message` (`string`): Human-readable error message.
+  - `status` (`number`): HTTP status code.
+  - `code` (`string`): Stable error code.
+  - `data` (`object`, optional): Sanitized structured context.
 
 After streaming starts, errors are sent as NDJSON events:
 

--- a/src/content/content-ai/capabilities/server-ai-toolkit/install.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/install.mdx
@@ -117,6 +117,7 @@ export async function createJwtToken(documentId?: string): Promise<string> {
   ]
 
   if (documentId) {
+    permissions.push({ action: 'Documents:Api:All', resource: '*' })
     permissions.push({ action: 'Documents:Write', resource: documentId })
   }
 


### PR DESCRIPTION
Temporarily adds permission that is currently necessary so that the new endpoints of the Server AI Toolkit work and do not have a permissions error. 

This permission requirement will be removed when the issue is fixed