### PR TITLE
Revert "Provisionally add Server AI Toolkit permission"

### DIFF
--- a/src/content/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/agents/ai-agent-chatbot.mdx
@@ -146,7 +146,7 @@ export async function getToolDefinitions(editorContext: unknown): Promise<{
 
 #### Execute tool
 
-This function executes a tool via the Server AI Toolkit API. It sends the tool name, input parameters, document ID, and editor context data to the API. The server automatically fetches and saves the Tiptap Cloud document when the JWT includes `Documents:Api:All` and `Documents:Write` permissions for that document.
+This function executes a tool via the Server AI Toolkit API. It sends the tool name, input parameters, document ID, and editor context data to the API. The server automatically fetches and saves the Tiptap Cloud document when the JWT includes `Documents:Write` permission for that document.
 
 ```ts
 // lib/server-ai-toolkit/execute-tool.ts

--- a/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/api-reference/rest-api.mdx
@@ -47,7 +47,7 @@ Sign the token server-side with these settings:
 - Audience: `AI`
 - Permissions: `AI:Toolkit`
 
-To fetch and save Tiptap Cloud documents automatically, add the `Documents` audience, the `Documents:Api:All` permission, and the `Documents:Write` permission. `Documents:Write` includes read and comment access.
+To fetch and save Tiptap Cloud documents automatically, add the `Documents` audience and the `Documents:Write` permission. `Documents:Write` includes read and comment access.
 
 See [Authentication](/authentication) for how to create a key pair and sign tokens, and the [authorization guide](/content-ai/capabilities/server-ai-toolkit/install#set-up-authorization) for the full setup.
 
@@ -59,7 +59,6 @@ const privateKey = await importPKCS8(process.env.TIPTAP_PRIVATE_KEY, 'ES256')
 const JWT_TOKEN = await new SignJWT({
   permissions: [
     { action: 'AI:Toolkit', resource: '*' },
-    { action: 'Documents:Api:All', resource: '*' },
     { action: 'Documents:Write', resource: 'your-document-id' },
   ],
 })

--- a/src/content/content-ai/capabilities/server-ai-toolkit/install.mdx
+++ b/src/content/content-ai/capabilities/server-ai-toolkit/install.mdx
@@ -117,7 +117,6 @@ export async function createJwtToken(documentId?: string): Promise<string> {
   ]
 
   if (documentId) {
-    permissions.push({ action: 'Documents:Api:All', resource: '*' })
     permissions.push({ action: 'Documents:Write', resource: documentId })
   }
 


### PR DESCRIPTION
Now that the AI Server has been configured to connect to the document server with the web socket connection instead of using the document REST API, we no longer have to set the Documents:Api:All permission when configuring the JWT

Reverts ueberdosis/tiptap-docs#888