### PR TITLE
fix: hocuspocus bind address

### DIFF
--- a/src/content/hocuspocus/server/configuration.mdx
+++ b/src/content/hocuspocus/server/configuration.mdx
@@ -16,6 +16,7 @@ There are only a few settings to pass for now. Most things are controlled throug
 |--------------------|--------------------------------------------------------------------------------------------------------------------------------------|-----------------|
 | `name`             | A name for the instance, used for logging.                                                                                           |                 |
 | `port`             | The port the server should listen on.                                                                                                | `80`            |
+| `address`          | The host/interface the server should bind to, e.g. `127.0.0.1`. If not set, the server listens on all interfaces.                    |                 |
 | `timeout`          | A connection healthcheck interval in milliseconds. Increased from 30s to 60s in v4.                                                  | `60000 (= 60s)` |
 | `debounce`         | Debounces the call of the onStoreDocument hook for the given amount of time in ms. Otherwise every single update would be persisted. | `2000 (= 2s)`   |
 | `maxDebounce`      | Makes sure to call onStoreDocument at least in the given amount of time (ms).                                                        | `10000 (= 10s)` |


### PR DESCRIPTION
works with 4.3.1+, so awaiting release of Hocuspocus.