### PR TITLE
docs(ui-components): table-node Pages support + stable cellMenu guidance

### DIFF
--- a/src/content/ui-components/getting-started/changelog.mdx
+++ b/src/content/ui-components/getting-started/changelog.mdx
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2026-07-09]
+
+### Added
+
+- **Table node**: Pages extension support. When the Pages extension is registered on the editor, tables now split across page boundaries row by row — preserving column widths, merged cells, and borders — with rowspan cells continuing across breaks and oversized cells becoming scrollable so pagination stays stable. Requires no configuration, and behavior is unchanged without Pages.
+
+### Fixed
+
+- **Table selection overlay**: The `cellMenu` prop must now be a stable component reference. Passing an inline arrow gave the menu a new component identity on every render, remounting its subtree and potentially throwing "Maximum update depth exceeded". Define the cell menu at module scope (or memoize it); the overlay and cell menu also guard against redundant menu open-state updates.
+- **Editor lifecycle**: Hardened the `comment`, `text-align`, and `undo-redo` components and `tiptap-utils` against destroyed or unmounted editors — added `isDestroyed`/mounted-view checks and error handling around `editor.can()` to prevent exceptions during teardown.
+
 ## [2026-03-26]
 
 ### Added

--- a/src/content/ui-components/node-components/table-node.mdx
+++ b/src/content/ui-components/node-components/table-node.mdx
@@ -18,6 +18,7 @@ tags:
 ---
 
 import { CodeDemo } from '@/components/CodeDemo'
+import { Callout } from '@/components/ui/Callout'
 
 An enhanced table node component for Tiptap editors with table handles for row and column manipulation, as well as cell alignment controls. It includes add, delete, move, and duplicate functionality, along with advanced table management capabilities, responsive styling, and accessibility features.
 
@@ -81,7 +82,24 @@ const editor = useEditor({
 })
 ```
 
-**3. Add the table components to your editor:**
+**3. Define a stable cell menu, then add the table components to your editor:**
+
+<Callout title="Pass a stable cellMenu reference" variant="warning">
+  Define the `cellMenu` component at module scope (or wrap it in `useMemo`). An inline arrow —
+  `cellMenu={(props) => <TableCellHandleMenu ... />}` — creates a new component type on every render,
+  which remounts the whole menu subtree and can throw `Maximum update depth exceeded` under editors
+  that re-render frequently.
+</Callout>
+
+```tsx
+// Module scope — stable identity across renders.
+const CellMenu = (props) => (
+  <TableCellHandleMenu
+    editor={props.editor}
+    onMouseDown={(e) => props.onResizeStart?.('br')(e)}
+  />
+)
+```
 
 ```tsx
 <EditorContext.Provider value={{ editor }}>
@@ -94,15 +112,7 @@ const editor = useEditor({
 
   {/* Add these components outside EditorContent for proper positioning */}
   <TableHandle />
-  <TableSelectionOverlay
-    showResizeHandles={true}
-    cellMenu={(props) => (
-      <TableCellHandleMenu
-        editor={props.editor}
-        onMouseDown={(e) => props.onResizeStart?.('br')(e)}
-      />
-    )}
-  />
+  <TableSelectionOverlay showResizeHandles={true} cellMenu={CellMenu} />
   <TableExtendRowColumnButtons />
 </EditorContext.Provider>
 ```
@@ -231,6 +241,16 @@ import '@/components/tiptap-node/table-node/styles/table-node.scss'
 import '@/components/tiptap-node/heading-node/heading-node.scss'
 import '@/components/tiptap-node/paragraph-node/paragraph-node.scss'
 
+// Define the cell menu at module scope so its identity is stable across renders.
+// An inline `cellMenu` arrow would remount the menu on every render and can throw
+// "Maximum update depth exceeded".
+const CellMenu = (props) => (
+  <TableCellHandleMenu
+    editor={props.editor}
+    onMouseDown={(e) => props.onResizeStart?.('br')(e)}
+  />
+)
+
 export default function BasicEditor() {
   const editor = useEditor({
     immediatelyRender: false,
@@ -321,15 +341,7 @@ export default function BasicEditor() {
       <EditorContent editor={editor} role="presentation" className="control-showcase" />
 
       <TableHandle />
-      <TableSelectionOverlay
-        showResizeHandles={true}
-        cellMenu={(props) => (
-          <TableCellHandleMenu
-            editor={props.editor}
-            onMouseDown={(e) => props.onResizeStart?.('br')(e)}
-          />
-        )}
-      />
+      <TableSelectionOverlay showResizeHandles={true} cellMenu={CellMenu} />
       <TableExtendRowColumnButtons />
     </EditorContext.Provider>
   )
@@ -642,6 +654,18 @@ Each hook returns:
 - `label: string` - UI label for the action
 - `Icon: ComponentType` - Icon component for the action
 
+## Pagination support
+
+The table node ships with a built-in integration that makes it compatible with the [Pages extension](/pages/getting-started/overview). When Pages is registered on the editor, tables automatically split across page boundaries row by row: column widths, merged cells, and cell borders are preserved; a vertically merged (rowspan) cell that crosses a page break continues on the next page; and a cell taller than the page content area becomes scrollable so pagination stays stable.
+
+No extra configuration is required — the table detects the Pages extension and adapts automatically. Without Pages, the table renders exactly as before.
+
+<Callout title="Pages Pro users" variant="info">
+  If you are building on the `@tiptap-pro` Pages packages directly (rather than these copy-and-paste
+  UI components), use the dedicated `@tiptap-pro/extension-pages-tablekit` package instead — see
+  [Using TableKit with Pages](/pages/guides/table-with-pages).
+</Callout>
+
 ## Styling
 
 The table node requires two stylesheets:
@@ -708,6 +732,7 @@ The table-node component internally uses:
 - ✅ **Alignment Controls**: Text and vertical alignment for cells
 - ✅ **Column Resizing**: Interactive column width adjustment
 - ✅ **Selection Overlay**: Visual feedback for selected cells
+- ✅ **Pagination**: Adapts to the Pages extension — tables split across pages
 - ✅ **Keyboard Shortcuts**: Efficient keyboard navigation
 - ✅ **Responsive Design**: Works on desktop and mobile devices
 - ✅ **Dark Mode Support**: Built-in dark mode theming


### PR DESCRIPTION
## Summary
Updates the Table Node UI component page to document its Pages compatibility and
to fix a code example that could crash apps that copy it.

## Changes
- **Pagination support (new section).** The table node ships with a built-in
  integration that makes it compatible with the Pages extension — tables split
  across page boundaries row by row, with column widths, merged cells, and
  borders preserved; a rowspan cell that crosses a break continues on the next
  page; and a cell taller than the page area becomes scrollable. No config
  needed; without Pages the table is unchanged. Added a matching Features bullet.
- **Stable `cellMenu` guidance (fix).** Both examples passed an inline
  `cellMenu={(props) => …}`, which gives the menu a new component identity every
  render, remounts its subtree, and can throw `Maximum update depth exceeded`.
  They now define `CellMenu` at module scope and pass the stable reference, with
  a warning callout.