### PR TITLE
docs(comments): remove beta tag

### DIFF
--- a/src/content/comments/getting-started/install.mdx
+++ b/src/content/comments/getting-started/install.mdx
@@ -3,7 +3,6 @@ title: Install the Comments extension
 tags:
   - type: beginStart
     tooltip: Comments work on the Start plan. Webhooks and REST API require the Team plan.
-  - type: beta
 meta:
   title: Install comments | Tiptap Comments Docs
   description: Install the comments extension in Tiptap to add threaded discussions to your editor and app. Learn more in the docs!

--- a/src/content/comments/getting-started/overview.mdx
+++ b/src/content/comments/getting-started/overview.mdx
@@ -3,7 +3,6 @@ title: Integrate Comments into your app
 tags:
   - type: beginStart
     tooltip: Comments work on the Start plan. Webhooks and REST API require the Team plan.
-  - type: beta
 meta:
   title: Comments | Tiptap Comments Docs
   description: Use the comments extension in Tiptap to add and manage comments in your Editor or via the REST API or Webhooks. More in the docs!

--- a/src/content/conversion/content-types/structures-and-media/comments.mdx
+++ b/src/content/conversion/content-types/structures-and-media/comments.mdx
@@ -1,7 +1,6 @@
 ---
 title: Comments
 tags:
-  - type: beta
   - type: version
     label: v2.29.0
 meta:

--- a/src/content/editor/extensions/functionality/comments.mdx
+++ b/src/content/editor/extensions/functionality/comments.mdx
@@ -2,7 +2,6 @@
 title: Integrate Comments into your editor
 tags:
   - type: start
-  - type: beta
 meta:
     category: Editor
 extension:

--- a/src/content/editor/sidebar.ts
+++ b/src/content/editor/sidebar.ts
@@ -292,7 +292,6 @@ export const sidebarConfig: SidebarConfig = {
               href: '/editor/extensions/functionality/comments',
               title: 'Comments',
               tags: ['Start'],
-              releaseTag: "beta",
             },
             {
               href: '/editor/extensions/functionality/drag-handle',


### PR DESCRIPTION
The Comments feature is now stable and the beta tag has been removed from its documentation and sidebar configuration.