### PR TITLE
fix: wrong status code in docs for revertDocument endpoint

### DIFF
--- a/src/content/collaboration/documents/rest-api.mdx
+++ b/src/content/collaboration/documents/rest-api.mdx
@@ -319,7 +319,7 @@ POST /api/documents/:identifier/versions/:versionId/revertTo
 
 This call lets you revert a document to a specific previous version by applying an update that corresponds to a prior state of the document.
 
-The endpoint returns HTTP status `204` if the document is successfully reverted, or `404` if the document or version is not found.
+The endpoint returns HTTP status `200` if the document is successfully reverted, or `404` if the document or version is not found.
 
 ```bash
 curl --location --request POST 'https://YOUR_APP_ID.collab.tiptap.cloud/api/documents/DOCUMENT_NAME/versions/VERSION_ID/revertTo' \


### PR DESCRIPTION
refs https://github.com/ueberdosis/tiptap/issues/6155