### PR TITLE
docs: add access requirements and enterprise callout to Tracked Changes pages

### DIFF
--- a/src/components/EnterpriseCallout.tsx
+++ b/src/components/EnterpriseCallout.tsx
@@ -16,6 +16,7 @@ export type EnterpriseCalloutProps = {
     | 'epub'
     | 'doc'
     | 'markdown'
+    | 'tracked-changes'
     | 'deprecated'
   inline?: boolean
   disableWaitlist?: boolean
@@ -24,7 +25,7 @@ export type EnterpriseCalloutProps = {
 
 const VARIANT_CONFIG: Record<
   EnterpriseCalloutProps['variant'],
-  { title: string; description: string; showWaitlist: boolean }
+  { title: string; description: string; showWaitlist: boolean; contactUrl?: string }
 > = {
   migration: {
     title: 'Migration support',
@@ -86,6 +87,13 @@ const VARIANT_CONFIG: Record<
       'Get dedicated Slack support, priority features, and hands-on help from our engineers to integrate Markdown conversion into your enterprise application.',
     showWaitlist: true,
   },
+  'tracked-changes': {
+    title: 'Get access to Tracked Changes',
+    description:
+      'Add Tracked Changes to any Tiptap subscription. Integrate it successfully with dedicated engineering support via Slack.',
+    showWaitlist: false,
+    contactUrl: 'https://tiptap.dev/contact-sales?form=tracked-changes',
+  },
   deprecated: {
     title: 'Migrate to AI Toolkit',
     description:
@@ -94,14 +102,15 @@ const VARIANT_CONFIG: Record<
   },
 }
 
-const CONTACT_URL = 'https://tiptap.dev/contact-sales?form=ai-toolkit'
+const DEFAULT_CONTACT_URL = 'https://tiptap.dev/contact-sales?form=ai-toolkit'
 
 export const EnterpriseCallout = forwardRef<HTMLDivElement, EnterpriseCalloutProps>(
   (
     { variant, inline = false, disableWaitlist = false, inverted = false, className, ...rest },
     ref,
   ) => {
-    const { title, description, showWaitlist } = VARIANT_CONFIG[variant]
+    const { title, description, showWaitlist, contactUrl } = VARIANT_CONFIG[variant]
+    const CONTACT_URL = contactUrl ?? DEFAULT_CONTACT_URL
     const displayWaitlist = showWaitlist && !disableWaitlist
 
     const waitlistText = 'On a different plan? Join the'

--- a/src/components/EnterpriseCalloutAuto.tsx
+++ b/src/components/EnterpriseCalloutAuto.tsx
@@ -16,6 +16,7 @@ export type EnterpriseCalloutAutoProps = {
     | 'epub'
     | 'doc'
     | 'markdown'
+    | 'tracked-changes'
     | 'deprecated'
   renderMode?: 'inline' | 'sidebar'
   disableWaitlist?: boolean

--- a/src/content/tracked-changes/getting-started/install.mdx
+++ b/src/content/tracked-changes/getting-started/install.mdx
@@ -9,10 +9,36 @@ meta:
 ---
 
 import { Callout } from '@/components/ui/Callout'
+import { Requirements, RequirementItem } from '@/components/Requirements'
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
 Install and configure the Tracked Changes extension by following this guide.
 
+<Requirements>
+  <RequirementItem label="1. Get access">
+    Access the Tracked Changes extension by purchasing the paid Tracked Changes add-on.{' '}
+    <a href="https://tiptap.dev/contact-sales?form=tracked-changes">Contact our team</a>.
+  </RequirementItem>
+  <RequirementItem label="2. Access the private registry">
+    The Tracked Changes extension is published in Tiptap's private npm registry. Authenticate to
+    Tiptap's private npm registry by following the [setup guide](/guides/pro-extensions).
+  </RequirementItem>
+  <RequirementItem label="3. Install the extension">
+    Install the extension from the private registry using npm or your preferred package manager.
+  </RequirementItem>
+</Requirements>
+
+<EnterpriseCalloutAuto variant="tracked-changes" renderMode="sidebar" />
+
 ## Install
+
+First, <a href="https://tiptap.dev/contact-sales?form=tracked-changes">contact our team</a> to
+purchase the paid Tracked Changes add-on.
+
+After gaining access, configure your package manager by following the [private registry
+guide](/guides/pro-extensions).
+
+Then, install the package:
 
 ```bash
 npm install @tiptap-pro/extension-tracked-changes

--- a/src/content/tracked-changes/getting-started/install.mdx
+++ b/src/content/tracked-changes/getting-started/install.mdx
@@ -16,8 +16,8 @@ Install and configure the Tracked Changes extension by following this guide.
 
 <Requirements>
   <RequirementItem label="1. Get access">
-    Access the Tracked Changes extension by purchasing the paid Tracked Changes add-on.{' '}
-    <a href="https://tiptap.dev/contact-sales?form=tracked-changes">Contact our team</a>.
+    <a href="https://tiptap.dev/contact-sales?form=tracked-changes">Contact our team</a> to get
+    access to the paid Tracked Changes add-on.
   </RequirementItem>
   <RequirementItem label="2. Access the private registry">
     The Tracked Changes extension is published in Tiptap's private npm registry. Authenticate to
@@ -32,8 +32,8 @@ Install and configure the Tracked Changes extension by following this guide.
 
 ## Install
 
-First, <a href="https://tiptap.dev/contact-sales?form=tracked-changes">contact our team</a> to
-purchase the paid Tracked Changes add-on.
+First, <a href="https://tiptap.dev/contact-sales?form=tracked-changes">contact our team</a> to get
+access to the paid Tracked Changes add-on.
 
 After gaining access, configure your package manager by following the [private registry
 guide](/guides/pro-extensions).

--- a/src/content/tracked-changes/getting-started/overview.mdx
+++ b/src/content/tracked-changes/getting-started/overview.mdx
@@ -16,8 +16,8 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 
 <Requirements>
   <RequirementItem label="1. Get access">
-    Access the Tracked Changes extension by purchasing the paid Tracked Changes add-on.{' '}
-    <a href="https://tiptap.dev/contact-sales?form=tracked-changes">Contact our team</a>.
+    <a href="https://tiptap.dev/contact-sales?form=tracked-changes">Contact our team</a> to get
+    access to the paid Tracked Changes add-on.
   </RequirementItem>
   <RequirementItem label="2. Access the private registry">
     The Tracked Changes extension is published in Tiptap's private npm registry. Authenticate to

--- a/src/content/tracked-changes/getting-started/overview.mdx
+++ b/src/content/tracked-changes/getting-started/overview.mdx
@@ -11,6 +11,24 @@ meta:
 ---
 
 import { CodeDemo } from '@/components/CodeDemo'
+import { Requirements, RequirementItem } from '@/components/Requirements'
+import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+
+<Requirements>
+  <RequirementItem label="1. Get access">
+    Access the Tracked Changes extension by purchasing the paid Tracked Changes add-on.{' '}
+    <a href="https://tiptap.dev/contact-sales?form=tracked-changes">Contact our team</a>.
+  </RequirementItem>
+  <RequirementItem label="2. Access the private registry">
+    The Tracked Changes extension is published in Tiptap's private npm registry. Authenticate to
+    Tiptap's private npm registry by following the [setup guide](/guides/pro-extensions).
+  </RequirementItem>
+  <RequirementItem label="3. Install the extension">
+    Install the extension from the private registry using npm or your preferred package manager.
+  </RequirementItem>
+</Requirements>
+
+<EnterpriseCalloutAuto variant="tracked-changes" renderMode="sidebar" />
 
 The Tracked Changes extension enables suggestion mode for collaborative editing workflows. When enabled, all edits appear as proposals that can be accepted or rejected, similar to change tracking in word processors.
 
@@ -38,6 +56,8 @@ Each suggestion carries metadata including who created it, when it was created, 
 - **Atom node support** — Tracks changes to images, horizontal rules, and other non-text content
 - **Table support** — Tracks row, cell, and column insertions and deletions, including cell selections
 - **Full query API** — Find, filter, and inspect suggestions programmatically
+
+<EnterpriseCalloutAuto variant="tracked-changes" renderMode="inline" />
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

The Tracked Changes overview and install pages never explained how to get access to the paid add-on (this gap existed since the docs were first created in #589/#660). This PR brings them in line with how the AI Toolkit pages communicate access and requirements:

- **Requirements block** (sidebar/top card) on both the overview and install pages: get access → authenticate to the private registry → install the extension
- **Enterprise callout card** ("Get access to Tracked Changes … Talk to an engineer") in the sidebar of both pages, plus inline in the body of the overview page — mirroring the AI Toolkit placement
- **Install page prose** now walks through contacting sales and setting up the private registry before the `npm install` step
- New `tracked-changes` variant for `EnterpriseCallout`/`EnterpriseCalloutAuto` with a per-variant contact URL (`https://tiptap.dev/contact-sales?form=tracked-changes`); all existing variants keep the current `?form=ai-toolkit` URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)