### PR TITLE
feat: allow requesting the changelogs as markdown

### DIFF
--- a/src/app/api/md/[...path]/route.ts
+++ b/src/app/api/md/[...path]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { resolveContentPath } from '@/server/markdown/resolveContentPath'
+import { resolveContentPath, normalizeRoutePath } from '@/server/markdown/resolveContentPath'
 import { fileToMarkdown } from '@/server/markdown/fileToMarkdown'
+import { changelogToMarkdown } from '@/server/markdown/changelogToMarkdown'
 import { createCanonicalUrl } from '@/server/createCanonicalUrl'
 
 // Needs the Node runtime for filesystem access to src/content.
@@ -9,15 +10,63 @@ export const dynamic = 'force-dynamic'
 
 type Params = { params: Promise<{ path?: string[] }> }
 
+const CHANGELOG_PREFIX = 'resources/changelog/'
+
 /** Append `.md` to internal doc routes (but not to asset paths with an extension). */
 function toMarkdownDestination(destination: string): string {
   if (/\.[a-z0-9]+$/i.test(destination)) return destination
   return `${destination}.md`
 }
 
+/**
+ * Build a 200 markdown response with the shared canonical/cache/robots headers.
+ *
+ * When reached via `Accept: text/markdown` (proxy signal), this response is
+ * cached under the bare HTML URL's key. Next strips `Vary: Accept` from the HTML
+ * page response (a known framework bug), so a Vary-ignoring shared cache could
+ * otherwise hand this markdown to a browser. Keep it out of shared caches; the
+ * standalone `.md` URL is its own key and stays cacheable.
+ */
+function markdownResponse(markdown: string, canonical: string, negotiated: boolean): NextResponse {
+  const cacheControl = negotiated
+    ? 'private, no-store'
+    : 'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400'
+
+  return new NextResponse(markdown, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'X-Content-Type-Options': 'nosniff',
+      // Same URL serves HTML or Markdown depending on the Accept header.
+      Vary: 'Accept',
+      'Cache-Control': cacheControl,
+      // Point crawlers at the canonical human page …
+      Link: `<${canonical}>; rel="canonical"`,
+      // … and keep the markdown duplicate out of search indexes.
+      'X-Robots-Tag': 'noindex',
+    },
+  })
+}
+
 export async function GET(request: NextRequest, { params }: Params) {
   const { path: segments } = await params
-  const routePath = (segments ?? []).join('/')
+  const routePath = normalizeRoutePath((segments ?? []).join('/'))
+  const negotiated = request.headers.get('x-markdown-negotiated') === '1'
+
+  // Changelog pages are generated from JSON data and rendered by the
+  // `resources/changelog/[slug]` route, so they have no `.mdx` file for
+  // resolveContentPath to find. Serve their markdown directly. A miss falls
+  // through to resolveContentPath, which yields the shared 404 response.
+  if (routePath.startsWith(CHANGELOG_PREFIX)) {
+    const slug = routePath.slice(CHANGELOG_PREFIX.length)
+    if (!slug.includes('/')) {
+      const canonical = createCanonicalUrl(['resources', 'changelog', slug])
+      const markdown = changelogToMarkdown(slug, canonical)
+      if (markdown) {
+        return markdownResponse(markdown, canonical, negotiated)
+      }
+    }
+  }
 
   const resolved = resolveContentPath(routePath)
 
@@ -44,30 +93,7 @@ export async function GET(request: NextRequest, { params }: Params) {
     const canonical = createCanonicalUrl(resolved.routePath ? resolved.routePath.split('/') : [])
     const markdown = await fileToMarkdown(resolved.filePath, canonical)
 
-    // When reached via `Accept: text/markdown` (proxy signal), this response is
-    // cached under the bare HTML URL's key. Next strips `Vary: Accept` from the
-    // HTML page response (a known framework bug), so a Vary-ignoring shared
-    // cache could otherwise hand this markdown to a browser. Keep it out of
-    // shared caches; the standalone `.md` URL is its own key and stays cacheable.
-    const negotiated = request.headers.get('x-markdown-negotiated') === '1'
-    const cacheControl = negotiated
-      ? 'private, no-store'
-      : 'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400'
-
-    return new NextResponse(markdown, {
-      status: 200,
-      headers: {
-        'Content-Type': 'text/markdown; charset=utf-8',
-        'X-Content-Type-Options': 'nosniff',
-        // Same URL serves HTML or Markdown depending on the Accept header.
-        Vary: 'Accept',
-        'Cache-Control': cacheControl,
-        // Point crawlers at the canonical human page …
-        Link: `<${canonical}>; rel="canonical"`,
-        // … and keep the markdown duplicate out of search indexes.
-        'X-Robots-Tag': 'noindex',
-      },
-    })
+    return markdownResponse(markdown, canonical, negotiated)
   } catch (error) {
     console.error(`Failed to render markdown for /${routePath}:`, error)
     return new NextResponse('# Error\n\nFailed to render this page as markdown.\n', {

--- a/src/server/markdown/changelogToMarkdown.ts
+++ b/src/server/markdown/changelogToMarkdown.ts
@@ -1,0 +1,23 @@
+import { getChangelogData } from '@/server/getChangelogData'
+import { buildFrontmatter } from './fileToMarkdown'
+
+/**
+ * Build the `.md` response for a changelog page. Changelog pages are generated
+ * from JSON data (see scripts/generate-changelogs.ts) and rendered by the
+ * `resources/changelog/[slug]` route, not from `.mdx` files — so
+ * resolveContentPath/fileToMarkdown can't see them. This mirrors the format
+ * fileToMarkdown produces: frontmatter + H1 title + description + body.
+ *
+ * Returns null when no changelog exists for the slug (unknown or invalid slug),
+ * so the caller can fall through to a 404.
+ */
+export function changelogToMarkdown(slug: string, canonicalUrl?: string): string | null {
+  const data = getChangelogData(slug)
+  if (!data) return null
+
+  const title = `${data.packageName} changelog`
+  const description = `Changelog for ${data.packageName}`
+  const frontmatter = buildFrontmatter({ title, description, canonicalUrl })
+
+  return `${[frontmatter, `# ${title}`, description, data.content].join('\n\n').trim()}\n`
+}

--- a/src/server/markdown/fileToMarkdown.ts
+++ b/src/server/markdown/fileToMarkdown.ts
@@ -43,7 +43,7 @@ function stripHtml(value: string): string {
 }
 
 /** Build the minimal YAML frontmatter block served atop every `.md` response. */
-function buildFrontmatter(fields: {
+export function buildFrontmatter(fields: {
   title?: string
   description?: string
   canonicalUrl?: string


### PR DESCRIPTION
Adds support to request the changelogs as markdown as well. They don't work the usual way because the changelogs are not stored in .mdx but in json files.

I was debugging the deployment of changelogs and had a hard time understanding why this doesnt work. Debugging a nextjs deployment via curl is really hard as you just get a lot of javascript back, which is the main reason for me to add support here :)