### PR TITLE
docs: add insertDefaultBlock command reference

### DIFF
--- a/src/content/editor/api/commands/index.mdx
+++ b/src/content/editor/api/commands/index.mdx
@@ -200,6 +200,7 @@ Have a look at all of the core commands listed below. They should give you a goo
 | `deleteNode()`          | Delete a node.                                            |
 | `extendMarkRange()`     | Extends the text selection to the current mark.           |
 | `exitCode()`            | Exit from a code block.                                   |
+| `insertDefaultBlock()`  | Insert the default block type at a position.              |
 | `joinBackward()`        | Join two nodes backward.                                  |
 | `joinForward()`         | Join two nodes forward.                                   |
 | `lift()`                | Removes an existing wrap.                                 |

--- a/src/content/editor/api/commands/nodes-and-marks/index.mdx
+++ b/src/content/editor/api/commands/nodes-and-marks/index.mdx
@@ -26,6 +26,7 @@ Nodes and marks are the building blocks of your Tiptap editor. Nodes represent c
 | `deleteNode`          | Deletes the selected node.                                                 |
 | `extendMarkRange`     | Expands the current selection to encompass the specified mark.             |
 | `exitCode`            | Exits the current code block and continues editing in a new default block. |
+| `insertDefaultBlock`  | Inserts the schema's default block type at a given position.              |
 | `joinBackward`        | Joins two nodes backwards from the current selection.                      |
 | `joinForward`         | Joins two nodes forwards from the current selection.                       |
 | `lift`                | Lifts a node up into its parent node.                                      |

--- a/src/content/editor/api/commands/nodes-and-marks/index.mdx
+++ b/src/content/editor/api/commands/nodes-and-marks/index.mdx
@@ -26,7 +26,7 @@ Nodes and marks are the building blocks of your Tiptap editor. Nodes represent c
 | `deleteNode`          | Deletes the selected node.                                                 |
 | `extendMarkRange`     | Expands the current selection to encompass the specified mark.             |
 | `exitCode`            | Exits the current code block and continues editing in a new default block. |
-| `insertDefaultBlock`  | Inserts the schema's default block type at a given position.              |
+| `insertDefaultBlock`  | Inserts the schema's default block type at a given position.               |
 | `joinBackward`        | Joins two nodes backwards from the current selection.                      |
 | `joinForward`         | Joins two nodes forwards from the current selection.                       |
 | `lift`                | Lifts a node up into its parent node.                                      |

--- a/src/content/editor/api/commands/nodes-and-marks/insert-default-block.mdx
+++ b/src/content/editor/api/commands/nodes-and-marks/insert-default-block.mdx
@@ -1,0 +1,44 @@
+---
+title: insertDefaultBlock command
+meta:
+  title: insertDefaultBlock command | Tiptap Editor Docs
+  description: Use the insertDefaultBlock command in Tiptap to insert the schema's default block at a position. More in the docs!
+  category: Editor
+---
+
+The `insertDefaultBlock` command inserts the schema's default content block type at a given position. The block type is determined automatically using `defaultBlockAt()`, so the schema decides what fits at the insertion point.
+
+This is useful for inserting context-aware empty blocks, for example, inserting a paragraph inside a document or a blockquote — without hardcoding the node type.
+
+The command returns `false` when no valid default block can be inserted at the position (e.g., when the position is inside a textblock). It does not silently reposition.
+
+## Parameters
+
+`options: InsertDefaultBlockOptions`
+
+- `pos: number | ResolvedPos` – Position to insert the block at. Accepts a numeric offset or a resolved ProseMirror position. Defaults to the current caret position.
+- `attrs: Record<string, any>` – Attributes to apply to the inserted node. Only keys defined in the node type's `spec.attrs` are kept; unknown attributes are filtered out.
+- `content: Content | ProseMirrorNode | Fragment` – Content to insert into the block. Accepts plain text, an HTML string, or a ProseMirror node/fragment.
+- `updateSelection: boolean` – Whether to move the selection to the newly inserted block. Defaults to `true`.
+
+## Use the insertDefaultBlock command
+
+```js
+// Insert at the current selection position
+editor.commands.insertDefaultBlock()
+
+// Insert at a specific position
+editor.commands.insertDefaultBlock({ pos: 0 })
+
+// Insert with text content
+editor.commands.insertDefaultBlock({ pos: 0, content: 'Hello' })
+
+// Insert with HTML content
+editor.commands.insertDefaultBlock({ pos: 0, content: '<strong>bold</strong>' })
+
+// Insert a heading (when heading is the default block at that position)
+editor.commands.insertDefaultBlock({ pos: 0, attrs: { level: 2 }, content: 'Title' })
+
+// Insert without updating the selection
+editor.commands.insertDefaultBlock({ pos: 0, content: 'Hello', updateSelection: false })
+```


### PR DESCRIPTION
Add documentation for the new `insertDefaultBlock` command from [#8081](https://github.com/ueberdosis/tiptap/pull/8081).

## Changes

- **new file**: `insert-default-block.mdx` with parameter docs, usage examples, and note on false return behavior
- **nodes-and-marks/index.mdx**: added row to command table
- **commands/index.mdx**: added row to Nodes & Marks overview table