### PR TITLE
docs(code-block): document exitOnArrowUp option

### DIFF
--- a/.changeset/document-code-block-exit-on-arrow-up.md
+++ b/.changeset/document-code-block-exit-on-arrow-up.md
@@ -1,5 +1,0 @@
----
-'tiptap-docs': patch
----
-
-Document CodeBlock `exitOnArrowUp` option

--- a/.changeset/document-code-block-exit-on-arrow-up.md
+++ b/.changeset/document-code-block-exit-on-arrow-up.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Document CodeBlock `exitOnArrowUp` option

--- a/src/content/editor/extensions/nodes/code-block.mdx
+++ b/src/content/editor/extensions/nodes/code-block.mdx
@@ -102,6 +102,18 @@ CodeBlock.configure({
 })
 ```
 
+### exitOnArrowUp
+
+Define whether the node should be exited on arrow up if there is no node before it.
+
+Default: `true`
+
+```js
+CodeBlock.configure({
+  exitOnArrowUp: false,
+})
+```
+
 ### enableTabIndentation
 
 Define whether pressing the Tab key should be used for indentation.


### PR DESCRIPTION
## Summary

Documents the new `exitOnArrowUp` option added to the `CodeBlock` extension
in https://github.com/ueberdosis/tiptap/pull/8114. The entry mirrors the
existing `exitOnArrowDown` docs entry immediately above it.

## Related

- Tiptap core PR: https://github.com/ueberdosis/tiptap/pull/8114
- Original issue: https://github.com/ueberdosis/tiptap/issues/5472

## Changes

- `src/content/editor/extensions/nodes/code-block.mdx` — new `### exitOnArrowUp` section
- Patch changeset (`tiptap-docs`)

## Test plan

- [x] `pnpm dev` — page renders, new `#exitonarrowup` anchor reachable
- [x] `pnpm exec prettier --check` clean on changed files