### PR TITLE
feat: api-us docs for conversion rest endpoints

### DIFF
--- a/src/content/conversion/_shared/_regional-endpoints.mdx
+++ b/src/content/conversion/_shared/_regional-endpoints.mdx
@@ -1,0 +1,6 @@
+import { Callout } from '@/components/ui/Callout'
+
+<Callout title="Choose your region" variant="info">
+  The default endpoint `api.tiptap.dev` is served from the **EU** region. The conversion service is
+  also available in the **US** region at `api-us.tiptap.dev`.
+</Callout>

--- a/src/content/conversion/export/doc/rest-api.mdx
+++ b/src/content/conversion/export/doc/rest-api.mdx
@@ -15,6 +15,7 @@ import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 import ElementOverridesRestApi from '../_shared/_element-overrides-rest-api.mdx'
+import RegionalEndpoints from '../../_shared/_regional-endpoints.mdx'
 
 <EnterpriseCalloutAuto variant="doc" renderMode="sidebar" disableWaitlist />
 
@@ -37,6 +38,8 @@ The DOC export API converts Tiptap JSON documents into DOC files (legacy Microso
     You can also experiment with the Document Conversion API by heading over to our [Postman
     Collection](https://www.postman.com/tiptap-platform/workspace/tiptap-workspace/collection/33042171-bcc93ecb-8bad-4484-8cb0-d995ee23ae60).
 </Callout>
+
+<RegionalEndpoints />
 
 ## Export DOC
 

--- a/src/content/conversion/export/docx/rest-api.mdx
+++ b/src/content/conversion/export/docx/rest-api.mdx
@@ -15,6 +15,7 @@ import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 import ElementOverridesRestApi from '../_shared/_element-overrides-rest-api.mdx'
+import RegionalEndpoints from '../../_shared/_regional-endpoints.mdx'
 
 <EnterpriseCalloutAuto variant="docx" renderMode="sidebar" disableWaitlist />
 
@@ -36,6 +37,8 @@ The REST API supports [style overrides](/conversion/export/docx/styles), [custom
   You can also experiment with the Document Conversion API by heading over to our [Postman
   Collection](https://www.postman.com/tiptap-platform/workspace/tiptap-workspace/collection/33042171-bcc93ecb-8bad-4484-8cb0-d995ee23ae60).
 </Callout>
+
+<RegionalEndpoints />
 
 ## Export DOCX
 

--- a/src/content/conversion/export/epub/rest-api.mdx
+++ b/src/content/conversion/export/epub/rest-api.mdx
@@ -15,6 +15,7 @@ import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 import ElementOverridesRestApi from '../_shared/_element-overrides-rest-api.mdx'
+import RegionalEndpoints from '../../_shared/_regional-endpoints.mdx'
 
 <EnterpriseCalloutAuto variant="epub" renderMode="sidebar" disableWaitlist />
 
@@ -33,6 +34,8 @@ The EPUB export API converts Tiptap JSON documents into EPUB files.
     You can also experiment with the Document Conversion API by heading over to our [Postman
     Collection](https://www.postman.com/tiptap-platform/workspace/tiptap-workspace/collection/33042171-bcc93ecb-8bad-4484-8cb0-d995ee23ae60).
 </Callout>
+
+<RegionalEndpoints />
 
 ## Export EPUB
 

--- a/src/content/conversion/export/markdown/rest-api.mdx
+++ b/src/content/conversion/export/markdown/rest-api.mdx
@@ -14,6 +14,7 @@ meta:
 import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+import RegionalEndpoints from '../../_shared/_regional-endpoints.mdx'
 
 <EnterpriseCalloutAuto variant="markdown" renderMode="sidebar" disableWaitlist />
 
@@ -32,6 +33,8 @@ The Markdown export API converts Tiptap JSON documents into Markdown files.
     You can also experiment with the Document Conversion API by heading over to our [Postman
     Collection](https://www.postman.com/tiptap-platform/workspace/tiptap-workspace/collection/33042171-bcc93ecb-8bad-4484-8cb0-d995ee23ae60).
 </Callout>
+
+<RegionalEndpoints />
 
 ## Export Markdown
 

--- a/src/content/conversion/export/odt/rest-api.mdx
+++ b/src/content/conversion/export/odt/rest-api.mdx
@@ -15,6 +15,7 @@ import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 import ElementOverridesRestApi from '../_shared/_element-overrides-rest-api.mdx'
+import RegionalEndpoints from '../../_shared/_regional-endpoints.mdx'
 
 <EnterpriseCalloutAuto variant="odt" renderMode="sidebar" disableWaitlist />
 
@@ -33,6 +34,8 @@ The ODT export API converts Tiptap JSON documents into OpenDocument Text (`.odt`
     You can also experiment with the Document Conversion API by heading over to our [Postman
     Collection](https://www.postman.com/tiptap-platform/workspace/tiptap-workspace/collection/33042171-bcc93ecb-8bad-4484-8cb0-d995ee23ae60).
 </Callout>
+
+<RegionalEndpoints />
 
 ## Export ODT
 

--- a/src/content/conversion/export/pdf/rest-api.mdx
+++ b/src/content/conversion/export/pdf/rest-api.mdx
@@ -15,6 +15,7 @@ import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
 import ElementOverridesRestApi from '../_shared/_element-overrides-rest-api.mdx'
+import RegionalEndpoints from '../../_shared/_regional-endpoints.mdx'
 
 <EnterpriseCalloutAuto variant="pdf" renderMode="sidebar" disableWaitlist />
 
@@ -33,6 +34,8 @@ The PDF export API converts Tiptap JSON documents into PDF files.
     You can also experiment with the Document Conversion API by heading over to our [Postman
     Collection](https://www.postman.com/tiptap-platform/workspace/tiptap-workspace/collection/33042171-bcc93ecb-8bad-4484-8cb0-d995ee23ae60).
 </Callout>
+
+<RegionalEndpoints />
 
 ## Export PDF
 

--- a/src/content/conversion/import/docx/rest-api.mdx
+++ b/src/content/conversion/import/docx/rest-api.mdx
@@ -14,6 +14,7 @@ meta:
 import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+import RegionalEndpoints from '../../_shared/_regional-endpoints.mdx'
 
 <EnterpriseCalloutAuto variant="docx" renderMode="sidebar" disableWaitlist />
 
@@ -34,6 +35,8 @@ The REST API is the better choice when you need server-side processing, access t
   You can also experiment with the Document Conversion API by heading over to our [Postman
   Collection](https://www.postman.com/tiptap-platform/workspace/tiptap-workspace/collection/33042171-bcc93ecb-8bad-4484-8cb0-d995ee23ae60).
 </Callout>
+
+<RegionalEndpoints />
 
 ## Import DOCX
 

--- a/src/content/conversion/import/markdown/rest-api.mdx
+++ b/src/content/conversion/import/markdown/rest-api.mdx
@@ -14,6 +14,7 @@ meta:
 import { Callout } from '@/components/ui/Callout'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
+import RegionalEndpoints from '../../_shared/_regional-endpoints.mdx'
 
 <EnterpriseCalloutAuto variant="markdown" renderMode="sidebar" disableWaitlist />
 
@@ -32,6 +33,8 @@ The Markdown import API converts `.md` files into Tiptap JSON format.
     You can also experiment with the Document Conversion API by heading over to our [Postman
     Collection](https://www.postman.com/tiptap-platform/workspace/tiptap-workspace/collection/33042171-bcc93ecb-8bad-4484-8cb0-d995ee23ae60).
 </Callout>
+
+<RegionalEndpoints />
 
 ## Import Markdown
 


### PR DESCRIPTION
Updates conversion REST api docs to mention newly available api-us.tiptap.dev region.