### PR TITLE
docs(ui): add search and replace documentation

### DIFF
--- a/src/content/ui-components/components/ai-menu.mdx
+++ b/src/content/ui-components/components/ai-menu.mdx
@@ -56,7 +56,7 @@ import { AiMenu } from '@/components/tiptap-ui/ai-menu'
 import { AiAskButton } from '@/components/tiptap-ui/ai-ask-button'
 
 // --- UI Primitive ---
-import { ButtonGroup } from '@/components/tiptap-ui-primitive/button'
+import { ButtonGroup } from '@/components/tiptap-ui-primitive/button-group'
 
 // --- Utils ---
 import { TIPTAP_AI_APP_ID } from '@/lib/tiptap-collab-utils'

--- a/src/content/ui-components/components/color-highlight-button.mdx
+++ b/src/content/ui-components/components/color-highlight-button.mdx
@@ -50,7 +50,7 @@ import { Highlight } from '@tiptap/extension-highlight'
 import { ColorHighlightButton } from '@/components/tiptap-ui/color-highlight-button'
 
 // --- UI Primitive ---
-import { ButtonGroup } from '@/components/tiptap-ui-primitive/button'
+import { ButtonGroup } from '@/components/tiptap-ui-primitive/button-group'
 
 // --- Node Styles ---
 import '@/components/tiptap-node/code-block-node/code-block-node.scss'

--- a/src/content/ui-components/components/color-text-popover.mdx
+++ b/src/content/ui-components/components/color-text-popover.mdx
@@ -148,7 +148,8 @@ const { recentColors, addRecentColor, isInitialized } = useRecentColors(3)
 Finds a color object by its value from a color array.
 
 ```tsx
-import { getColorByValue, TEXT_COLORS } from '@/components/tiptap-ui/color-text-popover'
+import { getColorByValue } from '@/components/tiptap-ui/color-text-popover'
+import { TEXT_COLORS } from '@/components/tiptap-ui/color-text-button'
 
 const blueColor = getColorByValue('var(--tt-color-text-blue)', TEXT_COLORS)
 // Returns: { label: "Blue text", value: "var(--tt-color-text-blue)", ... }

--- a/src/content/ui-components/components/improve-dropdown.mdx
+++ b/src/content/ui-components/components/improve-dropdown.mdx
@@ -55,7 +55,7 @@ import { UiState } from '@/components/tiptap-extension/ui-state-extension'
 import { AiProvider, useAi } from '@/components/contexts/ai-context'
 
 // --- UI Primitive ---
-import { ButtonGroup } from '@/components/tiptap-ui-primitive/button'
+import { ButtonGroup } from '@/components/tiptap-ui-primitive/button-group'
 
 // --- Tiptap Node ---
 import '@/components/tiptap-node/blockquote-node/blockquote-node.scss'
@@ -271,17 +271,16 @@ const shouldShow = shouldShowImproveDropdown({
 })
 ```
 
-### `executeAICommand(editor, command, textOptions?)`
+### `executeAICommand(command)`
 
-Programmatically executes an AI improvement command on the current selection.
+Runs an AI improvement command on the current selection. It is bound to the editor the hook resolved, so take it from `useImproveDropdown()` instead of importing it.
 
 ```tsx
-import { executeAICommand } from '@/components/tiptap-ui/improve-dropdown'
+import { useImproveDropdown } from '@/components/tiptap-ui/improve-dropdown'
 
-const success = executeAICommand(editor, 'fixSpellingAndGrammar')
-if (success) {
-  console.log('Grammar fixed successfully!')
-}
+const { executeAICommand } = useImproveDropdown({ editor })
+
+executeAICommand('fixSpellingAndGrammar')
 ```
 
 ## Requirements

--- a/src/content/ui-components/components/link-popover.mdx
+++ b/src/content/ui-components/components/link-popover.mdx
@@ -42,7 +42,6 @@ A prebuilt React component that provides a complete link editing interface in a 
 ```tsx
 import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
 import { StarterKit } from '@tiptap/starter-kit'
-import { Link } from '@/components/tiptap-extension/link-extension'
 import { LinkPopover } from '@/components/tiptap-ui/link-popover'
 
 import '@/components/tiptap-node/paragraph-node/paragraph-node.scss'
@@ -50,7 +49,11 @@ import '@/components/tiptap-node/paragraph-node/paragraph-node.scss'
 export default function MyEditor() {
   const editor = useEditor({
     immediatelyRender: false,
-    extensions: [StarterKit, Link.configure({ openOnClick: false })],
+    extensions: [
+      StarterKit.configure({
+        link: { openOnClick: false, enableClickSelection: true },
+      }),
+    ],
     content: `
         <p>Click the button to open the link popover.</p>
         <p><a href="https://www.tiptap.dev">Tiptap</a></p>
@@ -247,14 +250,15 @@ The link popover supports the following keyboard interactions:
 ### Dependencies
 
 - `@tiptap/react` - Core Tiptap React integration
-- `@tiptap/extension-link` - Link extension for link functionality
+- `@tiptap/starter-kit` - Provides the Link extension through its `link` option
 
 ### Referenced Components
 
 - `use-tiptap-editor` (hook)
-- `use-mobile` (hook)
+- `use-is-breakpoint` (hook)
 - `use-link-popover` (hook)
 - `button` (primitive)
+- `button-group` (primitive)
 - `popover` (primitive)
 - `card` (primitive)
 - `input` (primitive)

--- a/src/content/ui-components/components/list-button.mdx
+++ b/src/content/ui-components/components/list-button.mdx
@@ -151,15 +151,16 @@ import { isListActive } from '@/components/tiptap-ui/list-button'
 const active = isListActive(editor, 'taskList')
 ```
 
-### `getListOption(type)`
+### `listLabels`, `listIcons`, and `LIST_SHORTCUT_KEYS`
 
-Gets the configuration object for a specific list type.
+Per-type lookup maps for building your own list controls. Each is keyed by `ListType`.
 
 ```tsx
-import { getListOption } from '@/components/tiptap-ui/list-button'
+import { LIST_SHORTCUT_KEYS, listIcons, listLabels } from '@/components/tiptap-ui/list-button'
 
-const option = getListOption('bulletList')
-// Returns: { label: "Bullet List", type: "bulletList", icon: ListIcon }
+const Icon = listIcons.bulletList // ListIcon
+const label = listLabels.bulletList // "Bullet List"
+const shortcut = LIST_SHORTCUT_KEYS.bulletList // "mod+shift+8"
 ```
 
 ## Keyboard Shortcuts

--- a/src/content/ui-components/components/list-dropdown-menu.mdx
+++ b/src/content/ui-components/components/list-dropdown-menu.mdx
@@ -129,7 +129,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from '@/components/tiptap-ui-primitive/dropdown-menu'
-import { ButtonGroup } from '@/components/tiptap-ui-primitive/button'
+import { ButtonGroup } from '@/components/tiptap-ui-primitive/button-group'
 
 function MyListDropdown() {
   const { filteredLists, canToggle, isActive, isVisible, Icon, activeType } = useListDropdownMenu({

--- a/src/content/ui-components/components/search-and-replace.mdx
+++ b/src/content/ui-components/components/search-and-replace.mdx
@@ -28,8 +28,8 @@ The component owns the search state and editor commands, but deliberately does n
 
 <Callout title="Requires the Find and Replace extension" variant="warning">
   Register `@tiptap/extension-find-and-replace` on the same editor. Without the extension, the panel
-  remains visible but its controls are disabled by default. Set `hideWhenUnavailable` to `true` if
-  the panel should not render when the extension is missing.
+  still renders but its controls are disabled by default. Set `hideWhenUnavailable` to `true` if the
+  panel should not render when the extension is missing.
 </Callout>
 
 ## Installation
@@ -65,7 +65,7 @@ Search input changes are sent directly to the extension. The extension's `search
 
 ### `<SearchAndReplace />`
 
-The complete search and replace panel. Keep the component mounted and control it with `open` when you want the built-in `Mod+F` shortcut to reopen a hidden panel.
+The complete search and replace panel. Keep the component mounted and control it with `open` when you want the built-in `Mod+F` shortcut to reopen a closed panel.
 
 #### Usage
 
@@ -121,7 +121,7 @@ export default function MyEditor() {
 }
 ```
 
-When an open `SearchAndReplace` panel changes to `open={false}`, it stays mounted, hides the panel, removes result highlights, and keeps the entered search and replacement values. Opening it again reapplies the stored search. Unmounting the component clears the search and pending work entirely.
+When an open `SearchAndReplace` panel changes to `open={false}`, the component stays mounted, the closed panel is no longer displayed, result highlights are removed, and the entered search and replacement values are kept. Opening it again reapplies the stored search. Unmounting the component clears the search and pending work entirely.
 
 The panel does not close itself when the user clicks outside it. If your layout needs outside-click dismissal, manage that behavior in the component that owns `open`.
 
@@ -129,17 +129,19 @@ Navigating results moves the highlight only. The editor selection stays where th
 
 #### Props
 
+Two separate states control the panel: `open` decides whether a mounted panel is shown or closed, and `hideWhenUnavailable` decides whether the component renders at all.
+
 The component also forwards `HTMLAttributes<HTMLDivElement>`—except `children`—to the root panel.
 
 | Name                    | Type                    | Default                                   | Description                                                                                                                          |
 | ----------------------- | ----------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `editor`                | `Editor \| null`        | Editor from `EditorContext`               | The Tiptap editor instance.                                                                                                          |
-| `hideWhenUnavailable`   | `boolean`               | `false`                                   | Hides the panel when the Find and Replace extension is unavailable. Otherwise the panel remains visible with disabled controls.      |
+| `hideWhenUnavailable`   | `boolean`               | `false`                                   | Renders nothing when the Find and Replace extension is unavailable. Otherwise the panel still renders, with disabled controls.       |
 | `scrollIntoViewOptions` | `ScrollIntoViewOptions` | `{ block: 'nearest', inline: 'nearest' }` | Options used when the current result is scrolled into view. Smooth scrolling becomes immediate when the user prefers reduced motion. |
-| `open`                  | `boolean`               | `true`                                    | Whether the mounted panel is active and visible. Closing preserves entered values but suspends result highlighting.                  |
+| `open`                  | `boolean`               | `true`                                    | Whether the mounted panel is open. Closing preserves entered values but suspends result highlighting.                                |
 | `onClose`               | `() => void`            | `undefined`                               | Called by the close button or `Escape`. The callback must update the controlled `open` state.                                        |
-| `onOpen`                | `() => void`            | `undefined`                               | Called when `Mod+F` is pressed while the panel is hidden. Provide it when the shortcut should reopen the panel.                      |
-| `enableShortcut`        | `boolean`               | `true`                                    | Binds `Mod+F` page-wide while the component is visible and the extension is available.                                               |
+| `onOpen`                | `() => void`            | `undefined`                               | Called when `Mod+F` is pressed while the panel is closed. Provide it when the shortcut should reopen the panel.                      |
+| `enableShortcut`        | `boolean`               | `true`                                    | Binds `Mod+F` for the whole page while the component is mounted and the extension is available, including while the panel is closed. |
 | `autoFocusSearch`       | `boolean`               | `true`                                    | Focuses and selects the search input when the panel opens and the editor is ready.                                                   |
 | `className`             | `string`                | `undefined`                               | Adds a class to the root panel without removing `tiptap-search-replace`.                                                             |
 
@@ -248,11 +250,11 @@ function CustomSearchPanel({ editor }) {
 
 #### Configuration
 
-| Name                    | Type                    | Default                            | Description                                                                                   |
-| ----------------------- | ----------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------- |
-| `editor`                | `Editor \| null`        | Editor from `EditorContext`        | The Tiptap editor instance.                                                                   |
-| `hideWhenUnavailable`   | `boolean`               | `false`                            | Whether the hook reports the UI as hidden when the Find and Replace extension is unavailable. |
-| `scrollIntoViewOptions` | `ScrollIntoViewOptions` | `DEFAULT_SCROLL_INTO_VIEW_OPTIONS` | Options used to reveal the current result without moving focus.                               |
+| Name                    | Type                    | Default                            | Description                                                                                     |
+| ----------------------- | ----------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `editor`                | `Editor \| null`        | Editor from `EditorContext`        | The Tiptap editor instance.                                                                     |
+| `hideWhenUnavailable`   | `boolean`               | `false`                            | Whether the hook reports `isVisible: false` when the Find and Replace extension is unavailable. |
+| `scrollIntoViewOptions` | `ScrollIntoViewOptions` | `DEFAULT_SCROLL_INTO_VIEW_OPTIONS` | Options used to reveal the current result without moving focus.                                 |
 
 #### Return values
 
@@ -351,7 +353,7 @@ The module also exports `SearchAndReplaceProps`, `SearchAndReplaceContentProps`,
 
 | Keys               | Behavior                                                                                                                                        |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Mod+F`            | Focuses and selects the search input while open. While hidden, calls `onOpen` when provided; otherwise native browser search remains available. |
+| `Mod+F`            | Focuses and selects the search input while open. While closed, calls `onOpen` when provided; otherwise native browser search remains available. |
 | `ArrowDown`        | Selects the next result while search is open and results exist.                                                                                 |
 | `ArrowUp`          | Selects the previous result while search is open and results exist.                                                                             |
 | `Enter` in Search  | Selects the next result.                                                                                                                        |
@@ -362,7 +364,7 @@ The module also exports `SearchAndReplaceProps`, `SearchAndReplaceContentProps`,
 
 Plain arrow-key navigation outside the panel does not take over editor content, form fields, or other text inputs.
 
-While the panel is mounted, visible, and the extension is available, `Mod+F` is captured for the whole page—including other inputs and contenteditable areas—so the browser's find-in-page never competes with your own search. Set `enableShortcut` to `false` when a layout should leave `Mod+F` to the browser.
+While the component is mounted and the extension is available, whether the panel is open or closed, `Mod+F` is captured for the whole page—including other inputs and contenteditable areas—so the browser's find-in-page never competes with your own search. Set `enableShortcut` to `false` when a layout should leave `Mod+F` to the browser.
 
 ## Styling and public selectors
 

--- a/src/content/ui-components/components/search-and-replace.mdx
+++ b/src/content/ui-components/components/search-and-replace.mdx
@@ -125,6 +125,8 @@ When an open `SearchAndReplace` panel changes to `open={false}`, it stays mounte
 
 The panel does not close itself when the user clicks outside it. If your layout needs outside-click dismissal, manage that behavior in the component that owns `open`.
 
+Navigating results moves the highlight only. The editor selection stays where the user left it, so toolbar state, floating menus, and popovers such as the link popover do not react to the current match.
+
 #### Props
 
 The component also forwards `HTMLAttributes<HTMLDivElement>`—except `children`—to the root panel.
@@ -137,7 +139,7 @@ The component also forwards `HTMLAttributes<HTMLDivElement>`—except `children`
 | `open`                  | `boolean`               | `true`                                    | Whether the mounted panel is active and visible. Closing preserves entered values but suspends result highlighting.                  |
 | `onClose`               | `() => void`            | `undefined`                               | Called by the close button or `Escape`. The callback must update the controlled `open` state.                                        |
 | `onOpen`                | `() => void`            | `undefined`                               | Called when `Mod+F` is pressed while the panel is hidden. Provide it when the shortcut should reopen the panel.                      |
-| `enableShortcut`        | `boolean`               | `true`                                    | Binds `Mod+F` while the component is visible and the extension is available.                                                         |
+| `enableShortcut`        | `boolean`               | `true`                                    | Binds `Mod+F` page-wide while the component is visible and the extension is available.                                               |
 | `autoFocusSearch`       | `boolean`               | `true`                                    | Focuses and selects the search input when the panel opens and the editor is ready.                                                   |
 | `className`             | `string`                | `undefined`                               | Adds a class to the root panel without removing `tiptap-search-replace`.                                                             |
 
@@ -171,11 +173,11 @@ The button accepts the shared `ButtonProps`. Its default `tabIndex` is `-1` beca
 
 ## Regular expression mode
 
-Turn on **Use regular expression** to treat the search term as a JavaScript regular expression source. The component hides the match-case and whole-word rows while regex mode is active and shows buttons that fill the inputs with example patterns.
+Turn on **Use regular expression** to treat the search term as a regular expression source. The extension compiles these patterns with an RE2-compatible engine, so lookarounds and backreferences are not supported. The match-case and whole-word options stay available while regex mode is active, and the panel adds buttons that fill the inputs with example patterns.
 
-Invalid or rejected patterns return zero results without throwing. Regular expressions affect matching only: replacement text is inserted literally, so capture references such as `$1` are not expanded.
+Invalid patterns, and patterns the engine rejects as unsafe, return zero results without throwing. Regular expressions affect matching only: replacement text is inserted literally, so capture references such as `$1` are not expanded.
 
-For extension-level options and matching rules, see the [Find and Replace extension documentation](/editor/extensions/functionality/find-and-replace).
+For extension-level options and matching rules, including how each option behaves in regex mode, see the [Find and Replace extension documentation](/editor/extensions/functionality/find-and-replace).
 
 ## Hooks
 
@@ -289,7 +291,7 @@ function CustomSearchPanel({ editor }) {
 
 The exported `UseSearchAndReplaceReturn` type is the inferred return type of this hook.
 
-## Utilities and constants
+## Utilities
 
 ### Availability and storage helpers
 
@@ -345,7 +347,7 @@ scrollCurrentResultIntoView(editor, {
 
 The module also exports `SearchAndReplaceProps`, `SearchAndReplaceContentProps`, `UseSearchAndReplaceConfig`, `UseSearchAndReplaceReturn`, and `SearchAndReplaceEditorState`.
 
-## Keyboard interactions
+## Keyboard Shortcuts
 
 | Keys               | Behavior                                                                                                                                        |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -359,6 +361,8 @@ The module also exports `SearchAndReplaceProps`, `SearchAndReplaceContentProps`,
 | `Escape`           | Calls `onClose` while focus is inside the panel.                                                                                                |
 
 Plain arrow-key navigation outside the panel does not take over editor content, form fields, or other text inputs.
+
+While the panel is mounted, visible, and the extension is available, `Mod+F` is captured for the whole page—including other inputs and contenteditable areas—so the browser's find-in-page never competes with your own search. Set `enableShortcut` to `false` when a layout should leave `Mod+F` to the browser.
 
 ## Styling and public selectors
 
@@ -377,6 +381,7 @@ These classes are public styling and query hooks:
 
 The component also exposes:
 
+- `role="dialog"` and `aria-label="Search and replace"` on the root panel, with the result counter announced through `aria-live="polite"`.
 - `data-open="true|false"` on the root panel.
 - `data-search-replace-action="prev|next|close|replace|replace-all|regex-docs"` on actions and the regex documentation link.
 - `data-field="search-query|replace-query"` on the inputs.
@@ -389,22 +394,24 @@ The result highlight selectors are `.find-and-replace-result` and `.find-and-rep
 
 ### Dependencies
 
-- `@tiptap/react` — Core Tiptap React integration.
-- `@tiptap/extension-find-and-replace` — Search state, matching, navigation, and replacement commands.
-- `@tiptap/starter-kit` — Baseline editor extensions used by the installed example.
-- `react-hotkeys-hook` — Keyboard shortcut handling.
+- `@tiptap/react` - Core Tiptap React integration
+- `@tiptap/extension-find-and-replace` - Search state, matching, navigation, and replacement commands
+- `@tiptap/starter-kit` - Baseline editor extensions used by the installed example
+- `react-hotkeys-hook` - Keyboard shortcut handling
 
-### Optional dependencies
+### Optional Dependencies
 
-- `sass` — SCSS styling support.
-- `sass-embedded` — Sass compiler used by projects that select the embedded implementation.
+- `sass` - SCSS styling support
+- `sass-embedded` - Sass compiler used by projects that select the embedded implementation
 
-### Referenced components
+### Referenced Components
 
 - `use-tiptap-editor` and `use-composed-ref` hooks
 - `tiptap-utils`
 - `button`, `button-group`, `card`, `input-group`, `separator`, and `switch` primitives
-- `search-icon`, `arrow-right-icon`, `external-link-icon`, `chevron-up-icon`, `chevron-down-icon`, `close-icon`, `check-icon`, `case-sensitive-icon`, and `whole-word-icon`
+- `search-icon`, `arrow-right-icon`, `external-link-icon`, `chevron-up-icon`, `chevron-down-icon`, `close-icon`, `case-sensitive-icon`, and `whole-word-icon`
 - `styles` shared style foundation
+
+The `button` primitive additionally installs the `check-icon` used by its `check` variant.
 
 For a framework-neutral command and storage example, see the [custom Find and Replace UI guide](/guides/find-and-replace).

--- a/src/content/ui-components/components/search-and-replace.mdx
+++ b/src/content/ui-components/components/search-and-replace.mdx
@@ -1,0 +1,410 @@
+---
+title: Search and Replace
+meta:
+  title: Search and replace | Tiptap UI Components
+  description: Add a complete search and replace panel with navigation, match options, regular expressions, and keyboard shortcuts to your Tiptap editor.
+  category: UI Components
+component:
+  name: Search and replace
+  description: Search, navigate, and replace document text with match options, regular expressions, and keyboard shortcuts.
+  type: component
+  isFree: true
+  isCloud: false
+  isOpen: true
+  isNew: true
+  icon: Search
+tags:
+  - type: mit
+---
+
+import { CodeDemo } from '@/components/CodeDemo'
+import { Callout } from '@/components/ui/Callout'
+
+An accessible search and replace panel for Tiptap editors. It provides live result highlighting, a one-based result counter, wrap-around navigation, match-case and whole-word options, regular expression search, and replace or replace-all actions.
+
+The component owns the search state and editor commands, but deliberately does not own its position or open state. You can dock it in a corner, place it in a popover, or render it inline.
+
+<CodeDemo isScrollable src="https://template.tiptap.dev/preview/tiptap-ui/search-and-replace" />
+
+<Callout title="Requires the Find and Replace extension" variant="warning">
+  Register `@tiptap/extension-find-and-replace` on the same editor. Without the extension, the panel
+  remains visible but its controls are disabled by default. Set `hideWhenUnavailable` to `true` if
+  the panel should not render when the extension is missing.
+</Callout>
+
+## Installation
+
+Add the component via the Tiptap CLI:
+
+```bash
+npx @tiptap/cli@latest add search-and-replace
+```
+
+## Setup
+
+Register the [Find and Replace extension](/editor/extensions/functionality/find-and-replace) in your editor. The UI component includes styles for `.find-and-replace-result` and `.find-and-replace-result-current`, so disable the extension's injected highlight CSS when you use the included SCSS.
+
+```tsx
+import { FindAndReplace } from '@tiptap/extension-find-and-replace'
+import { StarterKit } from '@tiptap/starter-kit'
+
+const editor = useEditor({
+  immediatelyRender: false,
+  extensions: [
+    StarterKit,
+    FindAndReplace.configure({
+      injectCSS: false,
+    }),
+  ],
+})
+```
+
+Search input changes are sent directly to the extension. The extension's `searchDebounceMs` option controls when results update; the UI does not add a second debounce.
+
+## Components
+
+### `<SearchAndReplace />`
+
+The complete search and replace panel. Keep the component mounted and control it with `open` when you want the built-in `Mod+F` shortcut to reopen a hidden panel.
+
+#### Usage
+
+```tsx
+'use client'
+
+import { useState } from 'react'
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
+import { FindAndReplace } from '@tiptap/extension-find-and-replace'
+import { StarterKit } from '@tiptap/starter-kit'
+
+import { SearchAndReplace, SearchAndReplaceButton } from '@/components/tiptap-ui/search-and-replace'
+
+export default function MyEditor() {
+  const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [
+      StarterKit,
+      FindAndReplace.configure({
+        injectCSS: false,
+      }),
+    ],
+    content: '<p>Search this document for Tiptap.</p>',
+  })
+
+  return (
+    <EditorContext.Provider value={{ editor }}>
+      <SearchAndReplaceButton
+        tabIndex={0}
+        aria-expanded={isSearchOpen}
+        data-active-state={isSearchOpen ? 'on' : 'off'}
+        onClick={() => setIsSearchOpen((current) => !current)}
+      />
+
+      <div style={{ position: 'relative' }}>
+        <SearchAndReplace
+          open={isSearchOpen}
+          onOpen={() => setIsSearchOpen(true)}
+          onClose={() => setIsSearchOpen(false)}
+          style={{
+            position: 'absolute',
+            top: '0.5rem',
+            right: '0.5rem',
+            zIndex: 10,
+          }}
+        />
+
+        <EditorContent editor={editor} />
+      </div>
+    </EditorContext.Provider>
+  )
+}
+```
+
+When an open `SearchAndReplace` panel changes to `open={false}`, it stays mounted, hides the panel, removes result highlights, and keeps the entered search and replacement values. Opening it again reapplies the stored search. Unmounting the component clears the search and pending work entirely.
+
+The panel does not close itself when the user clicks outside it. If your layout needs outside-click dismissal, manage that behavior in the component that owns `open`.
+
+#### Props
+
+The component also forwards `HTMLAttributes<HTMLDivElement>`—except `children`—to the root panel.
+
+| Name                    | Type                    | Default                                   | Description                                                                                                                          |
+| ----------------------- | ----------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `editor`                | `Editor \| null`        | Editor from `EditorContext`               | The Tiptap editor instance.                                                                                                          |
+| `hideWhenUnavailable`   | `boolean`               | `false`                                   | Hides the panel when the Find and Replace extension is unavailable. Otherwise the panel remains visible with disabled controls.      |
+| `scrollIntoViewOptions` | `ScrollIntoViewOptions` | `{ block: 'nearest', inline: 'nearest' }` | Options used when the current result is scrolled into view. Smooth scrolling becomes immediate when the user prefers reduced motion. |
+| `open`                  | `boolean`               | `true`                                    | Whether the mounted panel is active and visible. Closing preserves entered values but suspends result highlighting.                  |
+| `onClose`               | `() => void`            | `undefined`                               | Called by the close button or `Escape`. The callback must update the controlled `open` state.                                        |
+| `onOpen`                | `() => void`            | `undefined`                               | Called when `Mod+F` is pressed while the panel is hidden. Provide it when the shortcut should reopen the panel.                      |
+| `enableShortcut`        | `boolean`               | `true`                                    | Binds `Mod+F` while the component is visible and the extension is available.                                                         |
+| `autoFocusSearch`       | `boolean`               | `true`                                    | Focuses and selects the search input when the panel opens and the editor is ready.                                                   |
+| `className`             | `string`                | `undefined`                               | Adds a class to the root panel without removing `tiptap-search-replace`.                                                             |
+
+### `<SearchAndReplaceContent />`
+
+An exact alias of `SearchAndReplace`. Use this name when the panel is embedded as inline content, such as inside a collapsed mobile toolbar. It accepts the same `SearchAndReplaceProps`.
+
+```tsx
+<SearchAndReplaceContent
+  editor={editor}
+  open={isSearchOpen}
+  onOpen={() => setIsSearchOpen(true)}
+  onClose={() => setIsSearchOpen(false)}
+/>
+```
+
+### `<SearchAndReplaceButton />`
+
+A presentational trigger built on the shared `Button` primitive. It renders the search icon, tooltip, and `Mod+F` shortcut hint, but it does not manage panel state or run editor commands.
+
+```tsx
+<SearchAndReplaceButton
+  tabIndex={0}
+  aria-expanded={isSearchOpen}
+  data-active-state={isSearchOpen ? 'on' : 'off'}
+  onClick={() => setIsSearchOpen((current) => !current)}
+/>
+```
+
+The button accepts the shared `ButtonProps`. Its default `tabIndex` is `-1` because toolbar primitives manage focus with roving tab stops. Set `tabIndex={0}` when you render it as a standalone button outside a managed toolbar.
+
+## Regular expression mode
+
+Turn on **Use regular expression** to treat the search term as a JavaScript regular expression source. The component hides the match-case and whole-word rows while regex mode is active and shows buttons that fill the inputs with example patterns.
+
+Invalid or rejected patterns return zero results without throwing. Regular expressions affect matching only: replacement text is inserted literally, so capture references such as `$1` are not expanded.
+
+For extension-level options and matching rules, see the [Find and Replace extension documentation](/editor/extensions/functionality/find-and-replace).
+
+## Hooks
+
+### `useSearchAndReplace()`
+
+A headless hook exposing the same reactive editor state and actions used by the prebuilt panel.
+
+#### Usage
+
+```tsx
+import { useSearchAndReplace } from '@/components/tiptap-ui/search-and-replace'
+
+function CustomSearchPanel({ editor }) {
+  const {
+    isVisible,
+    canSearch,
+    searchTerm,
+    replaceTerm,
+    resultCountLabel,
+    caseSensitive,
+    canNavigate,
+    canReplace,
+    setSearchTerm,
+    setReplaceTerm,
+    toggleCaseSensitive,
+    goToNext,
+    replaceCurrent,
+  } = useSearchAndReplace({
+    editor,
+    hideWhenUnavailable: true,
+  })
+
+  if (!isVisible) return null
+
+  return (
+    <div role="search">
+      <input
+        aria-label="Search"
+        value={searchTerm}
+        disabled={!canSearch}
+        onChange={(event) => setSearchTerm(event.target.value)}
+      />
+      <input
+        aria-label="Replace"
+        value={replaceTerm}
+        disabled={!canSearch}
+        onChange={(event) => setReplaceTerm(event.target.value)}
+      />
+      <span>{resultCountLabel}</span>
+      <button
+        type="button"
+        aria-pressed={caseSensitive}
+        disabled={!canSearch}
+        onClick={toggleCaseSensitive}
+      >
+        Match case
+      </button>
+      <button type="button" disabled={!canNavigate} onClick={goToNext}>
+        Next
+      </button>
+      <button type="button" disabled={!canReplace} onClick={replaceCurrent}>
+        Replace
+      </button>
+    </div>
+  )
+}
+```
+
+#### Configuration
+
+| Name                    | Type                    | Default                            | Description                                                                                   |
+| ----------------------- | ----------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------- |
+| `editor`                | `Editor \| null`        | Editor from `EditorContext`        | The Tiptap editor instance.                                                                   |
+| `hideWhenUnavailable`   | `boolean`               | `false`                            | Whether the hook reports the UI as hidden when the Find and Replace extension is unavailable. |
+| `scrollIntoViewOptions` | `ScrollIntoViewOptions` | `DEFAULT_SCROLL_INTO_VIEW_OPTIONS` | Options used to reveal the current result without moving focus.                               |
+
+#### Return values
+
+| Name                  | Type                      | Description                                                                                                      |
+| --------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `editor`              | `Editor \| null`          | The resolved editor instance.                                                                                    |
+| `isVisible`           | `boolean`                 | Whether the search UI should render.                                                                             |
+| `canSearch`           | `boolean`                 | Whether the editor has the Find and Replace extension.                                                           |
+| `searchTerm`          | `string`                  | The immediate search input value.                                                                                |
+| `replaceTerm`         | `string`                  | The immediate replacement input value.                                                                           |
+| `appliedSearchTerm`   | `string`                  | The search term currently applied by the extension after its debounce.                                           |
+| `total`               | `number`                  | Number of current results.                                                                                       |
+| `currentIndex`        | `number \| null`          | Zero-based current-result index, or `null` when no result is selected.                                           |
+| `resultCountLabel`    | `string`                  | One-based label such as `1 / 8`, or `0 / 0` without results.                                                     |
+| `caseSensitive`       | `boolean`                 | Current match-case state from extension storage.                                                                 |
+| `wholeWord`           | `boolean`                 | Current whole-word state from extension storage.                                                                 |
+| `useRegex`            | `boolean`                 | Current regular-expression state from extension storage.                                                         |
+| `canNavigate`         | `boolean`                 | Whether at least one result can be selected.                                                                     |
+| `canReplace`          | `boolean`                 | Whether the editor is editable, a current result exists, and replacement text is non-empty.                      |
+| `canReplaceAll`       | `boolean`                 | Whether the editor is editable, results exist, and replacement text is non-empty.                                |
+| `setSearchTerm`       | `(value: string) => void` | Updates the input immediately and forwards non-empty values to the extension. Empty text clears results at once. |
+| `setReplaceTerm`      | `(value: string) => void` | Updates the replacement value in the hook and extension.                                                         |
+| `toggleCaseSensitive` | `() => void`              | Toggles case-sensitive matching.                                                                                 |
+| `toggleWholeWord`     | `() => void`              | Toggles whole-word matching.                                                                                     |
+| `toggleUseRegex`      | `() => void`              | Toggles regular-expression matching.                                                                             |
+| `goToNext`            | `() => boolean`           | Selects the next result and wraps at the end.                                                                    |
+| `goToPrevious`        | `() => boolean`           | Selects the previous result and wraps at the beginning.                                                          |
+| `replaceCurrent`      | `() => boolean`           | Replaces the current result and advances when possible.                                                          |
+| `replaceAll`          | `() => boolean`           | Replaces every result in the current result set.                                                                 |
+| `applySearch`         | `() => void`              | Reapplies the stored search and replacement values, for example when reopening a mounted panel.                  |
+| `suspendSearch`       | `() => void`              | Clears highlights and pending work while preserving the hook's input values.                                     |
+| `clearSearch`         | `() => void`              | Clears input values, pending work, and highlights.                                                               |
+| `label`               | `string`                  | Accessible label: `Search and replace`.                                                                          |
+| `shortcutKeys`        | `string`                  | Main shortcut key: `mod+f`.                                                                                      |
+| `Icon`                | `React.ComponentType`     | Search icon component.                                                                                           |
+
+The exported `UseSearchAndReplaceReturn` type is the inferred return type of this hook.
+
+## Utilities and constants
+
+### Availability and storage helpers
+
+```tsx
+import {
+  getFindAndReplaceStorage,
+  isFindAndReplaceAvailable,
+  shouldShowSearchAndReplace,
+} from '@/components/tiptap-ui/search-and-replace'
+
+const available = isFindAndReplaceAvailable(editor)
+const storage = getFindAndReplaceStorage(editor)
+const visible = shouldShowSearchAndReplace({
+  editor,
+  hideWhenUnavailable: true,
+})
+```
+
+- `isFindAndReplaceAvailable(editor)` checks whether the `findAndReplace` extension is registered.
+- `getFindAndReplaceStorage(editor)` returns its reactive storage object, or `null`.
+- `shouldShowSearchAndReplace({ editor, hideWhenUnavailable })` applies the component's visibility rule.
+
+### Result formatting and scrolling
+
+```tsx
+import {
+  DEFAULT_SCROLL_INTO_VIEW_OPTIONS,
+  formatResultCount,
+  scrollCurrentResultIntoView,
+} from '@/components/tiptap-ui/search-and-replace'
+
+formatResultCount(null, 0) // "0 / 0"
+formatResultCount(0, 8) // "1 / 8"
+
+scrollCurrentResultIntoView(editor, {
+  block: 'center',
+  inline: 'nearest',
+})
+```
+
+`scrollCurrentResultIntoView()` resolves the current match from its document position and scrolls it without moving focus. It does nothing while focus is inside the editor and honors `prefers-reduced-motion`.
+
+### Exported constants
+
+| Constant                           | Value                                     | Purpose                                                |
+| ---------------------------------- | ----------------------------------------- | ------------------------------------------------------ |
+| `SEARCH_AND_REPLACE_SHORTCUT_KEY`  | `mod+f`                                   | Open or refocus search.                                |
+| `NEXT_RESULT_SHORTCUT_KEY`         | `mod+shift+f`                             | Select the next result from inside the panel.          |
+| `PREVIOUS_RESULT_SHORTCUT_KEY`     | `mod+shift+d`                             | Select the previous result from inside the panel.      |
+| `SEARCH_RESULT_CLASS`              | `find-and-replace-result`                 | Class rendered by the extension for every match.       |
+| `SEARCH_RESULT_CURRENT_CLASS`      | `find-and-replace-result-current`         | Class rendered by the extension for the current match. |
+| `DEFAULT_SCROLL_INTO_VIEW_OPTIONS` | `{ block: 'nearest', inline: 'nearest' }` | Default current-result scroll alignment.               |
+
+The module also exports `SearchAndReplaceProps`, `SearchAndReplaceContentProps`, `UseSearchAndReplaceConfig`, `UseSearchAndReplaceReturn`, and `SearchAndReplaceEditorState`.
+
+## Keyboard interactions
+
+| Keys               | Behavior                                                                                                                                        |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Mod+F`            | Focuses and selects the search input while open. While hidden, calls `onOpen` when provided; otherwise native browser search remains available. |
+| `ArrowDown`        | Selects the next result while search is open and results exist.                                                                                 |
+| `ArrowUp`          | Selects the previous result while search is open and results exist.                                                                             |
+| `Enter` in Search  | Selects the next result.                                                                                                                        |
+| `Enter` in Replace | Replaces the current result when replacement is enabled.                                                                                        |
+| `Mod+Shift+F`      | Selects the next result while focus is inside the panel.                                                                                        |
+| `Mod+Shift+D`      | Selects the previous result while focus is inside the panel.                                                                                    |
+| `Escape`           | Calls `onClose` while focus is inside the panel.                                                                                                |
+
+Plain arrow-key navigation outside the panel does not take over editor content, form fields, or other text inputs.
+
+## Styling and public selectors
+
+The panel is unpositioned by default and has a width of `19rem` with `max-width: 100%`. At viewports up to `480px`, it can stretch to the available width. Add positioning through `className`, `style`, or an outer layout component.
+
+These classes are public styling and query hooks:
+
+- `tiptap-search-replace`
+- `tiptap-search-replace-header`
+- `tiptap-search-replace-count`
+- `tiptap-search-replace-nav-group`
+- `tiptap-search-replace-inputs`
+- `tiptap-search-replace-options`
+- `tiptap-search-replace-actions`
+- `button-group`
+
+The component also exposes:
+
+- `data-open="true|false"` on the root panel.
+- `data-search-replace-action="prev|next|close|replace|replace-all|regex-docs"` on actions and the regex documentation link.
+- `data-field="search-query|replace-query"` on the inputs.
+- `data-option="match-case|whole-words|use-regex"` on matching controls.
+- `data-regex-example="<pattern>"` on each button that fills the fields with a regular expression example.
+
+The result highlight selectors are `.find-and-replace-result` and `.find-and-replace-result-current`. If you override them, keep `injectCSS: false` on the extension so only one highlight stylesheet controls the result.
+
+## Requirements
+
+### Dependencies
+
+- `@tiptap/react` — Core Tiptap React integration.
+- `@tiptap/extension-find-and-replace` — Search state, matching, navigation, and replacement commands.
+- `@tiptap/starter-kit` — Baseline editor extensions used by the installed example.
+- `react-hotkeys-hook` — Keyboard shortcut handling.
+
+### Optional dependencies
+
+- `sass` — SCSS styling support.
+- `sass-embedded` — Sass compiler used by projects that select the embedded implementation.
+
+### Referenced components
+
+- `use-tiptap-editor` and `use-composed-ref` hooks
+- `tiptap-utils`
+- `button`, `button-group`, `card`, `input-group`, `separator`, and `switch` primitives
+- `search-icon`, `arrow-right-icon`, `external-link-icon`, `chevron-up-icon`, `chevron-down-icon`, `close-icon`, `check-icon`, `case-sensitive-icon`, and `whole-word-icon`
+- `styles` shared style foundation
+
+For a framework-neutral command and storage example, see the [custom Find and Replace UI guide](/guides/find-and-replace).

--- a/src/content/ui-components/getting-started/changelog.mdx
+++ b/src/content/ui-components/getting-started/changelog.mdx
@@ -2,11 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2026-07-28]
+## [2026-08-01]
 
 ### Added
 
-- **Search and Replace**: Added an open-source search and replace panel with debounced live highlighting, a result counter, wrap-around navigation, match-case and whole-word options, regular expression search examples, controlled placement and open state, replace and replace-all actions, and keyboard shortcuts. Install it with `npx @tiptap/cli@latest add search-and-replace`.
+- **Search and Replace**: Added an open-source search and replace panel with debounced live highlighting, a one-based result counter, wrap-around navigation, match-case and whole-word options, regular expression search with example patterns, controlled placement and open state, replace and replace-all actions, and `Mod+F`, arrow-key, and `Enter` shortcuts. Install it with `npx @tiptap/cli@latest add search-and-replace`.
+- **Button**: Added a reusable `check` variant, a checkbox-style toggle that supplies `role="checkbox"`, its own check indicator, and the ghost style at small size by default. Control its state with `aria-checked`, which also accepts `mixed`.
+- **Simple editor template**: The template now ships search and replace, with a toolbar trigger and a panel docked below the toolbar.
+
+### Fixed
+
+- **Search result navigation**: Moving between results now updates only the highlight. The editor selection stays where the user left it, so toolbar state no longer follows the current match, and the link popover no longer opens when a match sits inside a link.
+- **Toolbar roving focus**: The toolbar now restores focus to its items only while focus is already inside the toolbar, so panels and popovers opened from the toolbar keep the focus they requested.
+- **Link popover**: `autoOpenOnLinkActive` now also requires the editor to be focused, so an active link no longer opens the popover after a programmatic selection change.
+
+Existing installations can update the complete set of copied source files with `npx @tiptap/cli@latest add button toolbar link-popover -o`. The `-o` flag overwrites installed component files, so review local customizations first.
 
 ## [2026-07-24]
 

--- a/src/content/ui-components/getting-started/changelog.mdx
+++ b/src/content/ui-components/getting-started/changelog.mdx
@@ -6,17 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- **Search and Replace**: Added an open-source search and replace panel with debounced live highlighting, a one-based result counter, wrap-around navigation, match-case and whole-word options, regular expression search with example patterns, controlled placement and open state, replace and replace-all actions, and `Mod+F`, arrow-key, and `Enter` shortcuts. Install it with `npx @tiptap/cli@latest add search-and-replace`.
+- **Search and Replace**: Added an open-source search and replace panel with debounced live highlighting, a one-based result counter, wrap-around navigation, match-case and whole-word options, regular expression search with example patterns, controlled placement and open state, replace and replace-all actions, and `Mod+F`, arrow-key, and `Enter` shortcuts. Moving between results updates only the highlight, so the editor selection and the toolbar state stay where the user left them. Install it with `npx @tiptap/cli@latest add search-and-replace`.
 - **Button**: Added a reusable `check` variant, a checkbox-style toggle that supplies `role="checkbox"`, its own check indicator, and the ghost style at small size by default. Control its state with `aria-checked`, which also accepts `mixed`.
 - **Simple editor template**: The template now ships search and replace, with a toolbar trigger and a panel docked below the toolbar.
 
 ### Fixed
 
-- **Search result navigation**: Moving between results now updates only the highlight. The editor selection stays where the user left it, so toolbar state no longer follows the current match, and the link popover no longer opens when a match sits inside a link.
 - **Toolbar roving focus**: The toolbar now restores focus to its items only while focus is already inside the toolbar, so panels and popovers opened from the toolbar keep the focus they requested.
-- **Link popover**: `autoOpenOnLinkActive` now also requires the editor to be focused, so an active link no longer opens the popover after a programmatic selection change.
+- **Link popover**: `autoOpenOnLinkActive` now also requires the editor to be focused, so an active link no longer opens the popover after a programmatic selection change, such as one made from a search panel.
 
-Existing installations can update the complete set of copied source files with `npx @tiptap/cli@latest add button toolbar link-popover -o`. The `-o` flag overwrites installed component files, so review local customizations first.
+Existing installations can refresh the changed components with `npx @tiptap/cli@latest add button toolbar link-popover -o`. Add `search-and-replace` to that list if you installed the panel on 2026-07-31, the day before this entry, so it picks up the result-navigation behavior. The `-o` flag overwrites installed component files, so review local customizations first.
 
 ## [2026-07-24]
 

--- a/src/content/ui-components/getting-started/changelog.mdx
+++ b/src/content/ui-components/getting-started/changelog.mdx
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2026-07-28]
+
+### Added
+
+- **Search and Replace**: Added an open-source search and replace panel with debounced live highlighting, a result counter, wrap-around navigation, match-case and whole-word options, regular expression search examples, controlled placement and open state, replace and replace-all actions, and keyboard shortcuts. Install it with `npx @tiptap/cli@latest add search-and-replace`.
+
 ## [2026-07-24]
 
 ### Fixed

--- a/src/content/ui-components/install/next.mdx
+++ b/src/content/ui-components/install/next.mdx
@@ -42,7 +42,7 @@ Alternatively, select **Template** to scaffold a full example project.
 Open `app/page.tsx` and render the template or component you installed. For example, if you added the **Simple Editor** template during `init`:
 
 ```tsx
-import { SimpleEditor } from '@/components/tiptap-templates/simple/simple-editor'
+import { SimpleEditor } from '@/components/tiptap-templates/simple/components/simple-editor'
 
 export default function Page() {
   return <SimpleEditor />

--- a/src/content/ui-components/install/vite.mdx
+++ b/src/content/ui-components/install/vite.mdx
@@ -83,7 +83,7 @@ export default defineConfig({
 Replace the contents of `src/App.tsx` with the template or component you installed. For example, the **Simple Editor** template:
 
 ```tsx
-import { SimpleEditor } from '@/components/tiptap-templates/simple/simple-editor'
+import { SimpleEditor } from '@/components/tiptap-templates/simple/components/simple-editor'
 
 export default function App() {
   return <SimpleEditor />

--- a/src/content/ui-components/node-components/table-node.mdx
+++ b/src/content/ui-components/node-components/table-node.mdx
@@ -225,7 +225,7 @@ import { Highlight } from '@tiptap/extension-highlight'
 import { NodeBackground } from '@/components/tiptap-extension/node-background-extension'
 import { NodeAlignment } from '@/components/tiptap-extension/node-alignment-extension'
 
-import { ButtonGroup } from '@/components/tiptap-ui-primitive/button'
+import { ButtonGroup } from '@/components/tiptap-ui-primitive/button-group'
 
 import { TableTriggerButton } from '@/components/tiptap-node/table-node/ui/table-trigger-button'
 import { TableKit } from '@/components/tiptap-node/table-node/extensions/table-node-extension'
@@ -604,7 +604,7 @@ function MyToolbar() {
 
 ### Menu Components
 
-#### `<TableAlignmentMenu />`
+#### `<TableAlignMenu />`
 
 Menu component providing alignment options for table cells.
 
@@ -616,10 +616,10 @@ Menu component providing alignment options for table cells.
 **Usage:**
 
 ```tsx
-import { TableAlignmentMenu } from '@/components/tiptap-node/table-node/ui/table-alignment-menu'
+import { TableAlignMenu } from '@/components/tiptap-node/table-node/ui/table-alignment-menu'
 
 function MyToolbar() {
-  return <TableAlignmentMenu orientation="row" index={0} />
+  return <TableAlignMenu orientation="row" index={0} />
 }
 ```
 

--- a/src/content/ui-components/primitives/badge.mdx
+++ b/src/content/ui-components/primitives/badge.mdx
@@ -37,7 +37,7 @@ npx @tiptap/cli@latest add badge
 
 ```tsx
 import { Badge } from '@/components/tiptap-ui-primitive/badge'
-import { CheckIcon } from '@/components/icons/check-icon'
+import { CheckIcon } from '@/components/tiptap-icons/check-icon'
 
 export default function MyComponent() {
   return (

--- a/src/content/ui-components/primitives/button.mdx
+++ b/src/content/ui-components/primitives/button.mdx
@@ -35,7 +35,7 @@ npx @tiptap/cli@latest add button
 
 ```tsx
 import { Button } from '@/components/tiptap-ui-primitive/button'
-import { BoldIcon } from '@/components/icons/bold-icon'
+import { BoldIcon } from '@/components/tiptap-icons/bold-icon'
 
 export default function MyComponent() {
   return (

--- a/src/content/ui-components/primitives/button.mdx
+++ b/src/content/ui-components/primitives/button.mdx
@@ -57,12 +57,46 @@ export default function MyComponent() {
 
 ### Button
 
-| Name              | Type          | Default   | Description                             |
-| ----------------- | ------------- | --------- | --------------------------------------- |
-| data-style        | string        | undefined | Button style (e.g., 'ghost', 'primary') |
-| data-active-state | 'on' \| 'off' | undefined | Button active state                     |
-| data-size         | string        | undefined | Button size (e.g., 'small', 'default')  |
-| data-appearance   | string        | undefined | Button appearance                       |
-| data-disabled     | boolean       | undefined | Visual disabled state                   |
-| tooltip           | string        | undefined | Text displayed in tooltip               |
-| shortcutKeys      | string        | undefined | Keyboard shortcut displayed in tooltip  |
+| Name              | Type                            | Default   | Description                                          |
+| ----------------- | ------------------------------- | --------- | ---------------------------------------------------- |
+| variant           | 'ghost' \| 'primary' \| 'check' | undefined | Visual style, or the `check` feature variant         |
+| size              | 'small' \| 'default' \| 'large' | undefined | Button size                                          |
+| tooltip           | ReactNode                       | undefined | Content displayed in the tooltip                     |
+| shortcutKeys      | string                          | undefined | Keyboard shortcut displayed in tooltip               |
+| showTooltip       | boolean                         | true      | Renders the tooltip wrapper when `tooltip` is set    |
+| data-style        | string                          | undefined | Button style, set from `variant` when it is provided |
+| data-active-state | 'on' \| 'off'                   | undefined | Button active state                                  |
+| data-size         | string                          | undefined | Button size, set from `size` when it is provided     |
+| data-appearance   | string                          | undefined | Button appearance                                    |
+| data-disabled     | boolean                         | undefined | Visual disabled state                                |
+
+The button forwards every other `ButtonHTMLAttributes<HTMLButtonElement>` to the underlying element.
+
+### Check variant
+
+`variant="check"` renders a checkbox-style toggle: a full-width row with the label on the left and a check indicator on the right. It defaults to the ghost style at small size, provides `role="checkbox"`, and renders its own indicator, so you supply only the label and the state.
+
+Drive it with `aria-checked`, which defaults to `false` and also accepts `"mixed"`:
+
+```tsx
+import { useState } from 'react'
+import { Button } from '@/components/tiptap-ui-primitive/button'
+import { CaseSensitiveIcon } from '@/components/tiptap-icons/case-sensitive-icon'
+
+export default function MatchCaseOption() {
+  const [matchCase, setMatchCase] = useState(false)
+
+  return (
+    <Button
+      variant="check"
+      aria-checked={matchCase}
+      onClick={() => setMatchCase((current) => !current)}
+    >
+      <CaseSensitiveIcon className="tiptap-button-icon" />
+      <span className="tiptap-button-text">Match case</span>
+    </Button>
+  )
+}
+```
+
+The variant sets `data-variant="check"` on the element and renders the indicator as `.tiptap-button-check`, so both are available for styling. Its colors come from the `--tt-button-check-*` custom properties in `button-colors.scss`, and it installs the `check-icon` component.

--- a/src/content/ui-components/primitives/input.mdx
+++ b/src/content/ui-components/primitives/input.mdx
@@ -32,7 +32,8 @@ npx @tiptap/cli@latest add input
 ## Usage
 
 ```tsx
-import { Input, InputGroup } from '@/components/tiptap-ui-primitive/input'
+import { Input } from '@/components/tiptap-ui-primitive/input'
+import { InputGroup } from '@/components/tiptap-ui-primitive/input-group'
 
 export default function MyComponent() {
   const [value, setValue] = React.useState('')

--- a/src/content/ui-components/primitives/toolbar.mdx
+++ b/src/content/ui-components/primitives/toolbar.mdx
@@ -40,8 +40,8 @@ npx @tiptap/cli@latest add toolbar
 ```tsx
 import { Toolbar, ToolbarGroup, ToolbarSeparator } from '@/components/tiptap-ui-primitive/toolbar'
 import { Button } from '@/components/tiptap-ui-primitive/button'
-import { BoldIcon } from '@/components/icons/bold-icon'
-import { ItalicIcon } from '@/components/icons/italic-icon'
+import { BoldIcon } from '@/components/tiptap-icons/bold-icon'
+import { ItalicIcon } from '@/components/tiptap-icons/italic-icon'
 import { Spacer } from '@/components/tiptap-ui-primitive/spacer'
 
 export default function MyComponent() {

--- a/src/content/ui-components/sidebar.ts
+++ b/src/content/ui-components/sidebar.ts
@@ -218,6 +218,10 @@ export const sidebarConfig: SidebarConfig = {
               href: '/ui-components/components/reset-all-formatting-button',
             },
             {
+              title: 'Search and replace',
+              href: '/ui-components/components/search-and-replace',
+            },
+            {
               title: 'Slash trigger button',
               href: '/ui-components/components/slash-command-trigger-button',
             },

--- a/src/content/ui-components/templates/notion-like-editor.mdx
+++ b/src/content/ui-components/templates/notion-like-editor.mdx
@@ -212,7 +212,7 @@ throw new Error('upload failed')
 Import and render the `NotionEditor` component in your React app:
 
 ```tsx
-import { NotionEditor } from '@/components/tiptap-templates/notion/notion-like-editor'
+import { NotionEditor } from '@/components/tiptap-templates/notion-like/components/notion-like-editor'
 
 export default function App() {
   return <NotionEditor room="my-document-room" placeholder="Start writing..." />

--- a/src/content/ui-components/templates/simple-editor.mdx
+++ b/src/content/ui-components/templates/simple-editor.mdx
@@ -55,7 +55,7 @@ This template requires styling setup. We stay unopinionated about styling framew
 After installation, use the SimpleEditor component in your React or Next.js project:
 
 ```jsx
-import { SimpleEditor } from '@/components/tiptap-templates/simple/simple-editor'
+import { SimpleEditor } from '@/components/tiptap-templates/simple/components/simple-editor'
 
 export default function App() {
   return <SimpleEditor />

--- a/src/content/ui-components/templates/simple-editor.mdx
+++ b/src/content/ui-components/templates/simple-editor.mdx
@@ -74,6 +74,7 @@ A fully responsive rich text editor with built-in support for common formatting 
 - **Headings**: Multiple levels via dropdown
 - **Image upload**
 - **Link editing:** UI for adding and editing links
+- **Search and replace:** Find text with match options and replace it, powered by the [Find and Replace extension](/editor/extensions/functionality/find-and-replace)
 - **Undo / Redo:** History management
 
 ### Used reference components
@@ -114,6 +115,7 @@ A fully responsive rich text editor with built-in support for common formatting 
 - `list-button`
 - `list-dropdown-menu`
 - `mark-button`
+- `search-and-replace`
 - `text-align-button`
 - `undo-redo-button`
 

--- a/src/content/ui-components/utils-components/floating-element.mdx
+++ b/src/content/ui-components/utils-components/floating-element.mdx
@@ -53,7 +53,7 @@ import { FloatingElement } from '@/components/tiptap-ui-utils/floating-element'
 import { MarkButton } from '@/components/tiptap-ui/mark-button'
 
 // --- UI Primitives ---
-import { ButtonGroup } from '@/components/tiptap-ui-primitive/button'
+import { ButtonGroup } from '@/components/tiptap-ui-primitive/button-group'
 import { Toolbar } from '@/components/tiptap-ui-primitive/toolbar'
 
 // --- Tiptap Node ---


### PR DESCRIPTION
## Summary

- add comprehensive documentation for the Search and Replace UI component
- document installation, setup, props, hooks, utilities, keyboard interactions, regex behavior, selectors, and dependencies
- add Search and Replace to the UI Components navigation
- add the release to the UI Components changelog