### PR TITLE
Refresh conversion and pages version badges

### DIFF
--- a/.changeset/plain-badges-refresh.md
+++ b/.changeset/plain-badges-refresh.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Refresh the version badges across the conversion and pages documentation so each one matches the latest published version of the package it documents, and the REST API pages match the deployed Convert service.

--- a/src/content/conversion/content-types/structures-and-media/comments.mdx
+++ b/src/content/conversion/content-types/structures-and-media/comments.mdx
@@ -2,7 +2,7 @@
 title: Comments
 tags:
   - type: version
-    label: v2.29.0
+    label: v2.39.1
 meta:
   title: Comments | Tiptap Conversion
   description: Import DOCX comments as live collaboration threads, export editor threads back to DOCX, and round-trip comments through Microsoft Word without duplicates.

--- a/src/content/conversion/export/doc/custom-nodes.mdx
+++ b/src/content/conversion/export/doc/custom-nodes.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.1
+    label: v0.6.2
 meta:
     title: Export custom nodes to DOC | Tiptap Conversion
     description: Learn how to export custom nodes to DOC (legacy Word) files using the Export DOC extension.

--- a/src/content/conversion/export/doc/editor-extension.mdx
+++ b/src/content/conversion/export/doc/editor-extension.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.1
+    label: v0.6.2
 meta:
   title: Export DOC | Tiptap Conversion
   description: Learn how to export Tiptap editor content to DOC (legacy Word) files using the Export DOC extension in our docs.

--- a/src/content/conversion/export/doc/headers-footers.mdx
+++ b/src/content/conversion/export/doc/headers-footers.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.1
+    label: v0.6.2
 meta:
     title: Extend your DOC export with Headers & Footers | Tiptap Conversion
     description: Learn how to extend your DOC exports with custom Headers & Footers using the Export DOC extension.

--- a/src/content/conversion/export/doc/page-layout.mdx
+++ b/src/content/conversion/export/doc/page-layout.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.1
+    label: v0.6.2
 meta:
   title: Custom page layouts in DOC | Tiptap Conversion
   description: Learn how to customize your DOC page and margin sizes using the Export DOC extension.

--- a/src/content/conversion/export/doc/rest-api.mdx
+++ b/src/content/conversion/export/doc/rest-api.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v2.25.0
+    label: v2.39.1
 meta:
     title: DOC REST API | Tiptap Conversion
     description: Learn how to export Tiptap JSON documents to DOC format (legacy Microsoft Word) using the Tiptap Conversion REST API v2.

--- a/src/content/conversion/export/doc/styles.mdx
+++ b/src/content/conversion/export/doc/styles.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.1
+    label: v0.6.2
 meta:
     title: Export styles to DOC | Tiptap Conversion
     description: Learn how to export custom styles from Tiptap JSON to DOC using the Export DOC extension.

--- a/src/content/conversion/export/docx/css-to-docx.mdx
+++ b/src/content/conversion/export/docx/css-to-docx.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.20.0
+    label: v0.26.1
 meta:
     title: CSS to DOCX | Tiptap Conversion
     description: Compile CSS rules from your editor into DOCX style definitions on export.

--- a/src/content/conversion/export/docx/custom-nodes-dsl-builder.mdx
+++ b/src/content/conversion/export/docx/custom-nodes-dsl-builder.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.20.0
+    label: v0.26.1
 meta:
   title: DSL builder for DOCX custom nodes | Tiptap Conversion
   description: A typed, fluent TypeScript API for authoring the DOCX custom-nodes DSL. Compile-time containment safety, autocomplete on every prop, and the same wire format the REST API consumes.

--- a/src/content/conversion/export/docx/custom-nodes-dsl.mdx
+++ b/src/content/conversion/export/docx/custom-nodes-dsl.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.20.0
+    label: v0.26.1
 meta:
   title: Custom-node DSL for DOCX | Tiptap Conversion
   description: A serializable JSON description of how Tiptap custom nodes should render into DOCX. Works in both the editor extension and the Conversion REST API.

--- a/src/content/conversion/export/docx/custom-nodes.mdx
+++ b/src/content/conversion/export/docx/custom-nodes.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.20.0
+    label: v0.26.1
 meta:
   title: Export custom nodes to DOCX | Tiptap Conversion
   description: Learn how to export custom nodes to DOCX (Word) files using the Export extension.

--- a/src/content/conversion/export/docx/editor-extension.mdx
+++ b/src/content/conversion/export/docx/editor-extension.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.23.0
+    label: v0.26.1
 meta:
   title: Export DOCX | Tiptap Conversion
   description: Learn how to export Tiptap editor content to DOCX (Word) files using the Export extension in our docs.

--- a/src/content/conversion/export/docx/fonts.mdx
+++ b/src/content/conversion/export/docx/fonts.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.20.0
+    label: v0.26.1
 meta:
   title: Custom fonts | Tiptap Conversion
   description: Embed TTF/OTF fonts into exported DOCX files (manually, or automatically from the fonts your document already uses) so they render correctly in Word everywhere.

--- a/src/content/conversion/export/docx/headers-footers.mdx
+++ b/src/content/conversion/export/docx/headers-footers.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.20.0
+    label: v0.26.1
 meta:
     title: Extend your DOCX export with Headers & Footers | Tiptap Conversion
     description: Learn how to extend your DOCX exports with Headers & Footers

--- a/src/content/conversion/export/docx/page-layout.mdx
+++ b/src/content/conversion/export/docx/page-layout.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.20.0
+    label: v0.26.1
 meta:
   title: Custom page layouts in DOCX | Tiptap Conversion
   description: Learn how to customize your DOCX (Word) page and margin sizes using the Export extension.

--- a/src/content/conversion/export/docx/rest-api.mdx
+++ b/src/content/conversion/export/docx/rest-api.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v2.25.0
+    label: v2.39.1
 meta:
   title: Export DOCX REST API | Tiptap Conversion
   description: Learn how to export Tiptap JSON documents to DOCX format via the Conversion REST API.

--- a/src/content/conversion/export/docx/styles.mdx
+++ b/src/content/conversion/export/docx/styles.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.20.0
+    label: v0.26.1
 meta:
   title: Export styles | Tiptap Conversion
   description: Learn how to export custom styles from Tiptap JSON to DOCX in our documentation.

--- a/src/content/conversion/export/epub/custom-nodes.mdx
+++ b/src/content/conversion/export/epub/custom-nodes.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.4.2
+    label: v0.4.3
 meta:
     title: Export custom nodes to EPUB | Tiptap Conversion
     description: Learn how to export custom nodes to EPUB files using the Export EPUB extension.

--- a/src/content/conversion/export/epub/editor-extension.mdx
+++ b/src/content/conversion/export/epub/editor-extension.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.4.2
+    label: v0.4.3
 meta:
   title: Export EPUB | Tiptap Conversion
   description: Learn how to export Tiptap editor content to EPUB files using the Export EPUB extension in our docs.

--- a/src/content/conversion/export/epub/headers-footers.mdx
+++ b/src/content/conversion/export/epub/headers-footers.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.4.2
+    label: v0.4.3
 meta:
     title: Extend your EPUB export with Headers & Footers | Tiptap Conversion
     description: Learn how to extend your EPUB exports with custom Headers & Footers using the Export EPUB extension.

--- a/src/content/conversion/export/epub/page-layout.mdx
+++ b/src/content/conversion/export/epub/page-layout.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.4.2
+    label: v0.4.3
 meta:
     title: Custom page layouts in EPUB | Tiptap Conversion
     description: Learn how to customize your EPUB page and margin sizes using the Export EPUB extension.

--- a/src/content/conversion/export/epub/rest-api.mdx
+++ b/src/content/conversion/export/epub/rest-api.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v2.25.0
+    label: v2.39.1
 meta:
     title: EPUB REST API | Tiptap Conversion
     description: Learn how to export Tiptap JSON documents to EPUB format using the Tiptap Conversion REST API v2.

--- a/src/content/conversion/export/epub/styles.mdx
+++ b/src/content/conversion/export/epub/styles.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.4.2
+    label: v0.4.3
 meta:
     title: Export styles to EPUB | Tiptap Conversion
     description: Learn how to export custom styles from Tiptap JSON to EPUB using the Export EPUB extension.

--- a/src/content/conversion/export/markdown/editor-extension.mdx
+++ b/src/content/conversion/export/markdown/editor-extension.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.2.1
+    label: v0.2.2
 meta:
   title: Export Markdown | Tiptap Conversion
   description: Learn how to export Tiptap editor content to Markdown files using the Export Markdown extension in our docs.

--- a/src/content/conversion/export/markdown/rest-api.mdx
+++ b/src/content/conversion/export/markdown/rest-api.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v2.25.0
+    label: v2.39.1
 meta:
     title: Export Markdown REST API | Tiptap Conversion
     description: Learn how to export Tiptap JSON documents to Markdown format using the Tiptap Conversion REST API v2.

--- a/src/content/conversion/export/odt/custom-nodes.mdx
+++ b/src/content/conversion/export/odt/custom-nodes.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.1
+    label: v0.6.2
 meta:
     title: Export custom nodes to ODT | Tiptap Conversion
     description: Learn how to export custom nodes to ODT (OpenDocument) files using the Export ODT extension.

--- a/src/content/conversion/export/odt/editor-extension.mdx
+++ b/src/content/conversion/export/odt/editor-extension.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.1
+    label: v0.6.2
 meta:
   title: Export ODT | Tiptap Conversion
   description: Learn how to export Tiptap editor content to ODT (OpenDocument) files using the Export ODT extension in our docs.

--- a/src/content/conversion/export/odt/headers-footers.mdx
+++ b/src/content/conversion/export/odt/headers-footers.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.1
+    label: v0.6.2
 meta:
     title: Extend your ODT export with Headers & Footers | Tiptap Conversion
     description: Learn how to extend your ODT exports with custom Headers & Footers using the Export ODT extension.

--- a/src/content/conversion/export/odt/page-layout.mdx
+++ b/src/content/conversion/export/odt/page-layout.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.1
+    label: v0.6.2
 meta:
   title: Custom page layouts in ODT | Tiptap Conversion
   description: Learn how to customize your ODT page and margin sizes using the Export ODT extension.

--- a/src/content/conversion/export/odt/rest-api.mdx
+++ b/src/content/conversion/export/odt/rest-api.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v2.25.0
+    label: v2.39.1
 meta:
     title: ODT REST API | Tiptap Conversion
     description: Learn how to export Tiptap JSON documents to ODT (OpenDocument Text) format using the Tiptap Conversion REST API v2.

--- a/src/content/conversion/export/odt/styles.mdx
+++ b/src/content/conversion/export/odt/styles.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.1
+    label: v0.6.2
 meta:
     title: Export styles to ODT | Tiptap Conversion
     description: Learn how to export custom styles from Tiptap JSON to ODT using the Export ODT extension.

--- a/src/content/conversion/export/pdf/custom-nodes.mdx
+++ b/src/content/conversion/export/pdf/custom-nodes.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.1
+    label: v0.6.2
 meta:
     title: Export custom nodes to PDF | Tiptap Conversion
     description: Learn how to export custom nodes to PDF files using the Export PDF extension.

--- a/src/content/conversion/export/pdf/editor-extension.mdx
+++ b/src/content/conversion/export/pdf/editor-extension.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.1
+    label: v0.6.2
 meta:
   title: Export PDF | Tiptap Conversion
   description: Learn how to export Tiptap editor content to PDF files using the Export PDF extension in our docs.

--- a/src/content/conversion/export/pdf/headers-footers.mdx
+++ b/src/content/conversion/export/pdf/headers-footers.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.1
+    label: v0.6.2
 meta:
     title: Extend your PDF export with Headers & Footers | Tiptap Conversion
     description: Learn how to extend your PDF exports with custom Headers & Footers using the Export PDF extension.

--- a/src/content/conversion/export/pdf/page-layout.mdx
+++ b/src/content/conversion/export/pdf/page-layout.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.1
+    label: v0.6.2
 meta:
   title: Custom page layouts in PDF | Tiptap Conversion
   description: Learn how to customize your PDF page and margin sizes using the Export PDF extension.

--- a/src/content/conversion/export/pdf/rest-api.mdx
+++ b/src/content/conversion/export/pdf/rest-api.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v2.25.0
+    label: v2.39.1
 meta:
     title: PDF REST API | Tiptap Conversion
     description: Learn how to export Tiptap JSON documents to PDF format using the Tiptap Conversion REST API v2.

--- a/src/content/conversion/export/pdf/styles.mdx
+++ b/src/content/conversion/export/pdf/styles.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.6.1
+    label: v0.6.2
 meta:
     title: Export styles to PDF | Tiptap Conversion
     description: Learn how to export custom styles from Tiptap JSON to PDF using the Export PDF extension.

--- a/src/content/conversion/import/docx/convertkit.mdx
+++ b/src/content/conversion/import/docx/convertkit.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.3.0
+    label: v0.8.0
 meta:
   title: ConvertKit | Tiptap Conversion
   description: A bundled Tiptap extension that configures the editor for DOCX-imported content.

--- a/src/content/conversion/import/docx/css-injection.mdx
+++ b/src/content/conversion/import/docx/css-injection.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.10.0
+    label: v0.12.3
 meta:
     title: CSS Injection (Import DOCX) | Tiptap Conversion
     description: Extract the default styles from a DOCX file as CSS and inject them into your Tiptap editor on import.

--- a/src/content/conversion/import/docx/custom-mark-mapping.mdx
+++ b/src/content/conversion/import/docx/custom-mark-mapping.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.10.0
+    label: v0.12.3
 meta:
     title: DOCX mark import | Tiptap Conversion
     description: Learn how to import custom marks from DOCX (Word) files using the Import extension in our docs.

--- a/src/content/conversion/import/docx/custom-node-mapping.mdx
+++ b/src/content/conversion/import/docx/custom-node-mapping.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.10.0
+    label: v0.12.3
 meta:
     title: Import custom nodes from DOCX | Tiptap Conversion
     description: Learn how to import custom nodes from DOCX (Word) files using the Import extension.

--- a/src/content/conversion/import/docx/editor-extension.mdx
+++ b/src/content/conversion/import/docx/editor-extension.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.11.0
+    label: v0.12.3
 meta:
   title: Import DOCX | Tiptap Conversion
   description: Learn how to import DOCX (Word) documents into a Tiptap editor using the Import extension in our docs.

--- a/src/content/conversion/import/docx/image-handling.mdx
+++ b/src/content/conversion/import/docx/image-handling.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v0.10.0
+    label: v0.12.3
 meta:
     title: Preserve images | Tiptap Conversion
     description: Preserve images in your converted documents by providing an image upload callback url. Learn more in the docs.

--- a/src/content/conversion/import/docx/rest-api.mdx
+++ b/src/content/conversion/import/docx/rest-api.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v2.25.0
+    label: v2.39.1
 meta:
   title: Import DOCX REST API | Tiptap Conversion
   description: Learn how to import .docx files into Tiptap JSON format via the Conversion REST API.

--- a/src/content/conversion/import/markdown/rest-api.mdx
+++ b/src/content/conversion/import/markdown/rest-api.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: beta
   - type: version
-    label: v2.25.0
+    label: v2.39.1
 meta:
     title: Import Markdown REST API | Tiptap Conversion
     description: Learn how to import Markdown files into Tiptap JSON format using the Tiptap Conversion REST API v2.

--- a/src/content/pages/guides/pages-tablekit.mdx
+++ b/src/content/pages/guides/pages-tablekit.mdx
@@ -4,7 +4,7 @@ tags:
   - type: start
   - type: experiment
   - type: version
-    label: v0.2.4
+    label: v0.2.11
 meta:
   title: PagesTableKit | Tiptap Pages
   description: Table extensions tailored for the Pages pagination extension. Works for any Pages setup; pairs with DOCX import for faithful Word-document rendering. Experimental feature; the API may change.


### PR DESCRIPTION
## Why

The version badges in the conversion and pages docs had drifted. This is the periodic refresh, following the same convention as `docs: bump conversion package + convert service version badges to latest` and `docs: make conversion version badges consistent per package`.

Every badge now shows the latest published version of the package that page documents, and every REST API page shows the version of the Convert service actually deployed to production.

## Versions used

Read from the registry rather than recalled:

| Package | Badge was | Now |
| --- | --- | --- |
| `extension-export-docx` | v0.20.0, one page on v0.23.0 | **v0.26.1** |
| `extension-export-doc` | v0.6.1 | **v0.6.2** |
| `extension-export-odt` | v0.6.1 | **v0.6.2** |
| `extension-export-pdf` | v0.6.1 | **v0.6.2** |
| `extension-export-epub` | v0.4.2 | **v0.4.3** |
| `extension-export-markdown` | v0.2.1 | **v0.2.2** |
| `extension-import-docx` | v0.10.0, one page on v0.11.0 | **v0.12.3** |
| `extension-convert-kit` | v0.3.0 | **v0.8.0** |
| `extension-pages-tablekit` | v0.2.4 | **v0.2.11** |
| Convert service (REST pages) | v2.25.0, comments page on v2.29.0 | **v2.39.1** |

The service version is production, confirmed with `GET https://api.tiptap.dev/v2/convert`. Staging is ahead on 2.40.0, but the REST pages describe what callers can actually reach today.

`extension-convert-kit` had drifted the furthest, five minor versions behind.

## Scope

46 files. The diff contains nothing but `label:` lines: every changed line matches `label: vX.Y.Z` and there are no other edits, which is easy to confirm from the diff itself.

Badges are now consistent within each package group again. Two pages had drifted off their group individually, the DOCX export extension page on v0.23.0 and the DOCX import extension page on v0.11.0, and both are back in line with their siblings.

## Notes

Only one page under `pages` carries a version badge, the TableKit guide. The rest of the pages docs have no version tags at all, so there was nothing to refresh there. Worth deciding separately whether those pages should carry an `extension-pages` badge (currently v0.28.2).

The two new tracked changes pages on #934 intentionally have no version badge yet, since the feature is unreleased. They should get one when it ships.

Formatting untouched, as with the other docs PRs in flight: these files already fail `prettier --check` on `main`.
