### PR TITLE
Update recommended AI model in AI Toolkit guides and demos to gpt-5.6-luna

### DIFF
--- a/src/content/ai/ai-toolkit/agents/ai-agent-chatbot.mdx
+++ b/src/content/ai/ai-toolkit/agents/ai-agent-chatbot.mdx
@@ -235,7 +235,7 @@ export async function handleChatRequest(request: Request): Promise<Response> {
   )
 
   const agent = new ToolLoopAgent({
-    model: openai('gpt-5.4-mini'),
+    model: openai('gpt-5.6-luna'),
     instructions: `You are an assistant that can edit rich text documents.
 In your responses, be concise and to the point. However, the content you generate in the document does not need to be concise and to the point: instead, it should follow the user's request as closely as possible.
 Before calling any tools, summarize you're going to do (in a sentence or less), as a high-level view of the task, as a human writer would describe it.

--- a/src/content/ai/ai-toolkit/agents/selection-awareness.mdx
+++ b/src/content/ai/ai-toolkit/agents/selection-awareness.mdx
@@ -141,7 +141,7 @@ An advanced option of collaborative documents is to store [multiple fields](/edi
 selection. Smaller, less capable AI models may rewrite the surrounding paragraph instead of
 just the selected span, especially for a sub-sentence selection.
 
-In our testing, models with reasoning enabled (for example, `gpt-5.4-mini` with reasoning effort set
+In our testing, models with reasoning enabled (for example, `gpt-5.6-luna` with reasoning effort set
 to `low`) keep their edits scoped to the selection more reliably. A clear instruction such as "edit
 only the selected text" also helps.
 

--- a/src/content/ai/ai-toolkit/agents/streaming.mdx
+++ b/src/content/ai/ai-toolkit/agents/streaming.mdx
@@ -134,7 +134,7 @@ export async function handleStreamEditRequest(request: Request): Promise<Respons
 
   // 3. Drive the model. Forward its tool input as start / delta / end messages.
   const result = streamText({
-    model: gateway('openai/gpt-5.4-mini'),
+    model: gateway('openai/gpt-5.6-luna'),
     system: `${systemPrompt}\n\nMake the edit with tiptapEdit, then reply with one short sentence confirming what you changed.`,
     prompt: JSON.stringify({ content: read.tool.output, task }),
     tools: {

--- a/src/content/ai/ai-toolkit/client/advanced-guides/ai-engineering.mdx
+++ b/src/content/ai/ai-toolkit/client/advanced-guides/ai-engineering.mdx
@@ -127,9 +127,9 @@ When choosing your model, consider its speed and latency. Refer to leaderboards 
 
 Speed and latency depend on the model and the provider where it is hosted. If output speed is your priority, there are providers that specialize in fast inference, like [groq](https://groq.com/), [SambaNova](https://www.sambanova.com/), or [Cerebras](https://www.cerebras.ai/).
 
-### Disable reasoning
+### Reduce reasoning effort
 
-Reasoning increases token consumption and latency. If you don't need it for your specific use case, disable it. For example, with GPT-5.6 Luna, set the `reasoningEffort` provider option to `'low'`.
+Reasoning increases token consumption and latency. Setting the `reasoningEffort` provider option to `'low'` diminishes the amount of reasoning tokens spent.
 
 ```ts
 // app/api/chat/route.ts
@@ -144,7 +144,7 @@ export async function POST(req: Request) {
     model: openai('gpt-5.6-luna'),
     instructions: `You are an assistant that can edit rich text documents.`,
     tools: toolDefinitions(),
-    // Disable reasoning
+    // Reduce reasoning effort
     providerOptions: {
       openai: {
         reasoningEffort: 'low',

--- a/src/content/ai/ai-toolkit/client/advanced-guides/ai-engineering.mdx
+++ b/src/content/ai/ai-toolkit/client/advanced-guides/ai-engineering.mdx
@@ -21,7 +21,7 @@ A key distinction for choosing the right AI model is whether you need to build a
 
 For complex agentic AI assistants like the one in the [AI agent chatbot](/ai/ai-toolkit/client/agents/ai-agent-chatbot) guide, it is recommended to use a frontier model with tool calling capabilities. In particular, the following models have shown positive results:
 
-- OpenAI models: GPT-5, GPT-5 mini, GPT-5.4, GPT-5.4 mini
+- OpenAI models: GPT-5.6 Luna
 - Anthropic models: Opus, Sonnet and Haiku (version 4 and later)
 - Google models: Gemini Pro, Gemini Flash (version 3 and later)
 - Mistral models: Mistral Large, Mistral Medium
@@ -34,7 +34,7 @@ For complex agentic AI assistants like the one in the [AI agent chatbot](/ai/ai-
 If you have an agentic document editing use case but keeping costs down is a priority, you can use a smaller model that still supports function calling. In particular, you can consider the following models:
 
 - Claude Haiku 4.5 (Anthropic) and later
-- GPT-5 mini (OpenAI) and later
+- GPT-5.6 Luna (OpenAI)
 - Gemini 3 Flash (Google) and later
 - Mistral Medium 3.1 (Mistral) and later
 
@@ -60,7 +60,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
   const agent = new ToolLoopAgent({
-    model: openai('gpt-5.4-mini'),
+    model: openai('gpt-5.6-luna'),
     instructions: `You are an assistant that edits rich text documents in the style of Shakespeare. 
     You should respond in the style of Shakespeare, and when editing the document, 
     the content you generate and add to the document should be written in the style
@@ -89,7 +89,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
   const agent = new ToolLoopAgent({
-    model: openai('gpt-5.4-mini'),
+    model: openai('gpt-5.6-luna'),
     instructions: `You are an assistant that can edit rich text documents. 
     Before calling the document editing tools like tiptapEdit,
     you should first read the document to get a sense of the content and context.
@@ -109,7 +109,7 @@ export async function POST(req: Request) {
 We recommend these resources for learning more about prompt engineering and AI engineering:
 
 - [Anthropic prompt engineering guide](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview)
-- [GPT-5 prompting guide](https://cookbook.openai.com/examples/gpt-5/gpt-5_prompting_guide)
+- [GPT-5.6 Luna model documentation](https://developers.openai.com/api/docs/models/gpt-5.6-luna)
 - [OpenAI prompt engineering guide](https://platform.openai.com/docs/guides/prompt-engineering)
 - [A practical guide to building agents](https://cdn.openai.com/business-guides-and-resources/a-practical-guide-to-building-agents.pdf)
 
@@ -129,7 +129,7 @@ Speed and latency depend on the model and the provider where it is hosted. If ou
 
 ### Disable reasoning
 
-Reasoning increases token consumption and latency. If you don't need it for your specific use case, disable it or set it to a minimum. For example, in GPT-5 and GPT-5 mini, it's recommended to set the `reasoningEffort` provider option to `'minimal'`.
+Reasoning increases token consumption and latency. If you don't need it for your specific use case, disable it. For example, with GPT-5.6 Luna, set the `reasoningEffort` provider option to `'low'`.
 
 ```ts
 // app/api/chat/route.ts
@@ -141,13 +141,13 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
   const agent = new ToolLoopAgent({
-    model: openai('gpt-5.4-mini'),
+    model: openai('gpt-5.6-luna'),
     instructions: `You are an assistant that can edit rich text documents.`,
     tools: toolDefinitions(),
-    // Set the reasoning effort to 'minimal'
+    // Disable reasoning
     providerOptions: {
       openai: {
-        reasoningEffort: 'minimal',
+        reasoningEffort: 'low',
       },
     },
   })

--- a/src/content/ai/ai-toolkit/client/advanced-guides/migration-guides/ai-generation.mdx
+++ b/src/content/ai/ai-toolkit/client/advanced-guides/migration-guides/ai-generation.mdx
@@ -26,7 +26,7 @@ export async function POST(req: Request) {
   const { userRequest, selection } = await req.json()
 
   const result = streamText({
-    model: openai('gpt-5.4-mini'),
+    model: openai('gpt-5.6-luna'),
     system: `You are an expert writer that can edit rich text documents.
 The user has selected part of the document. You will receive the current
 content of the selection (in HTML format) and the user's request. Re-write

--- a/src/content/ai/ai-toolkit/client/advanced-guides/non-typescript-backends.mdx
+++ b/src/content/ai/ai-toolkit/client/advanced-guides/non-typescript-backends.mdx
@@ -122,7 +122,7 @@ with open("proofreader-workflow.json") as f:
     workflow = json.load(f)
 
 response = client.chat.completions.create(
-    model="gpt-5.4-mini",
+    model="gpt-5.6-luna",
     messages=[
         {"role": "system", "content": workflow["systemPrompt"]},
         {"role": "user", "content": json.dumps({

--- a/src/content/ai/ai-toolkit/client/agents/ai-agent-chatbot.mdx
+++ b/src/content/ai/ai-toolkit/client/agents/ai-agent-chatbot.mdx
@@ -62,7 +62,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
   const agent = new ToolLoopAgent({
-    model: openai('gpt-5.4-mini'),
+    model: openai('gpt-5.6-luna'),
     instructions: 'You are an assistant that can edit rich text documents.',
     tools: toolDefinitions(),
   })

--- a/src/content/ai/ai-toolkit/client/agents/comments.mdx
+++ b/src/content/ai/ai-toolkit/client/agents/comments.mdx
@@ -40,7 +40,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
   const agent = new ToolLoopAgent({
-    model: openai('gpt-5.4-mini'),
+    model: openai('gpt-5.6-luna'),
     instructions: 'You are an assistant that can add comments to a rich text document.',
     tools: toolDefinitions({
       tools: {

--- a/src/content/ai/ai-toolkit/client/agents/multi-document.mdx
+++ b/src/content/ai/ai-toolkit/client/agents/multi-document.mdx
@@ -84,7 +84,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
   const agent = new ToolLoopAgent({
-    model: openai('gpt-5.4-mini'),
+    model: openai('gpt-5.6-luna'),
     instructions: `You are an assistant that can edit rich text documents. 
     You have access to multiple documents and can switch between them. 
     At any point in time, the "active document" is the document that is open in the editor.

--- a/src/content/ai/ai-toolkit/client/agents/review-changes/tracked-changes-with-comments.mdx
+++ b/src/content/ai/ai-toolkit/client/agents/review-changes/tracked-changes-with-comments.mdx
@@ -44,7 +44,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
   const agent = new ToolLoopAgent({
-    model: openai('gpt-5.4-mini'),
+    model: openai('gpt-5.6-luna'),
     instructions: `You are an assistant that can edit rich text documents.
 Rule: Use tiptapRead before tiptapEdit.
 Rule: When editing the document, ALWAYS provide a brief justification for each change in the meta field.`,

--- a/src/content/ai/ai-toolkit/client/agents/review-changes/tracked-changes.mdx
+++ b/src/content/ai/ai-toolkit/client/agents/review-changes/tracked-changes.mdx
@@ -47,7 +47,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
   const agent = new ToolLoopAgent({
-    model: openai('gpt-5.4-mini'),
+    model: openai('gpt-5.6-luna'),
     instructions:
       'You are an assistant that can edit rich text documents. Use tiptapRead before tiptapEdit.',
     tools: toolDefinitions(),

--- a/src/content/ai/ai-toolkit/client/agents/schema-awareness.mdx
+++ b/src/content/ai/ai-toolkit/client/agents/schema-awareness.mdx
@@ -121,7 +121,7 @@ export async function POST(req: Request) {
     await req.json()
 
   const agent = new ToolLoopAgent({
-    model: openai('gpt-5.4-mini'),
+    model: openai('gpt-5.6-luna'),
     // Add the schema awareness string to end of the system prompt
     instructions: `You are an assistant that can edit rich text documents.
 ${schemaAwareness}`,

--- a/src/content/ai/ai-toolkit/client/agents/selection-awareness.mdx
+++ b/src/content/ai/ai-toolkit/client/agents/selection-awareness.mdx
@@ -101,7 +101,7 @@ toolkit.setActiveSelection({ from: 10, to: 20 })
 
 The `readSelection` tool informs the AI about the selected content but it does not force it to only edit the selection. Therefore, the AI model might edit the surrounding paragraph instead of just the selected content.
 
-In our testing, we've found that models with reasoning enabled (like, for example, `gpt-5.4-mini` with reasoning effort set to `low`) perform better at keeping their edits scoped to the selection when told to do so.
+In our testing, we've found that models with reasoning enabled (like, for example, `gpt-5.6-luna` with reasoning effort set to `low`) perform better at keeping their edits scoped to the selection when told to do so.
 
 Another option is to implement the [insert content workflow](/ai/ai-toolkit/client/workflows/insert-content) instead. This workflow can be used to restrict the editable area, so the AI can strictly only re-write the selection.
 

--- a/src/content/ai/ai-toolkit/client/agents/tools/ai-sdk.mdx
+++ b/src/content/ai/ai-toolkit/client/agents/tools/ai-sdk.mdx
@@ -31,7 +31,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
   const agent = new ToolLoopAgent({
-    model: openai('gpt-5.4-mini'),
+    model: openai('gpt-5.6-luna'),
     tools: toolDefinitions(),
   })
 
@@ -54,7 +54,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json()
 
   const agent = new ToolLoopAgent({
-    model: openai('gpt-5.4-mini'),
+    model: openai('gpt-5.6-luna'),
     tools: {
       // Tool definitions from the AI Toolkit
       ...toolDefinitions(),

--- a/src/content/ai/ai-toolkit/client/agents/tools/langchain-js.mdx
+++ b/src/content/ai/ai-toolkit/client/agents/tools/langchain-js.mdx
@@ -24,7 +24,7 @@ Supply the tool definitions to your LangChain.js model.
 import { ChatOpenAI } from '@langchain/openai'
 import { toolDefinitions } from '@tiptap-pro/client-ai-toolkit-langchain'
 
-const llm = new ChatOpenAI({ model: 'gpt-5.4-mini' })
+const llm = new ChatOpenAI({ model: 'gpt-5.6-luna' })
 const llmWithTools = llm.bindTools(toolDefinitions())
 ```
 
@@ -36,7 +36,7 @@ import { toolDefinitions } from '@tiptap-pro/client-ai-toolkit-langchain'
 import { DynamicStructuredTool } from '@langchain/core/tools'
 import { z } from 'zod'
 
-const llm = new ChatOpenAI({ model: 'gpt-5.4-mini' })
+const llm = new ChatOpenAI({ model: 'gpt-5.6-luna' })
 
 const customTools = [
   new DynamicStructuredTool({

--- a/src/content/ai/ai-toolkit/client/agents/tools/mastra.mdx
+++ b/src/content/ai/ai-toolkit/client/agents/tools/mastra.mdx
@@ -28,7 +28,7 @@ import { toolDefinitions } from '@tiptap-pro/client-ai-toolkit-ai-sdk'
 const agent = new Agent({
   name: 'Tiptap AI Agent',
   instructions: 'You are an AI assistant that can read and edit Tiptap documents.',
-  model: openai('gpt-5.4-mini'),
+  model: openai('gpt-5.6-luna'),
   tools: toolDefinitions(),
 })
 
@@ -63,7 +63,7 @@ const agent = new Agent({
   name: 'Tiptap AI Agent with Weather',
   instructions:
     'You are an AI assistant that can read and edit Tiptap documents and get weather information.',
-  model: openai('gpt-5.4-mini'),
+  model: openai('gpt-5.6-luna'),
   tools: {
     // Tool definitions from the AI Toolkit
     ...toolDefinitions(),

--- a/src/content/ai/ai-toolkit/client/agents/tools/openai.mdx
+++ b/src/content/ai/ai-toolkit/client/agents/tools/openai.mdx
@@ -27,7 +27,7 @@ import { toolDefinitions } from '@tiptap-pro/client-ai-toolkit-openai'
 const openai = new OpenAI()
 
 const response = await openai.responses.create({
-  model: 'gpt-5.4-mini',
+  model: 'gpt-5.6-luna',
   input: [{ role: 'user', content: 'Help me edit this document' }],
   tools: toolDefinitions(),
 })
@@ -60,7 +60,7 @@ const customTools = [
 ]
 
 const response = await openai.responses.create({
-  model: 'gpt-5.4-mini',
+  model: 'gpt-5.6-luna',
   input: [{ role: 'user', content: 'What is the weather like and help me edit this document' }],
   tools: [...toolDefinitions(), ...customTools],
 })

--- a/src/content/ai/ai-toolkit/client/api-reference/workflows.mdx
+++ b/src/content/ai/ai-toolkit/client/api-reference/workflows.mdx
@@ -48,7 +48,7 @@ const { content } = apiEndpointRequest
 const workflow = createProofreaderWorkflow()
 
 const result = streamText({
-  model: openai('gpt-5.4-mini'),
+  model: openai('gpt-5.6-luna'),
   // System prompt
   system: workflow.systemPrompt,
   // User message with the content and the task
@@ -92,7 +92,7 @@ const { task, replace } = apiEndpointRequest
 const workflow = createInsertContentWorkflow()
 
 const result = streamText({
-  model: openai('gpt-5.4-mini'),
+  model: openai('gpt-5.6-luna'),
   // System prompt
   system: workflow.systemPrompt,
   // User message with the task and content in a JSON object
@@ -181,7 +181,7 @@ const { content, task } = apiEndpointRequest
 const workflow = createTiptapEditWorkflow()
 
 const result = streamText({
-  model: openai('gpt-5.4-mini'),
+  model: openai('gpt-5.6-luna'),
   system: workflow.systemPrompt,
   prompt: JSON.stringify({ content, task, context }),
   output: Output.object({ schema: workflow.zodOutputSchema }),
@@ -269,7 +269,7 @@ const { content, threads, task } = apiEndpointRequest
 const workflow = createEditThreadsWorkflow()
 
 const result = streamText({
-  model: openai('gpt-5.4-mini'),
+  model: openai('gpt-5.6-luna'),
   system: workflow.systemPrompt,
   prompt: JSON.stringify({ content, threads, task }),
   output: Output.object({ schema: workflow.zodOutputSchema }),
@@ -377,7 +377,7 @@ const { htmlTemplate, task } = apiEndpointRequest
 const workflow = createTemplateWorkflow({ htmlTemplate })
 
 const result = streamText({
-  model: openai('gpt-5.4-mini'),
+  model: openai('gpt-5.6-luna'),
   system: workflow.systemPrompt,
   prompt: JSON.stringify({ task, context }),
   output: Output.object({ schema: workflow.zodOutputSchema }),

--- a/src/content/ai/ai-toolkit/client/workflows/comments.mdx
+++ b/src/content/ai/ai-toolkit/client/workflows/comments.mdx
@@ -84,7 +84,7 @@ export async function POST(req: Request) {
   const workflow = createEditThreadsWorkflow()
 
   const result = streamText({
-    model: openai('gpt-5.4-mini'),
+    model: openai('gpt-5.6-luna'),
     // System prompt
     system: workflow.systemPrompt,
     // User message

--- a/src/content/ai/ai-toolkit/client/workflows/insert-content.mdx
+++ b/src/content/ai/ai-toolkit/client/workflows/insert-content.mdx
@@ -81,7 +81,7 @@ export async function POST(req: Request) {
   const workflow = createInsertContentWorkflow()
 
   const result = streamText({
-    model: openai('gpt-5.4-mini'),
+    model: openai('gpt-5.6-luna'),
     // System prompt
     system: workflow.systemPrompt,
     // User message with the task and the content to replace, as a JSON object.

--- a/src/content/ai/ai-toolkit/client/workflows/proofreader.mdx
+++ b/src/content/ai/ai-toolkit/client/workflows/proofreader.mdx
@@ -80,7 +80,7 @@ export async function POST(req: Request) {
   const workflow = createProofreaderWorkflow()
 
   const result = streamText({
-    model: openai('gpt-5.4-mini'),
+    model: openai('gpt-5.6-luna'),
     // System prompt
     system: workflow.systemPrompt,
     // User message

--- a/src/content/ai/ai-toolkit/client/workflows/template.mdx
+++ b/src/content/ai/ai-toolkit/client/workflows/template.mdx
@@ -132,7 +132,7 @@ export async function POST(req: Request) {
   const workflow = createTemplateWorkflow({ htmlTemplate })
 
   const result = streamText({
-    model: openai('gpt-5.4-mini'),
+    model: openai('gpt-5.6-luna'),
     system: workflow.systemPrompt,
     prompt: JSON.stringify({
       task,

--- a/src/content/ai/ai-toolkit/client/workflows/tiptap-edit.mdx
+++ b/src/content/ai/ai-toolkit/client/workflows/tiptap-edit.mdx
@@ -80,7 +80,7 @@ export async function POST(req: Request) {
   const workflow = createTiptapEditWorkflow()
 
   const result = streamText({
-    model: openai('gpt-5.4-mini'),
+    model: openai('gpt-5.6-luna'),
     // System prompt
     system: workflow.systemPrompt,
     // User message


### PR DESCRIPTION
Update recommended AI model in AI Toolkit guides from gpt-5.4-mini to [gpt-5.6-luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna) because the latter is cheaper and more capable.