### PR TITLE
docs(markdown): replace obsolete contentAsMarkdown option

### DIFF
--- a/src/content/editor/markdown/api/editor.mdx
+++ b/src/content/editor/markdown/api/editor.mdx
@@ -4,7 +4,7 @@ tags:
   - type: beta
 meta:
   title: Markdown Editor API | Tiptap Editor Docs
-  description: Learn about the `content` and `contentAsMarkdown` options in Tiptap's Editor API for handling HTML, Markdown, and Tiptap JSON content.
+  description: Learn about the `content` and `contentType` options in Tiptap's Editor API for handling HTML, Markdown, and Tiptap JSON content.
   category: Editor
 ---
 
@@ -51,7 +51,7 @@ const marked = editor.markdown.instance
 
 Editor content supports **HTML**, **Markdown** or **Tiptap JSON** as a value.
 
-> **Note**: For Markdown support `editor.contentAsMarkdown` must be set to `true`.
+> **Note**: Set `contentType: 'markdown'` when the initial `content` value is Markdown.
 
 - **type**: `string | object`
 - **default**: `''`


### PR DESCRIPTION
Fixes #698

Replace the obsolete `contentAsMarkdown` reference with the current `contentType` option in the Markdown editor API documentation.