### PR TITLE
docs(commands): document list item node arguments

### DIFF
--- a/src/content/editor/api/commands/lists/lift-list-item.mdx
+++ b/src/content/editor/api/commands/lists/lift-list-item.mdx
@@ -6,10 +6,10 @@ meta:
   category: Editor
 ---
 
-The `liftListItem` will try to lift the list item around the current selection up into a wrapping parent list.
+The `liftListItem` will try to lift the list item around the current selection up into a wrapping parent list. Pass the name of the list item node, usually `listItem`, as the argument.
 
 ## Using the liftListItem command
 
 ```js
-editor.commands.liftListItem()
+editor.commands.liftListItem('listItem')
 ```

--- a/src/content/editor/api/commands/lists/sink-list-item.mdx
+++ b/src/content/editor/api/commands/lists/sink-list-item.mdx
@@ -6,10 +6,10 @@ meta:
   category: Editor
 ---
 
-The `sinkListItem` will try to sink the list item around the current selection down into a wrapping child list.
+The `sinkListItem` will try to sink the list item around the current selection down into a wrapping child list. Pass the name of the list item node, usually `listItem`, as the argument.
 
 ## Use the sinkListItem command
 
 ```js
-editor.commands.sinkListItem()
+editor.commands.sinkListItem('listItem')
 ```


### PR DESCRIPTION
Fixes #573

Document the required `typeOrName` argument for `liftListItem` and `sinkListItem` with the standard `listItem` example.