### PR TITLE
docs(api): correct NodePos constructor usage

### DIFF
--- a/src/content/editor/api/node-positions.mdx
+++ b/src/content/editor/api/node-positions.mdx
@@ -34,9 +34,9 @@ const $myCustomPos = editor.$pos(30)
 You can also create your own NodePos instances:
 
 ```js
-// You need to have an editor instance
-// and a position you want to map to
-const myNodePos = new NodePos(100, editor)
+// You need to have an editor instance and a resolved document position.
+// Prefer editor.$pos() when you only have a numeric position.
+const myNodePos = new NodePos(editor.state.doc.resolve(100), editor)
 ```
 
 ## What can I do with a NodePos?
@@ -84,7 +84,7 @@ The NodePos class is the main class you will work with. It describes a specific 
 
 | Method           | Arguments                        | Returns               | Description                                                                                               |
 | ---------------- | --------------------------------- | --------------------- | --------------------------------------------------------------------------------------------------------- |
-| `constructor`    | `pos` (number), `editor` (object) | `NodePos`             | Creates a new `NodePos` instance at the given position (`pos`) within the specified `editor` instance     |
+| `constructor`    | `pos` (ResolvedPos), `editor` (object) | `NodePos`             | Creates a new `NodePos` instance at the given resolved position within the specified `editor` instance     |
 | `closest`        | `nodeType` (string)              | `NodePos` or `null`   | Finds the closest matching `NodePos` going up the document structure. Returns `null` if no match is found |
 | `querySelector`  | `nodeType` (string), `attributes` (object) | `NodePos` or `null` | Finds the first matching `NodePos` going down the document structure. Can be filtered by attributes       |
 | `querySelectorAll`| `nodeType` (string), `attributes` (object) | `Array<NodePos>`     | Finds all matching `NodePos` instances going down the document structure. Can be filtered by attributes   |
@@ -94,13 +94,13 @@ The NodePos class is the main class you will work with. It describes a specific 
 
 **Arguments**
 
-- `pos` – The position you want to map to
+- `pos` – The `ResolvedPos` instance to wrap (for example, `editor.state.doc.resolve(100)`)
 - `editor` – The editor instance you want to use
 
 **Returns** `NodePos`
 
 ```js
-const myNodePos = new NodePos(100, editor)
+const myNodePos = new NodePos(editor.state.doc.resolve(100), editor)
 ```
 
 ##### closest


### PR DESCRIPTION
Fixes #26

Document that `NodePos` wraps a ProseMirror `ResolvedPos` and show how to construct one from the editor state.