### PR TITLE
docs(auth): clarify legacy document access claims

### DIFF
--- a/src/content/authentication/legacy.mdx
+++ b/src/content/authentication/legacy.mdx
@@ -47,6 +47,12 @@ Access patterns:
 - **Comment only.** List names in `commentDocumentNames` alongside read-only access.
 - **Wildcards.** Use patterns like `project-alpha/*` in `allowedDocumentNames` to match a group.
 
+`readonlyDocumentNames` and `commentDocumentNames` refine the access granted by
+`allowedDocumentNames`; they do not define the complete document allowlist. If
+`allowedDocumentNames` is omitted, the user can access every document, with the
+listed read-only or comment-only documents restricted accordingly. Include an
+`allowedDocumentNames` list when access should be limited to a known set.
+
 For the equivalent in the new model, see [Authorize per document](/collaboration/getting-started/authenticate#authorize-per-document) and the [migration mapping](/authentication/migrate#collaboration-and-documents).
 
 ## Conversion


### PR DESCRIPTION
Fixes #38

Explain how `allowedDocumentNames`, `readonlyDocumentNames`, and `commentDocumentNames` combine, including the behavior when the allowlist is omitted.