### PR TITLE
docs(text-style): add font size usage example

### DIFF
--- a/src/content/editor/extensions/marks/text-style.mdx
+++ b/src/content/editor/extensions/marks/text-style.mdx
@@ -12,12 +12,12 @@ tags:
 extension:
   name: Text Style
   link: https://github.com/ueberdosis/tiptap/tree/main/packages/extension-text-style
-  description: 'Otherwise useless, it adds <span> tags required by other extensions.'
+  description: 'Otherwise useless, it adds inline span elements required by other extensions.'
   type: mark
   icon: Paintbrush
 meta:
   title: TextStyle extension | Tiptap Editor Docs
-  description: Use the Text Style extension in Tiptap to add <span> tags with custom styles. Learn more in our docs!
+  description: Use the Text Style extension in Tiptap to add inline span elements with custom styles. Learn more in our docs!
   category: Editor
 ---
 
@@ -26,6 +26,27 @@ import { CodeDemo } from '@/components/CodeDemo'
 This mark renders a `<span>` HTML tag and enables you to add a list of styling related attributes, for example font-family, font-size, or color. The extension doesn’t add any styling attribute by default, but other extensions use it as the foundation, for example [`FontFamily`](/editor/extensions/functionality/fontfamily) or [`Color`](/editor/extensions/functionality/color).
 
 <CodeDemo path="/Marks/Textstyle" />
+
+## Apply font sizes
+
+`TextStyle` provides the `<span>` mark, while extensions such as [`FontSize`](/editor/extensions/functionality/fontsize) add specific style attributes. Install the text-style package and include both extensions in your editor:
+
+```bash
+npm install @tiptap/extension-text-style
+```
+
+```ts
+import { Editor } from '@tiptap/core'
+import { TextStyle, FontSize } from '@tiptap/extension-text-style'
+
+const editor = new Editor({
+  extensions: [TextStyle, FontSize],
+})
+
+editor.chain().focus().setFontSize('18px').run()
+```
+
+The command renders the selected text as a `span` with an inline `font-size: 18px` style.
 
 ## Install
 


### PR DESCRIPTION
Fixes #29

Show that `TextStyle` supplies the span mark while `FontSize` applies the inline `font-size` attribute, including a complete setup and command example.