### PR TITLE
docs(mention): add Svelte usage example

### DIFF
--- a/src/content/editor/extensions/nodes/mention.mdx
+++ b/src/content/editor/extensions/nodes/mention.mdx
@@ -212,6 +212,46 @@ new Editor({
 
 You can also pass a custom React or Vue component for rendering. See the [Suggestion utility](/editor/api/utilities/suggestion) for details.
 
+## Use in Svelte
+
+The extension works with Svelte like any other Tiptap extension. Create the editor after the component mounts, bind the editor element, and configure the suggestion items in the same editor setup:
+
+```svelte
+<script>
+  import { onMount } from 'svelte'
+  import { Editor } from '@tiptap/core'
+  import StarterKit from '@tiptap/starter-kit'
+  import Mention from '@tiptap/extension-mention'
+
+  let element = $state()
+  let editor = $state()
+
+  onMount(() => {
+    editor = new Editor({
+      element,
+      extensions: [
+        StarterKit,
+        Mention.configure({
+          suggestion: {
+            items: ({ query }) =>
+              ['Alice', 'Bob', 'Carol'].filter((name) =>
+                name.toLowerCase().includes(query.toLowerCase()),
+              ),
+          },
+        }),
+      ],
+      content: '<p>Type @ to mention someone.</p>',
+    })
+
+    return () => editor?.destroy()
+  })
+</script>
+
+<div bind:this={element}></div>
+```
+
+Add a `render` function to the `suggestion` options when you need a custom Svelte popup. The `onStart`, `onUpdate`, and `onExit` lifecycle hooks receive the current items and command callback; see the [Suggestion utility](/editor/api/utilities/suggestion) for the complete API.
+
 ## Source code
 
 [packages/extension-mention/](https://github.com/ueberdosis/tiptap/blob/main/packages/extension-mention/)


### PR DESCRIPTION
Fixes #356

Add a Svelte 5 example showing how to initialize the editor, configure mention suggestions, and clean up the editor on unmount.