### PR TITLE
docs(svelte): refresh the Svelte REPL example

### DIFF
--- a/src/content/editor/getting-started/install/svelte.mdx
+++ b/src/content/editor/getting-started/install/svelte.mdx
@@ -10,7 +10,7 @@ Learn how to integrate Tiptap with your SvelteKit project using this step-by-ste
 
 ## Take a shortcut: Svelte REPL with Tiptap
 
-If you want to jump into it right away, here is a [Svelte REPL with Tiptap](https://svelte.dev/playground/66be82691d304dc981502659e93f8b92).
+If you want to jump into it right away, here is a [Svelte 5 REPL with Tiptap](https://svelte.dev/playground/69fd35ee512d40f6a412004a7bdbf549?version=5.37.0).
 
 ### Requirements
 


### PR DESCRIPTION
Fixes #94

Replace the stale Svelte REPL with a working Svelte 5 example matching the runes-based installation guide.