### PR TITLE
docs(cdn): use jsDelivr for Tiptap imports

### DIFF
--- a/src/content/editor/getting-started/install/vanilla-javascript.mdx
+++ b/src/content/editor/getting-started/install/vanilla-javascript.mdx
@@ -75,8 +75,8 @@ Your `<script>` tag must include `type="module"` for the import syntax to work i
 
 ```html
 <script type="module">
-  import { Editor } from 'https://esm.sh/@tiptap/core'
-  import StarterKit from 'https://esm.sh/@tiptap/starter-kit'
+  import { Editor } from 'https://cdn.jsdelivr.net/npm/@tiptap/core@3/+esm'
+  import StarterKit from 'https://cdn.jsdelivr.net/npm/@tiptap/starter-kit@3/+esm'
 
   new Editor({
     element: document.querySelector('.element'),
@@ -180,8 +180,8 @@ Here's a copy-paste ready example that includes a toolbar with formatting button
     </div>
 
     <script type="module">
-      import { Editor } from 'https://esm.sh/@tiptap/core'
-      import StarterKit from 'https://esm.sh/@tiptap/starter-kit'
+      import { Editor } from 'https://cdn.jsdelivr.net/npm/@tiptap/core@3/+esm'
+      import StarterKit from 'https://cdn.jsdelivr.net/npm/@tiptap/starter-kit@3/+esm'
 
       const editor = new Editor({
         element: document.querySelector('#editor'),


### PR DESCRIPTION
Addresses ueberdosis/tiptap#4873

Use jsDelivr ESM bundles for the vanilla JavaScript examples so the documented CDN setup resolves Tiptap dependencies from a single CDN and avoids duplicate ProseMirror packages.