### PR TITLE
docs(react): clarify node view element options

### DIFF
--- a/src/content/editor/extensions/custom-extensions/node-views/react.mdx
+++ b/src/content/editor/extensions/custom-extensions/node-views/react.mdx
@@ -105,16 +105,16 @@ The `NodeViewWrapper` and `NodeViewContent` components render a `<div>` HTML tag
 
 ## Changing the default content tag for a node view
 
-By default a node view rendered by `ReactNodeViewRenderer` will always have a wrapping `div` inside. If you want to change the type of this node, you can the `contentDOMElementTag` to the `ReactNodeViewRenderer` options:
+By default a node view rendered by `ReactNodeViewRenderer` has a `div` content element inside its wrapper. Use `contentDOMElementTag` to change the tag that contains the node's editable content:
 
 ```js
 // this will turn the div into a header tag
 return ReactNodeViewRenderer(Component, { contentDOMElementTag: 'header' })
 ```
 
-## Changing the wrapping DOM element
+## Changing the outer wrapper element
 
-To change the wrapping DOM elements tag, you can use the `as` option on the `ReactNodeViewRenderer` function to change the default tag name.
+The `as` option changes the outer wrapper element, while `contentDOMElementTag` above changes the inner editable content element. Use `as` when the node view itself needs a different semantic tag:
 
 ```js
 import { Node } from '@tiptap/core'


### PR DESCRIPTION
Addresses ueberdosis/tiptap#4969

Clarify the distinction between the inner `contentDOMElementTag` and outer `as` element so the two node-view sections are not ambiguous.