### PR TITLE
docs: remove strict from the stream-tool example

### DIFF
--- a/src/content/ai/ai-toolkit/agents/streaming.mdx
+++ b/src/content/ai/ai-toolkit/agents/streaming.mdx
@@ -150,8 +150,6 @@ export async function handleStreamEditRequest(request: Request): Promise<Respons
       tiptapEdit: tool({
         description: tiptapEdit.description,
         inputSchema: z.fromJSONSchema(tiptapEdit.inputSchema),
-        // Constrain sampling to the tool's input schema.
-        strict: true,
         onInputStart: () =>
           send({
             version: 1,


### PR DESCRIPTION
The streaming guide sets `strict: true` in its example. That makes the provider reject the `tiptapEdit` schema with a 400, so anyone copying it gets a broken integration.

`tiptapEdit`'s `content` accepts arbitrary ProseMirror JSON, so its schema is recursive and cannot satisfy OpenAI structured outputs. The AI agent chatbot guide does not set `strict`.

Matches ueberdosis/ai-toolkit-demos#116.