### PR TITLE
feature: respect CTA bar hideAt date

### DIFF
--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -32,6 +32,10 @@ const PageEditFooter = async () => {
 }
 
 export const LayoutCTABar = () => {
+  if (CTA_BAR.hideAt && CTA_BAR.hideAt <= new Date()) {
+    return null
+  }
+
   return (
     <div
       className={cn(

--- a/src/utils/constants.tsx
+++ b/src/utils/constants.tsx
@@ -19,6 +19,7 @@ export type CtaBarData = {
   label: string
   button: { text: string; href: string }
   productHunt?: { imageSrc: string; href: string; alt: string }
+  hideAt?: Date
 }
 
 export const CTA_BAR: CtaBarData = {


### PR DESCRIPTION
This PR adds a new CTA Bar option called hideAt which can be used to control when a CTA bar should automatically be disabled.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>