### PR TITLE
feature: add hideAt expiry date to CTA_BAR

### DIFF
--- a/src/utils/constants.tsx
+++ b/src/utils/constants.tsx
@@ -28,6 +28,7 @@ export const CTA_BAR: CtaBarData = {
     text: 'Learn more',
     href: 'https://tiptap.dev/blog/release-notes/ai-toolkit-now-in-beta',
   },
+  hideAt: new Date('2026-08-15T23:59:00+01:00'),
 }
 
 export const VERSIONS: Array<VersionData> = [


### PR DESCRIPTION
This PR adds a expiry date for our currently running campaign at August 15th, at 23:59 CET


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>