### PR TITLE
Build custom node results with the Docx re-export

### DIFF
--- a/src/content/conversion/export/_shared/_export-styles-guide.mdx
+++ b/src/content/conversion/export/_shared/_export-styles-guide.mdx
@@ -527,7 +527,7 @@ Element overrides apply to header and footer content as well as the body: a `par
 When you want to style header/footer content **differently** from the body, use `headerFooterOverrides`. It accepts the same six fields and replaces the matching body-wide override scoped to header/footer content only. Each field is a complete replacement, not a deep merge: fields you leave undefined fall back to the body-wide override of the same name.
 
 ```ts
-import { BorderStyle } from 'docx'
+import { Docx, ExportDocx } from '@tiptap-pro/extension-export-docx'
 
 ExportDocx.configure({
   onCompleteExport: (result) => {
@@ -536,12 +536,12 @@ ExportDocx.configure({
   // Body tables get a 1pt grid border
   tableOverrides: {
     borders: {
-      top: { style: BorderStyle.SINGLE, size: 4, color: '000000' },
-      bottom: { style: BorderStyle.SINGLE, size: 4, color: '000000' },
-      left: { style: BorderStyle.SINGLE, size: 4, color: '000000' },
-      right: { style: BorderStyle.SINGLE, size: 4, color: '000000' },
-      insideHorizontal: { style: BorderStyle.SINGLE, size: 4, color: '000000' },
-      insideVertical: { style: BorderStyle.SINGLE, size: 4, color: '000000' },
+      top: { style: Docx.BorderStyle.SINGLE, size: 4, color: '000000' },
+      bottom: { style: Docx.BorderStyle.SINGLE, size: 4, color: '000000' },
+      left: { style: Docx.BorderStyle.SINGLE, size: 4, color: '000000' },
+      right: { style: Docx.BorderStyle.SINGLE, size: 4, color: '000000' },
+      insideHorizontal: { style: Docx.BorderStyle.SINGLE, size: 4, color: '000000' },
+      insideVertical: { style: Docx.BorderStyle.SINGLE, size: 4, color: '000000' },
     },
   },
   // Header/footer tables (e.g. a layout table inside a page header) are
@@ -549,12 +549,12 @@ ExportDocx.configure({
   headerFooterOverrides: {
     tableOverrides: {
       borders: {
-        top: { style: BorderStyle.NONE },
-        bottom: { style: BorderStyle.NONE },
-        left: { style: BorderStyle.NONE },
-        right: { style: BorderStyle.NONE },
-        insideHorizontal: { style: BorderStyle.NONE },
-        insideVertical: { style: BorderStyle.NONE },
+        top: { style: Docx.BorderStyle.NONE },
+        bottom: { style: Docx.BorderStyle.NONE },
+        left: { style: Docx.BorderStyle.NONE },
+        right: { style: Docx.BorderStyle.NONE },
+        insideHorizontal: { style: Docx.BorderStyle.NONE },
+        insideVertical: { style: Docx.BorderStyle.NONE },
       },
     },
   },

--- a/src/content/conversion/getting-started/guides/custom-extensions.mdx
+++ b/src/content/conversion/getting-started/guides/custom-extensions.mdx
@@ -122,11 +122,17 @@ Imported DOCX blockquotes now arrive in the editor as `callout` nodes, with what
 
 ### Serialize the callout back to DOCX on export
 
-For exports to round-trip, `ExportDocx` needs to know how to write your custom node out. Pass a `customNodes` entry whose `type` matches the Tiptap node name and whose `render(node)` function returns one (or many) `docx` library objects:
+For exports to round-trip, `ExportDocx` needs to know how to write your custom node out. Pass a `customNodes` entry whose `type` matches the Tiptap node name and whose `render(node)` function returns one (or many) document objects:
+
+<Callout variant="warning" title="Build these with Docx, not with a direct docx import">
+  `@tiptap-pro/extension-export-docx` re-exports the document library as `Docx`, and that is the
+  copy the exporter recognises. If you build the result with `new Paragraph()` from your own `docx`
+  install instead, the export drops it. Only constructors matter: enums such as `BorderStyle` and
+  `WidthType` are plain strings and work either way.
+</Callout>
 
 ```ts
-import { Paragraph, TextRun } from 'docx'
-import { ExportDocx } from '@tiptap-pro/extension-export-docx'
+import { Docx, ExportDocx } from '@tiptap-pro/extension-export-docx'
 
 ExportDocx.configure({
   customNodes: [
@@ -141,8 +147,8 @@ ExportDocx.configure({
           .map((leaf) => leaf.text ?? '')
           .join('')
 
-        return new Paragraph({
-          children: [new TextRun({ text, bold: true })],
+        return new Docx.Paragraph({
+          children: [new Docx.TextRun({ text, bold: true })],
         })
       },
     },
@@ -153,7 +159,7 @@ ExportDocx.configure({
 })
 ```
 
-The `render` function is invoked with the Tiptap node and must return one of: `Paragraph`, `Paragraph[]`, `Table`, `TextRun`, `ExternalHyperlink`, or `null` (returning `null` drops the node from the export). See [Custom node export](/conversion/export/docx/custom-nodes) for the full API and more elaborate examples.
+The `render` function is invoked with the Tiptap node and must return one of: `Paragraph`, `Paragraph[]`, `Table`, `TextRun`, `ExternalHyperlink`, `InternalHyperlink`, `Bookmark`, or `null` (returning `null` drops the node from the export). See [Custom node export](/conversion/export/docx/custom-nodes) for the full API and more elaborate examples.
 
 ## What to expect
 


### PR DESCRIPTION
Our getting-started guide currently teaches the one import that silently loses content.

`conversion/getting-started/guides/custom-extensions.mdx` showed `import { Paragraph, TextRun } from 'docx'` feeding straight into `ExportDocx.configure({ customNodes })`. Objects built from a consumer's own `docx` install are a different class identity from the copy compiled into `extension-export-docx`, so they get discarded on the way out. No error, nothing in the log, the node just isn't in the file.

Meanwhile the reference pages already do it right, using `Docx.Paragraph`. So a reader following the guide gets broken exports and a reader following the reference gets working ones, which is worse than being uniformly wrong. This is very likely how a pilot customer lost five node types from every export for weeks.

A separate change in the export package adds a guard that throws instead of dropping the content silently. This is the docs half of that.

## What

**`custom-extensions.mdx`**, the actual bug:

- `import { Docx, ExportDocx } from '@tiptap-pro/extension-export-docx'`, and the render body builds `new Docx.Paragraph` / `new Docx.TextRun`.
- Added a warning callout on why, including that only constructors matter, so the change looks as small as it is.
- Corrected the return-types sentence, which was missing `InternalHyperlink` and `Bookmark`. Worth fixing now that the guard throws on anything outside `CustomNodeResult`.

**`_export-styles-guide.mdx`**, consistency only:

- `BorderStyle` → `Docx.BorderStyle`, 12 usages. **This was never broken.** `BorderStyle` is a plain string enum, it compares equal across both copies, and it sits inside `tableOverrides` which are option objects rather than components. Changed so readers get one rule, import from our package, instead of inferring "enums from `docx`, constructors from us". Happy to drop this half if you'd rather the diff stayed on the bug.

## Left alone

The two `import type { Footer, Header } from 'docx'` lines in `pdf/headers-footers.mdx` and `pdf/editor-extension.mdx`. Types carry no runtime identity, so those are fine.

## Verified

- No runtime `docx` imports remain anywhere in `src/content`, only the two type-only ones above.
- `prettier --check` clean on both files.
- `variant="warning"` checked against `Callout.tsx` rather than guessed.
- `pnpm lint` could not run: eslint 10.2.1 crashes internally on this repo, and it does so on a clean `origin/main` too (`react/display-name` rule loading, and an `addGlobals` failure in `eslint-plugin-mdx`). Pre-existing and unrelated to this change, so CI is the real check here. Might be worth its own ticket 🤔

