### PR TITLE
Document skipped images and the onWarning option on DOCX export

### DIFF
--- a/src/content/conversion/content-types/structures-and-media/images.mdx
+++ b/src/content/conversion/content-types/structures-and-media/images.mdx
@@ -97,3 +97,17 @@ On export, each image node's `src` URL is fetched and the binary data is embedde
 If the node has `width` and `height` attributes (in pixels), those values are converted to points (1px = 0.75pt). If no dimensions are set, the exporter detects intrinsic size automatically. If detection fails, images default to 800x400 pixels.
 
 The `alt` attribute on the image node is mapped to the DOCX image's alt text fields.
+
+### When an image cannot be fetched
+
+An image whose URL returns a 404, whose host does not answer, or whose format is not one of
+the supported ones is left out of the document, and the rest of the document still exports.
+If that image was the only thing in its paragraph, the paragraph is dropped too, so no blank
+line is left behind.
+
+EMF is the common case: Word writes it for pasted charts and equations, and DOCX export
+cannot embed it.
+
+Pass `onWarning` to see which images were skipped, or `onImageError: 'throw'` to fail the
+export instead. See [Images that cannot be
+exported](/conversion/export/docx/editor-extension#images-that-cannot-be-exported).

--- a/src/content/conversion/export/docx/editor-extension.mdx
+++ b/src/content/conversion/export/docx/editor-extension.mdx
@@ -89,6 +89,8 @@ const editor = new Editor({
       tableRowOverrides: {}, // optional. Default: {}
       tableCellOverrides: {}, // optional. Default: {}
       imageOverrides: {}, // optional. Default: {}
+      onWarning: undefined, // optional. Default: undefined
+      onImageError: 'skip', // optional. Default: 'skip'
       numberingFormats: undefined, // optional. Default: undefined
       headerFooterOverrides: undefined, // optional. Default: undefined
       fonts: undefined, // optional. Default: undefined
@@ -114,6 +116,8 @@ const editor = new Editor({
 | tableRowOverrides     | Base defaults for all table rows (e.g. `cantSplit`, `tableHeader`, `height`; also applied to header/footer tables). Accepts a static object applied to every row, or a function `(node) => overrides` that receives the current table row node. [See Element overrides](/conversion/export/docx/styles#element-overrides)                                                                                         | `{}`                                |
 | tableCellOverrides    | Base defaults for all table cells (also applied to header/footer cells). Accepts a static object applied to every cell, or a function `(node) => overrides` that receives the current table cell node. [See Element overrides](/conversion/export/docx/styles#element-overrides)                                                                                                                                  | `{}`                                |
 | imageOverrides        | Image property overrides (also applied to images in headers/footers). Accepts either a static object applied to every image, or a function `(node) => overrides` that receives the current image node so overrides can be derived from its attributes. [See Element overrides](/conversion/export/docx/styles#element-overrides)                                                                                  | `{}`                                |
+| onWarning             | Called for each image the export skipped, with `code`, `message` and `src`. Without it, skipped images go to `console.warn`. [See Images that cannot be exported](#images-that-cannot-be-exported)                                                                                                                                                                                                                 | `undefined`                         |
+| onImageError          | What to do with an image the exporter cannot use. `skip` leaves it out and reports it; `throw` fails the whole export. [See Images that cannot be exported](#images-that-cannot-be-exported)                                                                                                                                                                                                                      | `'skip'`                            |
 | numberingFormats      | Registry of multilevel ordered-list numbering format definitions. Each entry's `id` matches the `numberingFormat` attribute on the outermost `<ol>`; unknown / missing ids fall back to plain `1. 2. 3.` numbering. Pair this with `OrderedListNumbering` and `generateNumberingFormatCss` from `@tiptap-pro/extension-convert-kit`. [See Ordered list numbering](/conversion/export/docx/ordered-list-numbering) | `undefined`                         |
 | headerFooterOverrides | Per-field overrides scoped to header/footer content only; they fully replace the matching body-wide override inside headers and footers. Only applies to headers/footers auto-extracted from the [Pages extension](/pages/getting-started/overview). [See `headerFooterOverrides`](/conversion/export/docx/styles#headerfooteroverrides)                                                                          | `undefined`                         |
 | footnotes             | Footnote content keyed by note id (`Record<string, JSONContent>`). Each `footnoteReference` node in the body whose `noteId` has an entry exports as a real Word footnote. Auto-extracted from [Pages footnotes](/pages/core-concepts/footnotes) when enabled; pass this option only to override.                                                                                                                  | Auto-extracted from Pages           |
@@ -168,6 +172,8 @@ The `exportDocx` method takes an optional `ExportDocxOptions` (`object`) as an a
 | tableRowOverrides     | Base defaults for all table rows (e.g. `cantSplit`, `tableHeader`, `height`; also applied to header/footer tables). Accepts a static object applied to every row, or a function `(node) => overrides` that receives the current table row node. [See Element overrides](/conversion/export/docx/styles#element-overrides)                                                                                         | `{}`                                |
 | tableCellOverrides    | Base defaults for all table cells (also applied to header/footer cells). Accepts a static object applied to every cell, or a function `(node) => overrides` that receives the current table cell node. [See Element overrides](/conversion/export/docx/styles#element-overrides)                                                                                                                                  | `{}`                                |
 | imageOverrides        | Image property overrides (also applied to images in headers/footers). Accepts either a static object applied to every image, or a function `(node) => overrides` that receives the current image node so overrides can be derived from its attributes. [See Element overrides](/conversion/export/docx/styles#element-overrides)                                                                                  | `{}`                                |
+| onWarning             | Called for each image the export skipped, with `code`, `message` and `src`. Without it, skipped images go to `console.warn`. [See Images that cannot be exported](#images-that-cannot-be-exported)                                                                                                                                                                                                                 | `undefined`                         |
+| onImageError          | What to do with an image the exporter cannot use. `skip` leaves it out and reports it; `throw` fails the whole export. [See Images that cannot be exported](#images-that-cannot-be-exported)                                                                                                                                                                                                                      | `'skip'`                            |
 | numberingFormats      | Registry of multilevel ordered-list numbering format definitions. Each entry's `id` matches the `numberingFormat` attribute on the outermost `<ol>`; unknown / missing ids fall back to plain `1. 2. 3.` numbering. Pair this with `OrderedListNumbering` and `generateNumberingFormatCss` from `@tiptap-pro/extension-convert-kit`. [See Ordered list numbering](/conversion/export/docx/ordered-list-numbering) | `undefined`                         |
 | headerFooterOverrides | Per-field overrides scoped to header/footer content only; they fully replace the matching body-wide override inside headers and footers. Only applies to headers/footers auto-extracted from the [Pages extension](/pages/getting-started/overview). [See `headerFooterOverrides`](/conversion/export/docx/styles#headerfooteroverrides)                                                                          | `undefined`                         |
 | footnotes             | Footnote content keyed by note id (`Record<string, JSONContent>`). Each `footnoteReference` node in the body whose `noteId` has an entry exports as a real Word footnote. Auto-extracted from [Pages footnotes](/pages/core-concepts/footnotes) when enabled; pass this option only to override.                                                                                                                  | Auto-extracted from Pages           |
@@ -196,6 +202,8 @@ const editor = new Editor({
       tableRowOverrides: {}, // optional. Default: {}
       tableCellOverrides: {}, // optional. Default: {}
       imageOverrides: {}, // optional. Default: {}
+      onWarning: undefined, // optional. Default: undefined
+      onImageError: 'skip', // optional. Default: 'skip'
       headerFooterOverrides: undefined, // optional. Default: undefined
       fonts: undefined, // optional. Default: undefined
       embedFonts: false, // optional. Default: false
@@ -276,6 +284,8 @@ Let's first take a look into the `exportDocx` function signature:
  * @param options.tableRowOverrides - Base defaults for all table rows
  * @param options.tableCellOverrides - Base defaults for all table cells
  * @param options.imageOverrides - Image property overrides
+ * @param options.onWarning - Called for each image the export skipped
+ * @param options.onImageError - 'skip' (default) or 'throw'
  * @example exportDocx({ document: editor.getJSON(), exportType: 'blob', customNodes: [], styleOverrides: {} })
  */
 async function exportDocx({
@@ -289,6 +299,8 @@ async function exportDocx({
   tableRowOverrides,
   tableCellOverrides,
   imageOverrides,
+  onWarning,
+  onImageError,
 }: ExportDocxOptions) {}
 ```
 
@@ -322,6 +334,62 @@ app.post('/export-docx', async (req, res) => {
   }
 })
 ```
+
+## Images that cannot be exported
+
+The export fetches every image by its `src`. Some cannot be used: the URL returns a 404,
+the host does not answer, or the format is one DOCX cannot embed. Word writes EMF for
+pasted charts and equations, so documents that came from Word often carry one.
+
+By default the export leaves that image out and carries on, so one broken picture does not
+cost you the whole file. If the image was the only thing in its paragraph, the paragraph
+goes too, leaving no blank line behind.
+
+Pass `onWarning` to find out which images were skipped:
+
+```js
+ExportDocx.configure({
+  onCompleteExport: result => saveAs(result, 'export.docx'),
+  onWarning: warning => {
+    console.log(warning.code, warning.src)
+  },
+})
+```
+
+Each warning carries:
+
+| Field         | Description                                                                       |
+| ------------- | --------------------------------------------------------------------------------- |
+| `code`        | `image-missing-src`, `image-request-failed`, `image-fetch-failed`, or `image-unsupported-type` |
+| `message`     | Readable summary, safe to log                                                     |
+| `src`         | The image URL, when the node had one                                              |
+| `status`      | HTTP status, when the host answered with a failure                                 |
+| `contentType` | The detected type, for an unsupported format                                       |
+
+Without `onWarning`, skipped images are reported through `console.warn`. Exceptions thrown
+inside `onWarning` are swallowed, so a mistake in your handler cannot break an export.
+
+To fail the export instead, set `onImageError: 'throw'`. The thrown error is one of
+`ImageMissingSrcError`, `ImageRequestError`, `ImageFetchError` or `UnsupportedImageTypeError`,
+all exported from the package and all extending `ImageConversionError`:
+
+```js
+import { ImageConversionError } from '@tiptap-pro/extension-export-docx'
+
+try {
+  await exportDocx({ document, onImageError: 'throw' })
+} catch (error) {
+  if (error instanceof ImageConversionError) {
+    console.log(`Could not use ${error.src}: ${error.code}`)
+  }
+}
+```
+
+<Callout title="Relative image URLs are not resolved" variant="hint">
+  Export runs against the `src` exactly as stored. A relative URL such as `/img/chart.png` has
+  no origin to resolve against, so it is reported as `image-request-failed` and skipped. Store
+  absolute URLs the exporter can reach.
+</Callout>
 
 ## Node attribute inference
 


### PR DESCRIPTION
## Why

DOCX export used to fail entirely when one image couldn't be fetched. That's changing: an unusable image is skipped and reported instead, and there are two new options to document, `onWarning` and `onImageError`.

EMF is worth calling out explicitly. Word writes it for pasted charts and equations, so plenty of real documents carry one, and it can't be embedded in DOCX. People hit this and had no idea why their export died.

## What

`conversion/export/docx/editor-extension.mdx`

- `onWarning` and `onImageError` added to both option tables and both config samples, plus the server-side `exportDocx` signature
- new **Images that cannot be exported** section: what gets skipped, the warning shape, the four typed errors, and how to opt back into failing
- a hint callout that relative `src` values aren't resolved, since there's no origin to resolve them against server-side

`conversion/content-types/structures-and-media/images.mdx`

- a **When an image cannot be fetched** subsection under Export, linking to the detail above

## Please don't merge yet

This documents `@tiptap-pro/extension-export-docx` 0.28.0, which isn't released. The behaviour comes from ueberdosis/tiptap-pro#1011. Merging before that ships would document options nobody can use yet.

Full disclosure: I briefly pushed this content straight to `main` by mistake, then reverted it (a68062b9). `main` is back to where it was, and this branch is the same content with a sensible commit message.
