### PR TITLE
docs(tracked-changes): document node attribute changes

### DIFF
--- a/src/content/tracked-changes/api-reference/styling.mdx
+++ b/src/content/tracked-changes/api-reference/styling.mdx
@@ -8,7 +8,7 @@ meta:
   category: Tracked Changes
 ---
 
-The suggestion mark renders as a `<span>` element with data attributes that can be targeted with CSS.
+Suggestion marks and node-level suggestions render data attributes that can be targeted with CSS.
 
 ## CSS selectors
 
@@ -19,55 +19,62 @@ The suggestion mark renders as a `<span>` element with data attributes that can 
 }
 
 /* Insertions */
-[data-suggestion-type="add"] {
+[data-suggestion-type='add'] {
   background-color: rgba(0, 255, 0, 0.2);
   text-decoration: underline;
 }
 
 /* Deletions */
-[data-suggestion-type="delete"] {
+[data-suggestion-type='delete'] {
   background-color: rgba(255, 0, 0, 0.2);
   text-decoration: line-through;
 }
 
 /* Replacement deletions (old text being replaced) */
-[data-suggestion-type="replaceDeletion"] {
+[data-suggestion-type='replaceDeletion'] {
   background-color: rgba(255, 0, 0, 0.2);
   text-decoration: line-through;
 }
 
 /* Replacement insertions (new text replacing old) */
-[data-suggestion-type="replaceInsertion"] {
+[data-suggestion-type='replaceInsertion'] {
   background-color: rgba(0, 255, 0, 0.2);
   text-decoration: underline;
 }
 
 /* Mark changes (formatting added or removed) */
-[data-suggestion-type="markChange"] {
+[data-suggestion-type='markChange'] {
   background-color: rgba(255, 200, 0, 0.2);
 }
 
+/* Node attribute changes */
+[data-suggestion-type='attributeChange'] {
+  outline: 2px solid rgb(59, 130, 246);
+  outline-offset: 2px;
+}
+
 /* Suggested block splits (the block created by a tracked Enter) */
-[data-suggestion-type="blockSplit"] {
+[data-suggestion-type='blockSplit'] {
   box-shadow: inset 2px 0 0 rgb(59, 130, 246);
 }
 
 /* Style suggestions by user */
-[data-suggestion-user="user-123"] {
+[data-suggestion-user='user-123'] {
   border-bottom: 2px solid blue;
 }
 ```
 
 ## Available data attributes
 
-| Attribute | Description |
-| --- | --- |
-| `data-suggestion` | Always present on suggestion mark elements |
-| `data-suggestion-id` | The unique suggestion ID |
-| `data-suggestion-type` | The internal type: `'add'`, `'delete'`, `'replaceDeletion'`, `'replaceInsertion'`, `'markChange'`, `'sink'`, `'lift'`, or `'blockSplit'` |
-| `data-suggestion-user` | The ID of the user who created the suggestion |
-| `data-suggestion-created` | ISO timestamp when the suggestion was created |
-| `data-suggestion-user-metadata` | JSON-serialized user metadata object (only present when `userMetadata` is set) |
+| Attribute                           | Description                                                                                                                                                   |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data-suggestion`                   | Always present on suggestion mark elements                                                                                                                    |
+| `data-suggestion-id`                | The unique suggestion ID                                                                                                                                      |
+| `data-suggestion-type`              | The internal type: `'add'`, `'delete'`, `'replaceDeletion'`, `'replaceInsertion'`, `'markChange'`, `'attributeChange'`, `'sink'`, `'lift'`, or `'blockSplit'` |
+| `data-suggestion-user`              | The ID of the user who created the suggestion                                                                                                                 |
+| `data-suggestion-created`           | ISO timestamp when the suggestion was created                                                                                                                 |
+| `data-suggestion-user-metadata`     | JSON-serialized user metadata object (only present when `userMetadata` is set)                                                                                |
+| `data-suggestion-attribute-changes` | JSON-serialized attribute changes (only present for `attributeChange` suggestions)                                                                            |
 
 `data-suggestion-type` holds the internal [SuggestionNodeType](/tracked-changes/api-reference/types#suggestionnodetype), not the public one. A [block split](/tracked-changes/usage/advanced-usage#block-splits) is `blockSplit` here, even though the query API reports it as `split`.
 

--- a/src/content/tracked-changes/api-reference/styling.mdx
+++ b/src/content/tracked-changes/api-reference/styling.mdx
@@ -68,7 +68,7 @@ Suggestion marks and node-level suggestions render data attributes that can be t
 
 | Attribute                           | Description                                                                                                                                                   |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `data-suggestion`                   | Always present on suggestion mark elements                                                                                                                    |
+| `data-suggestion`                   | Always present on suggestion mark elements and node-level suggestion elements                                                                                 |
 | `data-suggestion-id`                | The unique suggestion ID                                                                                                                                      |
 | `data-suggestion-type`              | The internal type: `'add'`, `'delete'`, `'replaceDeletion'`, `'replaceInsertion'`, `'markChange'`, `'attributeChange'`, `'sink'`, `'lift'`, or `'blockSplit'` |
 | `data-suggestion-user`              | The ID of the user who created the suggestion                                                                                                                 |

--- a/src/content/tracked-changes/api-reference/types.mdx
+++ b/src/content/tracked-changes/api-reference/types.mdx
@@ -15,7 +15,15 @@ The extension exports TypeScript types for working with suggestions.
 Public-facing suggestion type returned by the query API:
 
 ```ts
-type SuggestionType = 'add' | 'delete' | 'replace' | 'markChange' | 'sink' | 'lift' | 'split'
+type SuggestionType =
+  | 'add'
+  | 'delete'
+  | 'replace'
+  | 'markChange'
+  | 'attributeChange'
+  | 'sink'
+  | 'lift'
+  | 'split'
 ```
 
 - `sink` and `lift` are pending list-item nesting changes (Tab and Shift-Tab)
@@ -34,7 +42,7 @@ type SuggestionMarkType = 'add' | 'delete' | 'replaceDeletion' | 'replaceInserti
 Internal type stored in node attributes. Covers every mark-level type plus the structural variants that can only exist at the node level:
 
 ```ts
-type SuggestionNodeType = SuggestionMarkType | 'sink' | 'lift' | 'blockSplit'
+type SuggestionNodeType = SuggestionMarkType | 'attributeChange' | 'sink' | 'lift' | 'blockSplit'
 ```
 
 `blockSplit` is the node-level counterpart of the public `split` type. It is what you find in `suggestionType` node attributes and in the `data-suggestion-type` DOM attribute, so use `blockSplit` in CSS selectors and `split` when filtering or switching on `suggestion.type`.
@@ -61,6 +69,20 @@ type SuggestionMarkChange = {
 }
 ```
 
+## SuggestionAttributeChange
+
+Describes one attribute mutation stored on an `attributeChange` suggestion:
+
+```ts
+type SuggestionAttributeChange = {
+  attributeName: string
+  oldValue: unknown
+  newValue: unknown
+}
+```
+
+`oldValue` is the value before the suggestion. `newValue` is the proposed value that is present in the document while the suggestion is pending.
+
 ## Suggestion
 
 Represents a suggestion found in the document:
@@ -83,6 +105,9 @@ type Suggestion = {
   replacedText?: string
   // Only present for 'markChange' suggestions:
   markChanges?: SuggestionMarkChange[]
+  // Only present for 'attributeChange' suggestions:
+  attributeChanges?: SuggestionAttributeChange[]
+  nodeType?: string
   // Only present when the suggestion affects block-level nodes:
   insertedNodes?: JSONContent[]
   deletedNodes?: JSONContent[]
@@ -105,16 +130,16 @@ Note that `text` only drops text that a nested suggestion **inserted**. A nested
 
 Author A inserts `"Hello world"`, then author B inserts `"great "` before `"world"` (nested inside A's addition):
 
-| Suggestion        | `text`          | `fullText`            |
-| ----------------- | --------------- | --------------------- |
-| A (add, user-1)   | `"Hello world"` | `"Hello great world"` |
-| B (add, user-2)   | `"great "`      | `"great "`            |
+| Suggestion      | `text`          | `fullText`            |
+| --------------- | --------------- | --------------------- |
+| A (add, user-1) | `"Hello world"` | `"Hello great world"` |
+| B (add, user-2) | `"great "`      | `"great "`            |
 
 ```ts
 import { findSuggestions } from '@tiptap-pro/extension-tracked-changes'
 
 const suggestions = findSuggestions(editor)
-const outer = suggestions.find(s => s.userId === 'user-1')
+const outer = suggestions.find((s) => s.userId === 'user-1')
 
 outer.text // "Hello world"        → show this in a review sidebar
 outer.fullText // "Hello great world"  → use when you need the literal span
@@ -123,16 +148,25 @@ outer.fullText // "Hello great world"  → use when you need the literal span
 Default to `text` when displaying "what this person changed" (review panels, comment threads, activity logs). Reach for `fullText` only when you need the exact contiguous text the mark covers in the document.
 
 For `replace` suggestions:
+
 - `text` contains the **new** (inserted) text
 - `replacedText` contains the **old** (deleted) text
 - `deletionRange` and `insertionRange` give the exact positions of each part
 - `from` and `to` cover the full range of both parts
 
 For `markChange` suggestions:
+
 - `text` contains the affected text content
 - `markChanges` contains the tracked mark operations, including mark names and attrs
 
+For `attributeChange` suggestions:
+
+- `nodeType` is the schema name of the updated node
+- `attributeChanges` lists each attribute's previous and proposed values
+- accepting keeps the proposed values; rejecting restores the previous values
+
 For block-level node suggestions (e.g. inserting or deleting a paragraph or heading):
+
 - `text` always contains the actual text content of the affected node — never a `[nodeName]` placeholder
 - `insertedNodes` contains the full JSON representation of each inserted node
 - `deletedNodes` contains the full JSON representation of each deleted node
@@ -140,6 +174,7 @@ For block-level node suggestions (e.g. inserting or deleting a paragraph or head
 Use `insertedNodes` and `deletedNodes` to inspect node types and attributes when building richer UIs, such as displaying a node type badge alongside the suggestion text.
 
 For `split` suggestions:
+
 - `text` is always empty, because a block split neither adds nor removes text
 - `from` and `to` span the second block, the one created by the split
 
@@ -234,15 +269,16 @@ import {
 } from '@tiptap-pro/extension-tracked-changes'
 
 // Constants
-SUGGESTION_TYPES.ADD              // 'add'
-SUGGESTION_TYPES.DELETE           // 'delete'
-SUGGESTION_TYPES.REPLACE_DELETION  // 'replaceDeletion'
+SUGGESTION_TYPES.ADD // 'add'
+SUGGESTION_TYPES.DELETE // 'delete'
+SUGGESTION_TYPES.REPLACE_DELETION // 'replaceDeletion'
 SUGGESTION_TYPES.REPLACE_INSERTION // 'replaceInsertion'
-SUGGESTION_TYPES.MARK_CHANGE      // 'markChange'
-SUGGESTION_TYPES.SINK             // 'sink'
-SUGGESTION_TYPES.LIFT             // 'lift'
-SUGGESTION_TYPES.BLOCK_SPLIT      // 'blockSplit' (node-level)
-SUGGESTION_TYPES.SPLIT            // 'split' (query API)
+SUGGESTION_TYPES.MARK_CHANGE // 'markChange'
+SUGGESTION_TYPES.ATTRIBUTE_CHANGE // 'attributeChange'
+SUGGESTION_TYPES.SINK // 'sink'
+SUGGESTION_TYPES.LIFT // 'lift'
+SUGGESTION_TYPES.BLOCK_SPLIT // 'blockSplit' (node-level)
+SUGGESTION_TYPES.SPLIT // 'split' (query API)
 
 // Check if a mark type represents added content (matches 'add' and 'replaceInsertion')
 isAddLikeType('add') // true

--- a/src/content/tracked-changes/getting-started/overview.mdx
+++ b/src/content/tracked-changes/getting-started/overview.mdx
@@ -35,12 +35,13 @@ The Tracked Changes extension enables suggestion mode for collaborative editing 
 
 ## Features
 
-The extension tracks seven types of changes:
+The extension tracks eight types of changes:
 
 - **Insertions** (`add`) — New content added to the document
 - **Deletions** (`delete`) — Existing content marked for removal
 - **Replacements** (`replace`) — Content that was simultaneously deleted and replaced with new content
 - **Mark changes** (`markChange`) — Formatting or other mark-level changes applied to existing text
+- **Attribute changes** (`attributeChange`) — Updates to existing node attributes, such as an image's `src` or a custom node's configuration
 - **Block splits** (`split`) — A paragraph break added by pressing Enter
 - **List indents** (`sink`) — A list item nested one level deeper with Tab
 - **List outdents** (`lift`) — A list item moved one level out with Shift-Tab

--- a/src/content/tracked-changes/guides/suggestion-list.mdx
+++ b/src/content/tracked-changes/guides/suggestion-list.mdx
@@ -53,9 +53,7 @@ function Editor() {
   })
 
   // Deduplicate — a suggestion can span multiple text nodes
-  const uniqueSuggestions = Array.from(
-    new Map(suggestions.map(s => [s.id, s])).values(),
-  )
+  const uniqueSuggestions = Array.from(new Map(suggestions.map((s) => [s.id, s])).values())
 
   if (!editor) {
     return null
@@ -88,7 +86,7 @@ A single suggestion can span multiple text nodes when it crosses formatting boun
 
 ## Build the SuggestionList component
 
-Each suggestion has a `type` (`add`, `delete`, or `replace`), the changed `text`, user metadata, and a timestamp. Use these to render a clear list.
+Each suggestion has a `type`, the changed `text`, user metadata, and a timestamp. Attribute-change suggestions also expose the changed node type and values. Use these to render a clear list.
 
 ```jsx
 function SuggestionList({ suggestions, onAccept, onReject }) {
@@ -103,7 +101,7 @@ function SuggestionList({ suggestions, onAccept, onReject }) {
   return (
     <div className="suggestion-list">
       <h3>Suggestions ({suggestions.length})</h3>
-      {suggestions.map(suggestion => (
+      {suggestions.map((suggestion) => (
         <SuggestionItem
           key={suggestion.id}
           suggestion={suggestion}
@@ -128,30 +126,36 @@ function SuggestionItem({ suggestion, onAccept, onReject }) {
     add: '+ Insertion',
     delete: '− Deletion',
     replace: '~ Replacement',
+    markChange: '~ Formatting change',
+    attributeChange: '~ Attribute change',
+    sink: '→ List indent',
+    lift: '← List outdent',
+    split: '↵ Paragraph break',
   }
 
   // Derive a node type label from block-level node suggestions
   const nodes = suggestion.insertedNodes ?? suggestion.deletedNodes
-  const nodeType = nodes?.[0]?.type
+  const nodeType = suggestion.nodeType ?? nodes?.[0]?.type
 
   return (
     <div className="suggestion-item">
-      <div className="suggestion-item__type">
-        {typeLabel[suggestion.type]}
-      </div>
+      <div className="suggestion-item__type">{typeLabel[suggestion.type]}</div>
 
-      {nodeType && (
-        <span className="suggestion-item__node-badge">
-          {nodeType}
-        </span>
-      )}
+      {nodeType && <span className="suggestion-item__node-badge">{nodeType}</span>}
 
       <div className="suggestion-item__text">
-        "{suggestion.text}"
-        {suggestion.type === 'replace' && suggestion.replacedText && (
-          <span className="suggestion-item__replaced-text">
-            {' '}(was: "{suggestion.replacedText}")
-          </span>
+        {suggestion.type === 'attributeChange' ? (
+          <AttributeChanges changes={suggestion.attributeChanges ?? []} />
+        ) : (
+          <>
+            "{suggestion.text}"
+            {suggestion.type === 'replace' && suggestion.replacedText && (
+              <span className="suggestion-item__replaced-text">
+                {' '}
+                (was: "{suggestion.replacedText}")
+              </span>
+            )}
+          </>
         )}
       </div>
 
@@ -168,16 +172,26 @@ function SuggestionItem({ suggestion, onAccept, onReject }) {
     </div>
   )
 }
+
+function AttributeChanges({ changes }) {
+  return changes.map((change) => (
+    <div key={change.attributeName}>
+      {change.attributeName}: {JSON.stringify(change.oldValue)} → {JSON.stringify(change.newValue)}
+    </div>
+  ))
+}
 ```
 
 Using `suggestion.text` shows what each author contributed on their own — the right default for a review panel. When another author has stacked an edit inside this suggestion, `suggestion.fullText` differs from `suggestion.text` and holds the complete span including the nested text. You can surface that as a hint:
 
 ```jsx
-{suggestion.fullText !== suggestion.text && (
-  <span className="suggestion-item__stacked-hint">
-    with stacked edits: "{suggestion.fullText}"
-  </span>
-)}
+{
+  suggestion.fullText !== suggestion.text && (
+    <span className="suggestion-item__stacked-hint">
+      with stacked edits: "{suggestion.fullText}"
+    </span>
+  )
+}
 ```
 
 See [`text` vs `fullText`](/tracked-changes/api-reference/types#text-vs-fulltext) and [nested suggestions](/tracked-changes/usage/advanced-usage#nested-and-stacked-suggestions) for the full behavior.
@@ -261,7 +275,7 @@ function SuggestionList({ suggestions, onAccept, onReject, onAcceptAll, onReject
         </div>
       )}
 
-      {suggestions.map(suggestion => (
+      {suggestions.map((suggestion) => (
         <SuggestionItem
           key={suggestion.id}
           suggestion={suggestion}

--- a/src/content/tracked-changes/usage/advanced-usage.mdx
+++ b/src/content/tracked-changes/usage/advanced-usage.mdx
@@ -185,7 +185,7 @@ While the suggestion is pending, the document contains the proposed attribute va
 }
 ```
 
-Accepting the suggestion keeps the proposed values. Rejecting it restores every `oldValue`. If the same author changes an attribute again before review, the suggestion retains its original `oldValue` and updates its `newValue`. Changing it back to the original value removes that attribute from the pending suggestion.
+Accepting the suggestion keeps the proposed values. Rejecting it restores every `oldValue`. If the same author changes an attribute again before review, the suggestion retains its original `oldValue` and updates its `newValue`. Changing an attribute back to its original value removes that attribute from the pending suggestion. When that is the final changed attribute, the extension cancels the `attributeChange` suggestion.
 
 Style the affected node with `[data-suggestion-type="attributeChange"]`. See [Styling](/tracked-changes/api-reference/styling) and [SuggestionAttributeChange](/tracked-changes/api-reference/types#suggestionattributechange) for the DOM and API details.
 

--- a/src/content/tracked-changes/usage/advanced-usage.mdx
+++ b/src/content/tracked-changes/usage/advanced-usage.mdx
@@ -56,12 +56,12 @@ This matches how word processors show a tracked paragraph break.
 
 ### Accept, reject, and cancel
 
-| Action | Result |
-| --- | --- |
-| **Accept** the split | The suggestion attributes are stripped. Two plain blocks remain. |
-| **Reject** the split | The second block is merged back into the first, restoring the original single block. |
-| **Backspace** at the start of the split block | Cancels the split, same as rejecting it. |
-| **Delete** at the end of the block before the split | Cancels the split, same as rejecting it. |
+| Action                                              | Result                                                                               |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Accept** the split                                | The suggestion attributes are stripped. Two plain blocks remain.                     |
+| **Reject** the split                                | The second block is merged back into the first, restoring the original single block. |
+| **Backspace** at the start of the split block       | Cancels the split, same as rejecting it.                                             |
+| **Delete** at the end of the block before the split | Cancels the split, same as rejecting it.                                             |
 
 Backspace and Delete only cancel a split created by the **current user**. Another author's split is not collapsed by editing around it.
 
@@ -105,15 +105,16 @@ When suggestions are stacked, the outer suggestion's `text` and `fullText` field
 
 ### Accept and reject rules
 
-| Action                        | Result                                                                                  |
-| ----------------------------- | --------------------------------------------------------------------------------------- |
-| Accept an **inner** suggestion | Inner is applied; the **outer** suggestion stays intact.                                |
-| Reject an **inner** suggestion | Inner is discarded; the **outer** suggestion stays intact.                              |
-| Accept an **outer** suggestion | Outer is applied; **nested suggestions inside it survive** as their own pending suggestions. |
+| Action                         | Result                                                                                            |
+| ------------------------------ | ------------------------------------------------------------------------------------------------- |
+| Accept an **inner** suggestion | Inner is applied; the **outer** suggestion stays intact.                                          |
+| Reject an **inner** suggestion | Inner is discarded; the **outer** suggestion stays intact.                                        |
+| Accept an **outer** suggestion | Outer is applied; **nested suggestions inside it survive** as their own pending suggestions.      |
 | Reject an **outer** suggestion | Outer is discarded **along with its nested edits**, because the content they lived on is removed. |
 
 <Callout title="Inline only" variant="info">
-  Nesting is supported for inline suggestions only. Block-level nested suggestions (for example, a nested suggestion spanning whole blocks) are out of scope.
+  Nesting is supported for inline suggestions only. Block-level nested suggestions (for example, a
+  nested suggestion spanning whole blocks) are out of scope.
 </Callout>
 
 ## Mark tracking
@@ -164,6 +165,30 @@ TrackedChanges.configure({
 
 Use this option when your application has decorative or integration-specific marks that should never appear in tracked changes.
 
+## Node attribute tracking
+
+Updating an existing node's attributes creates an `attributeChange` suggestion instead of replacing the node. This applies to atom nodes, such as images, and non-atom nodes with custom attributes.
+
+While the suggestion is pending, the document contains the proposed attribute values. The suggestion exposes the previous and proposed values through `attributeChanges`, so a review UI can explain the change:
+
+```ts
+{
+  type: 'attributeChange',
+  nodeType: 'image',
+  attributeChanges: [
+    {
+      attributeName: 'src',
+      oldValue: 'https://example.com/old.png',
+      newValue: 'https://example.com/new.png',
+    },
+  ],
+}
+```
+
+Accepting the suggestion keeps the proposed values. Rejecting it restores every `oldValue`. If the same author changes an attribute again before review, the suggestion retains its original `oldValue` and updates its `newValue`. Changing it back to the original value removes that attribute from the pending suggestion.
+
+Style the affected node with `[data-suggestion-type="attributeChange"]`. See [Styling](/tracked-changes/api-reference/styling) and [SuggestionAttributeChange](/tracked-changes/api-reference/types#suggestionattributechange) for the DOM and API details.
+
 ## Table support
 
 The extension tracks structural changes inside tables, including row, cell, and column operations.
@@ -198,7 +223,7 @@ No additional configuration is required — table changes are tracked automatica
 
 ## Atom node tracking
 
-The extension automatically tracks changes to atom nodes like images, horizontal rules, and other non-text content. These nodes cannot have marks, so the extension uses node attributes (`suggestionId`, `suggestionType`, `suggestionUserId`, `suggestionCreatedAt`, `suggestionUserMetadata`) instead. This happens transparently — atom nodes appear in the same suggestion queries and can be accepted or rejected like any other suggestion.
+The extension automatically tracks changes to atom nodes like images, horizontal rules, and other non-text content. These nodes cannot have marks, so the extension uses node attributes (`suggestionId`, `suggestionType`, `suggestionUserId`, `suggestionCreatedAt`, `suggestionUserMetadata`) instead. Attribute updates on these nodes are tracked as `attributeChange` suggestions; other changes appear in the same suggestion queries and can be accepted or rejected like any other suggestion.
 
 ## Collaboration compatibility
 
@@ -231,7 +256,10 @@ By default, Tiptap code blocks do not allow marks, which prevents suggestion mar
 
 ```js
 import { CodeBlock } from '@tiptap/extension-code-block'
-import { TrackedChanges, withSuggestionMarkOnCodeBlock } from '@tiptap-pro/extension-tracked-changes'
+import {
+  TrackedChanges,
+  withSuggestionMarkOnCodeBlock,
+} from '@tiptap-pro/extension-tracked-changes'
 import StarterKit from '@tiptap/starter-kit'
 
 const TrackableCodeBlock = withSuggestionMarkOnCodeBlock(CodeBlock)


### PR DESCRIPTION
- Document attributeChange suggestions, styling, and API types
- Add attribute-change examples to tracked changes guides