### PR TITLE
docs: remove immediatelyRender from the Nuxt guide

### DIFF
--- a/src/content/editor/getting-started/install/nuxt.mdx
+++ b/src/content/editor/getting-started/install/nuxt.mdx
@@ -9,6 +9,7 @@ meta:
 This guide covers how to integrate Tiptap with your Nuxt 4 project, complete with code examples.
 
 import { CodeDemo } from '@/components/CodeDemo'
+import { Callout } from '@/components/ui/Callout'
 
 ### Requirements
 
@@ -45,8 +46,6 @@ To actually start using Tiptap, you'll need to add a new component to your app. 
 
 This is the fastest way to get Tiptap up and running with Vue. It will give you a very basic version of Tiptap, without any buttons. No worries, you will be able to add more functionality soon.
 
-Nuxt uses server-side rendering (SSR), but you don't need to configure anything for it. `useEditor` creates the editor in `onMounted`, so it only runs on the client after hydration. The `immediatelyRender` option is React-only and is not part of the Vue options.
-
 ```html
 <template>
   <EditorContent :editor="editor" />
@@ -62,6 +61,12 @@ Nuxt uses server-side rendering (SSR), but you don't need to configure anything 
   })
 </script>
 ```
+
+<Callout title="Do I need immediatelyRender: false?" variant="hint">
+  No. Nuxt uses server-side rendering, but `useEditor` only creates the editor once the component is
+  mounted, so it never runs on the server. `immediatelyRender` is a React-only option and doesn't
+  exist in Vue.
+</Callout>
 
 ### Add it to your app
 

--- a/src/content/editor/getting-started/install/nuxt.mdx
+++ b/src/content/editor/getting-started/install/nuxt.mdx
@@ -45,7 +45,7 @@ To actually start using Tiptap, you'll need to add a new component to your app. 
 
 This is the fastest way to get Tiptap up and running with Vue. It will give you a very basic version of Tiptap, without any buttons. No worries, you will be able to add more functionality soon.
 
-Since Nuxt uses server-side rendering (SSR), we set `immediatelyRender: false` to prevent the editor from rendering on the server. The editor requires browser APIs that aren't available during SSR, so this option ensures it only renders on the client after hydration.
+Nuxt uses server-side rendering (SSR), but you don't need to configure anything for it. `useEditor` creates the editor in `onMounted`, so it only runs on the client after hydration. The `immediatelyRender` option is React-only and is not part of the Vue options.
 
 ```html
 <template>
@@ -59,8 +59,6 @@ Since Nuxt uses server-side rendering (SSR), we set `immediatelyRender: false` t
   const editor = useEditor({
     content: `<p>I'm running Tiptap with Vue.js. 🎉</p>`,
     extensions: [StarterKit],
-    // Don't render on the server, only on the client after hydration
-    immediatelyRender: false,
   })
 </script>
 ```
@@ -105,8 +103,6 @@ You're probably used to binding your data with `v-model` in forms. This also pos
   const editor = useEditor({
     content: props.modelValue,
     extensions: [StarterKit],
-    // Don't render on the server, only on the client after hydration
-    immediatelyRender: false,
     onUpdate: ({ editor }) => {
       // HTML
       emit('update:modelValue', editor.getHTML())


### PR DESCRIPTION
The Nuxt guide tells you to pass `immediatelyRender: false`, but that option only exists on React's `useEditor`. In Vue it is not part of `Partial<EditorOptions>`, so TypeScript users get `Object literal may only specify known properties, and immediatelyRender does not exist in type Partial<EditorOptions>` when they copy the example.

Nothing is needed in its place: the Vue `useEditor` builds the editor inside `onMounted`, so it never runs during SSR. This drops the option from both snippets and answers the question in a callout instead, the same way the Next.js guide does.

Fixes ueberdosis/tiptap#8270