### PR TITLE
docs(extension-text-style): document color normalization

### DIFF
--- a/.changeset/color-normalizer-option.md
+++ b/.changeset/color-normalizer-option.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': patch
+---
+
+Document the opt-in `colorNormalizer` option on the Color and Background Color extensions.

--- a/src/content/editor/extensions/functionality/background-color.mdx
+++ b/src/content/editor/extensions/functionality/background-color.mdx
@@ -69,6 +69,32 @@ BackgroundColor.configure({
 })
 ```
 
+### colorNormalizer
+
+An optional callback used to normalize color values to a canonical form (for example, hex to `rgb(...)`), so parsed and rendered colors stay consistent. This can prevent the cursor from jumping during IME composition (for example when typing Korean, Japanese, or Chinese) if a color gets re-parsed into a different string representation while composing.
+
+This option is opt-in and disabled by default, since normalizing colors changes the format in which they're stored and rendered, which can be a breaking change if your application relies on the exact color string a user typed or pasted.
+
+Default: `null`
+
+Pass the built-in `normalizeColor` helper to normalize using the browser's own CSS color parser:
+
+```js
+import { BackgroundColor, normalizeColor } from '@tiptap/extension-text-style'
+
+BackgroundColor.configure({
+  colorNormalizer: normalizeColor,
+})
+```
+
+Or provide your own function, for example to normalize to hex instead of `rgb(...)`:
+
+```js
+BackgroundColor.configure({
+  colorNormalizer: (color) => myColorLibrary.toHex(color),
+})
+```
+
 ## Commands
 
 ### setBackgroundColor()

--- a/src/content/editor/extensions/functionality/color.mdx
+++ b/src/content/editor/extensions/functionality/color.mdx
@@ -69,6 +69,32 @@ Color.configure({
 })
 ```
 
+### colorNormalizer
+
+An optional callback used to normalize color values to a canonical form (for example, hex to `rgb(...)`), so parsed and rendered colors stay consistent. This can prevent the cursor from jumping during IME composition (for example when typing Korean, Japanese, or Chinese) if a color gets re-parsed into a different string representation while composing.
+
+This option is opt-in and disabled by default, since normalizing colors changes the format in which they're stored and rendered, which can be a breaking change if your application relies on the exact color string a user typed or pasted.
+
+Default: `null`
+
+Pass the built-in `normalizeColor` helper to normalize using the browser's own CSS color parser:
+
+```js
+import { Color, normalizeColor } from '@tiptap/extension-text-style'
+
+Color.configure({
+  colorNormalizer: normalizeColor,
+})
+```
+
+Or provide your own function, for example to normalize to hex instead of `rgb(...)`:
+
+```js
+Color.configure({
+  colorNormalizer: (color) => myColorLibrary.toHex(color),
+})
+```
+
 ## Commands
 
 ### setColor()


### PR DESCRIPTION
## Summary

- document the opt-in `colorNormalizer` option for Color
- document the same option for BackgroundColor
- include built-in and custom normalizer examples

## Related

- ueberdosis/tiptap#7899

## Validation

- Prettier formatting check passed

## AI usage

AI tools were used to assist with drafting and validating these documentation changes.