### PR TITLE
docs(hocuspocus): document onMaxAttemptsFailed

### DIFF
--- a/src/content/hocuspocus/provider/configuration.mdx
+++ b/src/content/hocuspocus/provider/configuration.mdx
@@ -37,6 +37,7 @@ meta:
 | `messageReconnectTimeout` | Closes the connection when after the configured messageReconnectTimeout no message was received.                                                                                    | `30000`           |
 | `delay`                   | The delay between each attempt in milliseconds. You can provide a factor to have the delay grow exponentially.                                                                      | `1000`            |
 | `initialDelay`            | The initialDelay is the amount of time to wait before making the first attempt. This option should typically be 0 since you typically want the first attempt to happen immediately. | `0`               |
+| `onMaxAttemptsFailed`     | Called with `{ error }` once every one of the `maxAttempts` reconnect attempts has failed and the provider stops retrying. Never fires with the default `maxAttempts: 0`, because the provider then retries forever. See [Reacting to failed reconnects](#reacting-to-failed-reconnects). | `() => null`      |
 
 
 ## Usage
@@ -60,3 +61,48 @@ const provider = new HocuspocusProvider({
 Within each window, buffered Yjs updates are merged with `Y.mergeUpdates` into a single message, and awareness collapses to the latest state of each changed client. The window is a fixed batch rather than a resetting debounce, so the added latency is capped at `flushDelay` even while the user keeps typing — keep it small (e.g. `500`) to avoid delaying what other clients see.
 
 You can force everything buffered for the current window to be sent immediately by calling `provider.flushPendingUpdates()`.
+
+## Reacting to failed reconnects
+
+With the default `maxAttempts: 0` the provider reconnects forever, so a connection failure is never final. If you set `maxAttempts` to a number, the provider gives up once those attempts are used up — and tells you so through `onMaxAttemptsFailed`, which is a good place to show a “you’re offline” state or a “try again” button:
+
+```js
+import { HocuspocusProvider } from '@hocuspocus/provider'
+
+const provider = new HocuspocusProvider({
+  url: 'ws://127.0.0.1:1234',
+  name: 'example-document',
+  maxAttempts: 5,
+  onMaxAttemptsFailed: ({ error }) => {
+    console.error('Could not connect to the server:', error)
+  },
+})
+```
+
+`error` is whatever made the last attempt fail: the WebSocket error, or — when the socket closed without ever emitting an error — an `Error` carrying the close code and reason.
+
+This is a `HocuspocusProviderWebsocket` event, and it is deliberately not forwarded to `HocuspocusProvider`, because a single socket can be shared by many documents. Passing `onMaxAttemptsFailed` to `HocuspocusProvider` works (the option is handed to the socket it creates for you), but binding a listener later has to happen on the socket:
+
+```js
+import { HocuspocusProvider, HocuspocusProviderWebsocket } from '@hocuspocus/provider'
+
+const socket = new HocuspocusProviderWebsocket({
+  url: 'ws://127.0.0.1:1234',
+  maxAttempts: 5,
+})
+
+socket.on('maxAttemptsFailed', ({ error }) => {
+  // …
+})
+
+const provider = new HocuspocusProvider({
+  websocketProvider: socket,
+  name: 'example-document',
+})
+```
+
+Giving up is not permanent. Call `connect()` on the websocket provider to start a fresh round of attempts, for example from a “try again” button:
+
+```js
+provider.configuration.websocketProvider.connect()
+```

--- a/src/content/hocuspocus/provider/events.mdx
+++ b/src/content/hocuspocus/provider/events.mdx
@@ -61,6 +61,10 @@ const provider = new HocuspocusProvider({
   onStateless: ({ payload }) => {
     // ...
     // the provider can also send a custom message to the server: provider.sendStateless('any string payload')
+  },
+  onMaxAttemptsFailed: ({ error }) => {
+    // Only relevant if you set `maxAttempts`. Handled by the underlying
+    // HocuspocusProviderWebsocket – see the section below.
   }
 });
 ```
@@ -112,3 +116,21 @@ provider.off("onMessage", onMessage);
 | awarenessUpdate      | When the awareness updates (see https://docs.yjs.dev/api/about-awareness) |
 | awarenessChange      | When the awareness changes (see https://docs.yjs.dev/api/about-awareness) |
 | stateless            | When the stateless message was received.                                  |
+
+## HocuspocusProviderWebsocket events
+
+The events above belong to the `HocuspocusProvider`, which represents a single document. The WebSocket connection underneath it — a `HocuspocusProviderWebsocket`, potentially shared by several documents — has one event of its own:
+
+| Name              | Description                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------------ |
+| maxAttemptsFailed | When all `maxAttempts` reconnect attempts have failed and the provider stops retrying.   |
+
+It is not forwarded to the document providers, so bind it on the socket:
+
+```js
+provider.configuration.websocketProvider.on("maxAttemptsFailed", ({ error }) => {
+  // …
+});
+```
+
+Passing `onMaxAttemptsFailed` to the `HocuspocusProvider` constructor works as well, as long as you let the provider create its own socket. See [Reacting to failed reconnects](/hocuspocus/provider/configuration#reacting-to-failed-reconnects).

--- a/src/content/hocuspocus/provider/react.mdx
+++ b/src/content/hocuspocus/provider/react.mdx
@@ -61,6 +61,36 @@ Manages the shared `HocuspocusProviderWebsocket` instance. Create it once near t
 
 The component handles React StrictMode double-mounts gracefully — the WebSocket is created once per mount cycle and only destroyed if it wasn't externally provided.
 
+Socket-level options such as `maxAttempts`, `messageReconnectTimeout` or `onMaxAttemptsFailed` are not props on this component. To use them, build the `HocuspocusProviderWebsocket` yourself and pass it as `websocketProvider`:
+
+```tsx
+import { useMemo } from 'react'
+import { HocuspocusProviderWebsocket } from '@hocuspocus/provider'
+import { HocuspocusProviderWebsocketComponent } from '@hocuspocus/provider-react'
+
+function App({ children }) {
+  const websocketProvider = useMemo(
+    () =>
+      new HocuspocusProviderWebsocket({
+        url: 'ws://127.0.0.1:1234',
+        maxAttempts: 5,
+        onMaxAttemptsFailed: ({ error }) => {
+          console.error('Could not connect to the server:', error)
+        },
+      }),
+    [],
+  )
+
+  return (
+    <HocuspocusProviderWebsocketComponent websocketProvider={websocketProvider}>
+      {children}
+    </HocuspocusProviderWebsocketComponent>
+  )
+}
+```
+
+When you provide the socket yourself, you are responsible for destroying it. See [Reacting to failed reconnects](/hocuspocus/provider/configuration#reacting-to-failed-reconnects).
+
 ### HocuspocusRoom
 
 Creates a document-specific `HocuspocusProvider` that attaches to the shared WebSocket. Must be rendered inside `HocuspocusProviderWebsocketComponent`.


### PR DESCRIPTION
Documents the `onMaxAttemptsFailed` option / `maxAttemptsFailed` event added to `@hocuspocus/provider` in ueberdosis/hocuspocus#1149.

### Changes

- **`provider/configuration.mdx`** — `onMaxAttemptsFailed` row in the `HocuspocusProviderWebsocket` settings table, plus a *Reacting to failed reconnects* section covering the payload, why the event lives on the socket rather than the document provider, and how to resume after giving up.
- **`provider/events.mdx`** — added to the constructor example and a new *HocuspocusProviderWebsocket events* section, since the existing event list only covers `HocuspocusProvider` events.
- **`provider/react.mdx`** — `HocuspocusProviderWebsocketComponent` only takes `url` / `websocketProvider`, so an example showing how to reach socket-level options by building the socket yourself.

### Notes

- Behaviour was verified against the code rather than paraphrased: passing `onMaxAttemptsFailed` to `HocuspocusProvider` **does** work (the config object is handed to the socket it creates), but `provider.on('maxAttemptsFailed', …)` does **not** — it is not among the events forwarded in `HocuspocusProvider.attach()`.
- ⚠️ **Do not merge before ueberdosis/hocuspocus#1149 is released.** The described `error` payload (an `Error` carrying the close code/reason when the socket closes without an error event) also depends on the follow-up commit on that PR.
- Prettier is not run on these files — every `provider/*.mdx` already fails `prettier --check` on `main`, so formatting them would bury the change in noise.