### PR TITLE
Document list numbering formats on bullet lists

### DIFF
--- a/.changeset/list-numbering-and-bullets.md
+++ b/.changeset/list-numbering-and-bullets.md
@@ -1,0 +1,5 @@
+---
+'tiptap-docs': minor
+---
+
+Document decorative bullets: a numbering format whose levels use `baseStyle: 'bullet'` draws a glyph ladder, and a `bulletList` selects it through the same `numberingFormat` attribute. Covers the bullet commands, `defaultBulletFormat`, `suffix`, `isLegalNumbering`, `linkedStyle`, and where the preview and Word disagree on nesting depth. The page is renamed to cover both kinds of list.

--- a/src/content/conversion/export/docx/ordered-list-numbering.mdx
+++ b/src/content/conversion/export/docx/ordered-list-numbering.mdx
@@ -249,8 +249,8 @@ ConvertKit's types use plain string literals so the package does not pull in `do
 | `textIndent`   | Word's per-level default | Distance from the page margin to the body text. Should be greater than `numberIndent`.                                                                                                                                                                                    |
 | `markerFont`   | None                     | Marker-only run formatting (see [`NumberingMarkerFont`](#numberingmarkerfont) below). Survives DOCX export and is reflected by `generateNumberingFormatCss` in the editor preview. On a `'bullet'` level, `font` is what a Word symbol-font bullet needs.                  |
 | `suffix`       | `'tab'`                  | Word's "Follow number with" (`w:suff`). A tab pads the marker out to `textIndent`; `'space'` draws one non-breaking space after the marker and `'nothing'` draws none, so the body text follows the marker directly. Honoured by the editor preview. |
-| `isLegalNumbering` | `false`              | Word's "Legal style numbering" (`w:isLgl`): every `%N` in `textTemplate` is drawn with arabic numerals whatever the level it points at counts in, so `Article IV.2` becomes `Article 4.2`. A `%N` pointing at a level that counts nothing still draws nothing. Honoured by the editor preview. |
-| `linkedStyle`  | None                     | Word's "Link level to style" (`w:pStyle`): applying that style in Word puts a paragraph at this level. Names a style id such as `'Heading1'`. Export only; the editor preview has no equivalent. |
+| `isLegalNumbering` | `false`              | Word's "Legal style numbering" (`w:isLgl`): a `%N` pointing at a roman or letter level is redrawn in arabic, so `Article IV.2` becomes `Article 4.2`. An arabic level keeps the form it counts in, so `decimalZero` stays zero-padded (`01.1`, not `1.1`), and a level that counts nothing still draws nothing. Honoured by the editor preview. |
+| `linkedStyle`  | None                     | Word's "Link level to style" (`w:pStyle`): paragraphs in that style number at this level. Names a style id such as `'Heading1'`. A format with a linked level is **one list for the whole document**, so its lists continue each other instead of restarting. Export only; the editor preview has no equivalent. |
 
 ## `NumberingMarkerFont`
 
@@ -385,7 +385,7 @@ Every format emits both `ul[data-numbering-format="…"]` and `ol[data-numbering
 
 - A matched id renders every level of that multilevel list (including all nested lists of the same kind) using the corresponding definition.
 - An unmatched id (typo, missing attribute, empty `numberingFormats`) keeps the default ladder for that list kind: plain `1. 2. 3.` for an ordered list, the built-in glyph ladder for a bullet list.
-- Sibling multilevel lists referencing the same format restart independently, each starting at its own `startAt`.
+- Sibling multilevel lists referencing the same format restart independently, each starting at its own `startAt`. A format with a `linkedStyle` on any level is the exception: it is one list for the whole document, so its lists continue each other.
 
 ## Known limitations
 

--- a/src/content/conversion/export/docx/ordered-list-numbering.mdx
+++ b/src/content/conversion/export/docx/ordered-list-numbering.mdx
@@ -151,7 +151,7 @@ editor.chain().focus().setOrderedListNumberingFormat('decimal-paren').run()
 editor.chain().focus().setOrderedListNumberingFormat(null).run()
 ```
 
-The command returns `false` when the selection isn't inside an ordered list, and also when a list of another kind stands between the selection and that ordered list, because such a list ends the ladder. Gate a toolbar button on `editor.can().setOrderedListNumberingFormat(null)` rather than `editor.isActive('orderedList')`: the two disagree in exactly that case, and only `can()` matches what the command will do.
+The command returns `false` when the selection isn't inside an ordered list, and also when a list of another kind stands between the selection and that ordered list, because such a list ends the ladder. To ask whether this command will reach a list, use `editor.can().setOrderedListNumberingFormat(null)` rather than `editor.isActive('orderedList')`: the two disagree in exactly that case, and only `can()` matches what the command will do.
 
 ### Starting a new list in a format
 
@@ -169,16 +169,26 @@ When the selection is already inside an ordered list the command toggles the lis
 
 Omitting the argument is not the same as passing `null`. Omit it and the new list takes the configured `defaultFormat`; pass `null` and it takes no format at all.
 
-Both commands answer `editor.can()` the same way their plain toggle does, so a toolbar button can be disabled on it.
+The two commands answer `editor.can()` about different things, so a toolbar needs both. `toggleOrderedListWithFormat` answers the same way its plain toggle does, which is `true` from an ordinary paragraph because it can create the list; disable a "start a list in this format" button on that. `setOrderedListNumberingFormat` answers whether a list is already there to change, which is `false` from that same paragraph. Use the setter's answer to pick which command to run, not to disable the button:
+
+```ts
+// One "apply this format" button, doing the right thing in both places.
+if (editor.can().setOrderedListNumberingFormat(null)) {
+  editor.chain().focus().setOrderedListNumberingFormat(id).run()
+} else {
+  editor.chain().focus().toggleOrderedListWithFormat(id).run()
+}
+```
 
 <Callout variant="warning" title="The toggle reaches past a list of another kind">
   A list of another kind ends the ladder for the **set** command but not for the **toggle**, which
   still sees a non-list position and takes its create branch. With the selection inside a `<ul>`
   nested in an `<ol>`, `toggleOrderedListWithFormat` converts that inner `<ul>` to an `<ol>` and
   then writes the format onto the enclosing `<ol>`, a list the user was not editing. With a
-  checklist there instead, it flattens the checklist and lifts its items into the enclosing `<ol>`.
-  Drive a toolbar from `editor.can().setOrderedListNumberingFormat(null)`, which reports `false` in
-  both positions, rather than from the toggle's own `can()`.
+  checklist there instead, it flattens the checklist and lifts its items into the enclosing `<ol>`,
+  losing the checkboxes. The toggle's own `can()` reports `true` in both positions, so it cannot
+  warn you, and the branch above reaches the toggle there because the setter reports `false`. A
+  toolbar that should leave a checklist alone has to test `editor.isActive('taskList')` itself.
 </Callout>
 
 ### Bullet lists
@@ -190,7 +200,7 @@ editor.chain().focus().setBulletListNumberingFormat('arrows').run()
 editor.chain().focus().toggleBulletListWithFormat('arrows').run()
 ```
 
-Everything above holds for the bullet pair, with `defaultBulletFormat` in place of `defaultFormat`. `setBulletListNumberingFormat` returns `false` in four positions: outside any list, inside an ordered list, inside a checklist, and inside a bullet list reached only by crossing one of those two. A task list is not a bullet list, so it ends the ladder the same way an ordered list does. Gate the button on `editor.can().setBulletListNumberingFormat(null)`, which is `false` in all four.
+Everything above holds for the bullet pair, with `defaultBulletFormat` in place of `defaultFormat`. `setBulletListNumberingFormat` returns `false` in four positions: outside any list, inside an ordered list, inside a checklist, and inside a bullet list reached only by crossing one of those two. A task list is not a bullet list, so it ends the ladder the same way an ordered list does. Branch on `editor.can().setBulletListNumberingFormat(null)`, which is `false` in all four, the same way the ordered pair does above.
 
 `toggleBulletListWithFormat` has the same reach as its ordered twin: from inside a checklist it converts the whole checklist into a plain bullet list, losing the checkboxes.
 
@@ -217,7 +227,7 @@ interface NumberingFormatDefinition {
 
 | Field    | Type                         | Description                                                                                                                            |
 | -------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`     | `string`                     | Unique within your `numberingFormats[]`. Serialized into the orderedList's `numberingFormat` attribute.                                |
+| `id`     | `string`                     | Unique within your `numberingFormats[]`. Serialized into the `numberingFormat` attribute of the outermost `orderedList` or `bulletList` that names it. |
 | `levels` | `NumberingLevelDefinition[]` | One entry per nesting depth. Must be non-empty. When a list nests deeper than the array, depth `N` reuses `levels[N % levels.length]`. |
 
 ## `NumberingLevelDefinition`

--- a/src/content/conversion/export/docx/ordered-list-numbering.mdx
+++ b/src/content/conversion/export/docx/ordered-list-numbering.mdx
@@ -1,14 +1,15 @@
 ---
-title: Customize ordered list numbering for DOCX export
+title: Customize list numbering and bullets for DOCX export
 tags:
   - type: start
   - type: beta
 meta:
-  title: Ordered list numbering formats | Tiptap Conversion
-  description: Define multilevel ordered list numbering formats that survive DOCX export, covering base style, marker template, alignment, indent, and font.
+  title: List numbering formats | Tiptap Conversion
+  description: Define multilevel numbering formats and decorative bullet ladders that survive DOCX export, covering base style, marker template, alignment, indent, and font.
   category: Conversion
 ---
 
+import { Callout } from '@/components/ui/Callout'
 import { CodeDemo } from '@/components/CodeDemo'
 import { Requirements, RequirementItem } from '@/components/Requirements'
 import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
@@ -26,7 +27,9 @@ import { EnterpriseCalloutAuto } from '@/components/EnterpriseCalloutAuto'
   </RequirementItem>
 </Requirements>
 
-`@tiptap-pro/extension-export-docx` accepts an optional registry of **numbering format definitions** (multilevel marker style, marker text, alignment, indent, and font) selected per-list via an attribute on the outermost `<ol>`. Lists with a matching id export with the corresponding definition; lists without one export as plain `1. 2. 3.`.
+`@tiptap-pro/extension-export-docx` accepts an optional registry of **numbering format definitions** (multilevel marker style, marker text, alignment, indent, and font) selected per-list via an attribute on the outermost `<ol>` or `<ul>`. Lists with a matching id export with the corresponding definition; lists without one keep the default ladder for their kind.
+
+A format whose levels use `baseStyle: 'bullet'` describes a glyph ladder instead of a counter, so the same registry also carries decorative bullets. See [Bullet ladders](#bullet-ladders).
 
 The feature is opt-in. Consumers who don't supply `numberingFormats` see no behavior change.
 
@@ -36,7 +39,7 @@ The feature is opt-in. Consumers who don't supply `numberingFormats` see no beha
 
 | Export                                                                         | Package                             | Purpose                                                                                                                                                                                                                                                                                                                                   |
 | ------------------------------------------------------------------------------ | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `OrderedListNumbering`                                                         | `@tiptap-pro/extension-convert-kit` | Tiptap extension that adds the `numberingFormat` attribute to `orderedList` and exposes the `setOrderedListNumberingFormat(id)` and `toggleOrderedListWithFormat(format?)` commands, and tracks the active format at the selection via `editor.storage.orderedListNumbering`. Registered by `ConvertKit` (opt in via `orderedListNumbering: true`, or an options object with `defaultFormat` / `formats`). Enforces outermost-only numbering on paste, JSON, collaborative sync, and programmatic edits. |
+| `OrderedListNumbering`                                                         | `@tiptap-pro/extension-convert-kit` | Tiptap extension that adds the `numberingFormat` attribute to `orderedList` and `bulletList` and exposes the `setOrderedListNumberingFormat(id)`, `toggleOrderedListWithFormat(format?)`, `setBulletListNumberingFormat(id)` and `toggleBulletListWithFormat(format?)` commands, and tracks the active format of each list kind at the selection via `editor.storage.orderedListNumbering`. Registered by `ConvertKit` (opt in via `orderedListNumbering: true`, or an options object with `defaultFormat` / `defaultBulletFormat` / `formats`). Enforces outermost-only numbering on paste, JSON, collaborative sync, and programmatic edits. |
 | `generateNumberingFormatCss(formats, options?)`                                | `@tiptap-pro/extension-convert-kit` | Pure, dependency-free function that returns CSS text for the editor preview: same registry, same visual result.                                                                                                                                                                                                                          |
 | `NumberingFormatDefinition`, `NumberingLevelDefinition`, `NumberingMarkerFont` | `@tiptap-pro/extension-convert-kit` | The data shape your registry follows. Structurally compatible with `ExportDocx`'s `numberingFormats` config.                                                                                                                                                                                                                              |
 | `ExportDocx.configure({ numberingFormats })`                                   | `@tiptap-pro/extension-export-docx` | Pass the registry to the exporter so the `.docx` carries the matching definitions.                                                                                                                                                                                                                                                        |
@@ -105,13 +108,24 @@ Prefer to manage the stylesheet yourself? Omit `formats` and inject the CSS from
 ConvertKit.configure({ orderedListNumbering: true })
 ```
 
-Pass an options object instead of `true` to configure two things:
+<Callout variant="warning" title="Bullet lists gain an attribute in stored JSON">
+  Turning this on registers `numberingFormat` on `bulletList` as well as `orderedList`, so
+  `editor.getJSON()` now writes `attrs: { numberingFormat: null }` on a bullet list that names no
+  format, where it wrote no `attrs` at all before. This is what an ordered list has always looked
+  like, and the rendered HTML does not change: a list with no format is still a bare `<ul>`. Stored
+  JSON, collaborative documents and snapshot tests that compare a bullet list byte for byte will
+  see the new key.
+</Callout>
+
+Pass an options object instead of `true` to configure three things:
 
 ```ts
 ConvertKit.configure({
   orderedListNumbering: {
     // The format id new ordered lists start with. Defaults to `null` (plain `1. 2. 3.`).
     defaultFormat: 'outline',
+    // The same, for new bullet lists.
+    defaultBulletFormat: 'arrows',
     // The same definitions you pass to ExportDocx. When provided, the
     // editor-preview CSS is generated from them and injected automatically,
     // so on-screen markers match the export with no extra wiring.
@@ -120,10 +134,11 @@ ConvertKit.configure({
 })
 ```
 
-| Option          | Default | Description                                                                                                                                                                                                                                                                                                                                              |
-| --------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `defaultFormat` | `null`  | The numbering format id applied to a newly created ordered list (the `numberingFormat` attribute default). Only the outermost list is formatted; nested lists stay clear.                                                                                                                                                                                |
-| `formats`       | `null`  | Numbering format definitions used to generate and inject the editor-preview CSS, the same array passed to `ExportDocx.configure({ numberingFormats })`. Editors configured with the same formats share one preview stylesheet, while editors with different formats get separate ones, so each always shows the correct markers; a shared stylesheet is removed only once the last editor using it is destroyed. |
+| Option                | Default | Description                                                                                                                                                                                                                                                                                                                                              |
+| --------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `defaultFormat`       | `null`  | The numbering format id applied to a newly created **ordered** list (the `numberingFormat` attribute default). Only the outermost list is formatted; nested ordered lists stay clear. |
+| `defaultBulletFormat` | `null`  | The same for a newly created **bullet** list. The two are separate, so neither default lands on the other kind of list. |
+| `formats`             | `null`  | Numbering format definitions used to generate and inject the editor-preview CSS, the same array passed to `ExportDocx.configure({ numberingFormats })`. Editors configured with the same formats share one preview stylesheet, while editors with different formats get separate ones, so each always shows the correct markers; a shared stylesheet is removed only once the last editor using it is destroyed. |
 
 Passing `formats` here is the equivalent of calling [`generateNumberingFormatCss`](#generatenumberingformatcssformats-options) and injecting the result yourself: choose whichever fits your setup.
 
@@ -136,7 +151,7 @@ editor.chain().focus().setOrderedListNumberingFormat('decimal-paren').run()
 editor.chain().focus().setOrderedListNumberingFormat(null).run()
 ```
 
-The command returns `false` when the selection isn't inside an ordered list.
+The command returns `false` when the selection isn't inside an ordered list, and also when a list of another kind stands between the selection and that ordered list, because such a list ends the ladder. Gate a toolbar button on `editor.can().setOrderedListNumberingFormat(null)` rather than `editor.isActive('orderedList')`: the two disagree in exactly that case, and only `can()` matches what the command will do.
 
 ### Starting a new list in a format
 
@@ -150,14 +165,46 @@ editor.chain().focus().toggleOrderedListWithFormat('outline').run()
 editor.chain().focus().toggleOrderedListWithFormat().run()
 ```
 
-When the selection is already inside an ordered list, the command toggles the list off, mirroring `toggleOrderedList`. Chaining `toggleOrderedList().setOrderedListNumberingFormat(format)` reaches the same end state; the single command is simply more convenient and also handles the toggle-off case.
+When the selection is already inside an ordered list the command toggles the list off, mirroring `toggleOrderedList`. Chaining `toggleOrderedList().setOrderedListNumberingFormat(format)` reaches the same end state; the single command is simply more convenient and also handles the toggle-off case.
+
+Omitting the argument is not the same as passing `null`. Omit it and the new list takes the configured `defaultFormat`; pass `null` and it takes no format at all.
+
+Both commands answer `editor.can()` the same way their plain toggle does, so a toolbar button can be disabled on it.
+
+<Callout variant="warning" title="The toggle reaches past a list of another kind">
+  A list of another kind ends the ladder for the **set** command but not for the **toggle**, which
+  still sees a non-list position and takes its create branch. With the selection inside a `<ul>`
+  nested in an `<ol>`, `toggleOrderedListWithFormat` converts that inner `<ul>` to an `<ol>` and
+  then writes the format onto the enclosing `<ol>`, a list the user was not editing. With a
+  checklist there instead, it flattens the checklist and lifts its items into the enclosing `<ol>`.
+  Drive a toolbar from `editor.can().setOrderedListNumberingFormat(null)`, which reports `false` in
+  both positions, rather than from the toggle's own `can()`.
+</Callout>
+
+### Bullet lists
+
+Bullet lists have the same pair, targeting the outermost `bulletList` ancestor:
+
+```ts
+editor.chain().focus().setBulletListNumberingFormat('arrows').run()
+editor.chain().focus().toggleBulletListWithFormat('arrows').run()
+```
+
+Everything above holds for the bullet pair, with `defaultBulletFormat` in place of `defaultFormat`. `setBulletListNumberingFormat` returns `false` in four positions: outside any list, inside an ordered list, inside a checklist, and inside a bullet list reached only by crossing one of those two. A task list is not a bullet list, so it ends the ladder the same way an ordered list does. Gate the button on `editor.can().setBulletListNumberingFormat(null)`, which is `false` in all four.
+
+`toggleBulletListWithFormat` has the same reach as its ordered twin: from inside a checklist it converts the whole checklist into a plain bullet list, losing the checkboxes.
+
+### Reading the active format
 
 To reflect the active format in a toolbar, read it from the extension's storage, which stays in sync as the selection and document change:
 
 ```ts
-const activeFormatId = editor.storage.orderedListNumbering.activeNumberingFormat
-// a format id, or `null` when the selection is not inside an ordered list
+const activeOrdered = editor.storage.orderedListNumbering.activeNumberingFormat
+const activeBullet = editor.storage.orderedListNumbering.activeBulletNumberingFormat
+// a format id, or `null` when the selection is not inside a list of that kind
 ```
+
+Each field answers what its own command would target, so only one is set at a time: inside a bullet list nested in an ordered one, the bullet field reports that list and the ordered field reads `null`.
 
 ## `NumberingFormatDefinition`
 
@@ -184,6 +231,9 @@ interface NumberingLevelDefinition {
   numberIndent?: number | string
   textIndent?: number | string
   markerFont?: NumberingMarkerFont
+  suffix?: 'tab' | 'space' | 'nothing'
+  isLegalNumbering?: boolean
+  linkedStyle?: string
 }
 ```
 
@@ -191,13 +241,16 @@ ConvertKit's types use plain string literals so the package does not pull in `do
 
 | Field          | Default                  | Description                                                                                                                                                                                                                                                               |
 | -------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `baseStyle`    | (required)               | The counter glyph, equivalent to the matching docx [`LevelFormat`](https://docx.js.org/api/enums/LevelFormat.html) value. The Latin/numeric styles (`'decimal'`, `'decimalZero'`, `'upperLetter'`, `'lowerLetter'`, `'upperRoman'`, `'lowerRoman'`, `'none'`) and many locale styles (e.g. `'hebrew1'`, `'thaiNumbers'`, `'hindiNumbers'`, `'japaneseCounting'`, `'koreanDigital'`, `'chineseCounting'`, `'ideographDigital'`) map to a matching CSS counter style so the preview renders their native glyph. Styles with no faithful CSS equivalent (e.g. `'chicago'`, `'ordinal'`, `'cardinalText'`), and any unrecognized string, fall back to `decimal` **in the editor preview only**; the exported `.docx` always carries the exact `LevelFormat` you set. |
-| `textTemplate` | (required)               | Marker text using Word's `<w:lvlText>` grammar (see below).                                                                                                                                                                                                               |
+| `baseStyle`    | (required)               | The counter glyph, or the literal `'bullet'` for a [bullet ladder](#bullet-ladders). Otherwise equivalent to the matching docx [`LevelFormat`](https://docx.js.org/api/enums/LevelFormat.html) value. The Latin/numeric styles (`'decimal'`, `'decimalZero'`, `'upperLetter'`, `'lowerLetter'`, `'upperRoman'`, `'lowerRoman'`, `'none'`) and many locale styles (e.g. `'hebrew1'`, `'thaiNumbers'`, `'hindiNumbers'`, `'japaneseCounting'`, `'koreanDigital'`, `'chineseCounting'`, `'ideographDigital'`) map to a matching CSS counter style so the preview renders their native glyph. Styles with no faithful CSS equivalent (e.g. `'chicago'`, `'ordinal'`, `'cardinalText'`), and any unrecognized string, fall back to `decimal` **in the editor preview only**; the exported `.docx` always carries the exact `LevelFormat` you set. |
+| `textTemplate` | (required)               | Marker text using Word's `<w:lvlText>` grammar (see below). On a `'bullet'` level it is the glyph itself.                                                                                                                                             |
 | `startAt`      | `1`                      | Initial counter value.                                                                                                                                                                                                                                                    |
-| `alignment`    | `'left'`                 | Marker text alignment within the number area.                                                                                                                                                                                                                             |
+| `alignment`    | `'left'`                 | Marker text alignment within the number area. A `suffix` of `'space'` or `'nothing'` shrinks that area to the marker itself, leaving nothing to align in.                                                                                                                  |
 | `numberIndent` | Word's per-level default | Distance from the page margin to the marker. Twips number or a docx-style measure string (`'0.63cm'`, `'0.25in'`, `'18pt'`).                                                                                                                                              |
 | `textIndent`   | Word's per-level default | Distance from the page margin to the body text. Should be greater than `numberIndent`.                                                                                                                                                                                    |
-| `markerFont`   | None                     | Marker-only run formatting (see [`NumberingMarkerFont`](#numberingmarkerfont) below). Survives DOCX export and is reflected by `generateNumberingFormatCss` in the editor preview.                                                                                        |
+| `markerFont`   | None                     | Marker-only run formatting (see [`NumberingMarkerFont`](#numberingmarkerfont) below). Survives DOCX export and is reflected by `generateNumberingFormatCss` in the editor preview. On a `'bullet'` level, `font` is what a Word symbol-font bullet needs.                  |
+| `suffix`       | `'tab'`                  | Word's "Follow number with" (`w:suff`). A tab pads the marker out to `textIndent`; `'space'` draws one non-breaking space after the marker and `'nothing'` draws none, so the body text follows the marker directly. Honoured by the editor preview. |
+| `isLegalNumbering` | `false`              | Word's "Legal style numbering" (`w:isLgl`): every `%N` in `textTemplate` is drawn with arabic numerals whatever the level it points at counts in, so `Article IV.2` becomes `Article 4.2`. A `%N` pointing at a level that counts nothing still draws nothing. Honoured by the editor preview. |
+| `linkedStyle`  | None                     | Word's "Link level to style" (`w:pStyle`): applying that style in Word puts a paragraph at this level. Names a style id such as `'Heading1'`. Export only; the editor preview has no equivalent. |
 
 ## `NumberingMarkerFont`
 
@@ -228,6 +281,7 @@ Mirrors the subset of docx [`IRunOptions`](https://docx.js.org/api/interfaces/IR
 - `%1` through `%9` reference the counter at the 1-indexed nesting depth. So `%1` is always "the counter at the outermost level", regardless of which level the `textTemplate` belongs to.
 - All other characters render literally.
 - Stray `%` followed by a non-digit (e.g. `"50%"`) is preserved.
+- A `%N` pointing at a level that counts nothing, a `'bullet'` or `'none'` level, draws nothing.
 
 To make each level display its own counter, use ascending `%N` per level. To make a level include parent counters (legal-style outlines), chain them: `'%1.%2.'` at level 1 renders `'1.1.'`.
 
@@ -241,11 +295,51 @@ To make each level display its own counter, use ascending `%N` per level. To mak
 | `'§ %1 —'` at level 0     | `§ 1 —`                    |
 | `'(%3)'` at level 2       | `(1)`                      |
 
-## Schema convention: outermost only
+## Bullet ladders
 
-The `numberingFormat` attribute belongs on the **outermost** `<ol>` only. One definition declares all nesting levels for the entire multilevel list. `OrderedListNumbering` enforces this on parse: pasted HTML with `data-numbering-format` on a nested `<ol>` has the attribute stripped.
+Word draws a bullet from the glyph in `w:lvlText`, so an arrow, diamond or star is something the document carries rather than something the reader's Word decides. A format whose levels use `baseStyle: 'bullet'` describes that ladder, and a `bulletList` selects it through the same `numberingFormat` attribute:
 
-All nesting levels under one outermost `<ol>` share a single counter scope, and sub-levels restart when the parent advances, exactly as Word does.
+```ts
+numberingFormats: [
+  {
+    id: 'arrows',
+    levels: [
+      { baseStyle: 'bullet', textTemplate: '➔' },
+      { baseStyle: 'bullet', textTemplate: '◆' },
+    ],
+  },
+]
+// { type: 'bulletList', attrs: { numberingFormat: 'arrows' }, content: [...] }
+```
+
+On a `'bullet'` level, `textTemplate` is the glyph itself and `markerFont.font` names the font to draw it in, which is what a Word symbol-font bullet needs. Everything else on the level works the same way it does for a counter, indents included. Only the exact value `bullet` marks a level this way; every other `baseStyle` stays a counter level.
+
+A bullet level counts nothing, so a `%N` pointing at one draws nothing. `'Item %1:'` on a bullet level renders `Item :`, in Word and in the preview alike. `'none'` behaves the same way, and `isLegalNumbering` does not change it: legal numbering redraws a counter in arabic, but it cannot give a level a counter it does not have.
+
+A format is not tied to a list kind. It applies to whichever list names it, the way a Word `numId` points at a definition whatever the list looks like, so a glyph ladder on an `<ol>` draws glyphs and a counter ladder on a `<ul>` counts. `generateNumberingFormatCss` selects the attribute on `ul` and `ol` alike, so the preview and the export agree either way.
+
+A list nested inside another of the same kind takes the outer list's ladder at its own depth, so one multilevel list keeps one definition.
+
+### Task lists
+
+A task list renders as a `ul`, but it is not a level of a bullet ladder. A checklist keeps its checkboxes, and a bullet list nested inside one keeps its own `numberingFormat`.
+
+A checklist also ends the chain, exactly as a list of the other kind does. The commands and the `active…` storage fields stop there, so a bullet list reached only through a checklist is outermost again and carries its own format.
+
+<Callout variant="info" title="Nesting depth is counted differently on each side">
+  The editor preview counts nesting only through lists of the **same kind**, while the export counts
+  **every** enclosing list. A list sitting under a checklist, or under a list of the other kind,
+  therefore draws its format's first level on screen and a deeper level in Word. Keep a multilevel
+  ladder in one kind of list to avoid the difference.
+</Callout>
+
+## Schema convention: outermost of its own kind
+
+The `numberingFormat` attribute belongs on the **outermost** list of each kind. One definition declares all nesting levels for that entire multilevel list. `OrderedListNumbering` enforces this on parse: pasted HTML with `data-numbering-format` on an `<ol>` nested in another `<ol>`, or on a `<ul>` nested in another `<ul>`, has the attribute stripped.
+
+A list of the other kind starts a ladder of its own, and it also **ends** the chain: a `<ul>` reached through an `<ol>` is outermost again, so it keeps a format of its own even when a further `<ul>` encloses the whole thing. The commands and the `active…` storage fields stop at that boundary too, so each targets the list the export and the preview actually draw.
+
+All nesting levels under one outermost list share a single counter scope, and sub-levels restart when the parent advances, exactly as Word does.
 
 ## Cycling rule
 
@@ -285,24 +379,25 @@ generateNumberingFormatCss(formats, {
 
 The generated CSS positions each list marker and its body text to match the absolute positions Word renders, including the stair-step indents at every nesting depth. If you need to override anything for theming (dark mode, RTL, font scaling), wrap the output in your own selector or scope and rely on the cascade.
 
+Every format emits both `ul[data-numbering-format="…"]` and `ol[data-numbering-format="…"]` rules, because a format applies to whichever list names it. Each chain then steps to the next depth with `> li >` through its own element (`ul:not([data-type="taskList"])` or `ol`), so a checklist keeps its checkboxes, and a ladder stops at a list of the other kind rather than reaching through it.
+
 ## Resolution rules
 
-- A matched id renders every level of that multilevel list (including all nested `<ol>`s) using the corresponding definition.
-- An unmatched id (typo, missing attribute, empty `numberingFormats`) renders as plain `1. 2. 3.` numbering.
+- A matched id renders every level of that multilevel list (including all nested lists of the same kind) using the corresponding definition.
+- An unmatched id (typo, missing attribute, empty `numberingFormats`) keeps the default ladder for that list kind: plain `1. 2. 3.` for an ordered list, the built-in glyph ladder for a bullet list.
 - Sibling multilevel lists referencing the same format restart independently, each starting at its own `startAt`.
 
 ## Known limitations
 
 Word features the exporter intentionally does not model:
 
-| Feature                                                                                                      | Workaround / scope                                                                    |
-| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
-| Forcing parent-counter refs to render as arabic regardless of base style (Word's "legal numbering" override) | Define a separate format with all-`DECIMAL` levels for the same visual output.        |
-| Per-level counter-restart customization                                                                      | Word's default behavior (sub-levels restart when the parent advances) is always used. |
-| Marker-text suffix (tab / space / nothing between marker and body)                                           | Always `tab` (Word's default).                                                        |
-| Continuing numbering across separate lists                                                                   | Each list starts at its `startAt` independently.                                      |
-| Per-item marker overrides                                                                                    | Use a separate list to start at a different counter value.                            |
-| DOCX → editor import                                                                                         | Handled separately by `@tiptap-pro/extension-import-docx`.                            |
+| Feature                                    | Workaround / scope                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------------------- |
+| Per-level counter-restart (Word's "restart list after level N", `w:lvlRestart`) | Word's default behavior (sub-levels restart when the parent advances) is always used. |
+| Picture bullets (`w:lvlPicBulletId`)       | Use a symbol font through `markerFont.font` instead.                                  |
+| Continuing numbering across separate lists | Each list starts at its `startAt` independently.                                      |
+| Per-item marker overrides                  | Use a separate list to start at a different counter value.                            |
+| DOCX → editor import                       | Handled separately by `@tiptap-pro/extension-import-docx`.                            |
 
 ## See also
 

--- a/src/content/conversion/import/docx/convertkit.mdx
+++ b/src/content/conversion/import/docx/convertkit.mdx
@@ -105,7 +105,7 @@ ConvertKit ships **30** extensions inside the single `@tiptap-pro/extension-conv
 
 Extensions marked with `*` are custom, DOCX-aware overrides of the Tiptap base. See the next section for what they add. Extensions marked with `†` are bundled but **off by default**: opt in via the configuration option of the same name (see [Configuration reference](#configuration-reference)).
 
-ConvertKit also exports the helpers and types that pair with `OrderedListNumbering` for editor-preview rendering: `generateNumberingFormatCss`, `GenerateNumberingFormatCssOptions`, `NumberingFormatDefinition`, `NumberingLevelDefinition`, `NumberingBaseStyle`, and `NumberingMarkerFont`. See [Ordered list numbering](/conversion/export/docx/ordered-list-numbering) for the end-to-end recipe.
+ConvertKit also exports the helpers and types that pair with `OrderedListNumbering` for editor-preview rendering: `generateNumberingFormatCss`, `GenerateNumberingFormatCssOptions`, `NumberingFormatDefinition`, `NumberingLevelDefinition`, `NumberingBaseStyle`, and `NumberingMarkerFont`. See [List numbering and bullets](/conversion/export/docx/ordered-list-numbering) for the end-to-end recipe.
 
 ### Attributes added on top of Tiptap base extensions
 
@@ -117,7 +117,7 @@ ConvertKit also exports the helpers and types that pair with `OrderedListNumberi
 | `Table`                     | `width`, `indent` (+ `cellMinWidth: 1` default, vs Tiptap's `25`)                                           | DOCX `w:tblW`, `w:tblInd`, `w:tblGrid`                                                                                |
 | `TableRow`                  | `height`, `heightRule` (`exact` / `atLeast`)                                                                | DOCX `w:trHeight` + `w:hRule`                                                                                         |
 | `TableCell` / `TableHeader` | `background`, `verticalAlign`, per-side border (`width` / `style` / `color` on top/bottom/left/right)       | DOCX `w:tcPr`                                                                                                         |
-| `OrderedListNumbering`†     | `numberingFormat`                                                                                           | `ExportDocx` numbering format registry. See [Ordered list numbering](/conversion/export/docx/ordered-list-numbering). |
+| `OrderedListNumbering`†     | `numberingFormat`, on `orderedList` and `bulletList`                                                        | `ExportDocx` numbering format registry, outermost list of each kind only. See [List numbering and bullets](/conversion/export/docx/ordered-list-numbering). |
 
 ### What the CSS reset normalises
 
@@ -197,7 +197,7 @@ ConvertKit.configure({
   orderedList: Partial<OrderedListOptions> | false,
   listItem: Partial<ListItemOptions> | false,
   listKeymap: Partial<ListKeymapOptions> | false,
-  orderedListNumbering: boolean | Partial<OrderedListNumberingOptions>, // default: false; opt in with `true`, or an options object (`defaultFormat`, `formats`)
+  orderedListNumbering: boolean | Partial<OrderedListNumberingOptions>, // default: false; opt in with `true`, or an options object (`defaultFormat`, `defaultBulletFormat`, `formats`)
   hardBreak: Partial<HardBreakOptions> | false,
   horizontalRule: Partial<HorizontalRuleOptions> | false,
   dropcursor: Partial<DropcursorOptions> | false,
@@ -213,6 +213,15 @@ ConvertKit.configure({
   table: Partial<ConvertTableKitOptions> | false,
 })
 ```
+
+<Callout variant="warning" title="Turning on `orderedListNumbering` changes bullet-list JSON">
+  The `numberingFormat` attribute is registered on `bulletList` as well as `orderedList`, so with
+  the option on, `editor.getJSON()` writes `attrs: { numberingFormat: null }` on a bullet list that
+  names no format, where it wrote no `attrs` at all before. This is what an ordered list has always
+  looked like, and the rendered HTML does not change: a list with no format is still a bare `<ul>`.
+  Stored JSON, collaborative documents and snapshot tests that compare a bullet list byte for byte
+  will see the new key.
+</Callout>
 
 ## Related
 

--- a/src/content/conversion/import/docx/rest-api.mdx
+++ b/src/content/conversion/import/docx/rest-api.mdx
@@ -297,7 +297,7 @@ Two more fields describe the document as a whole rather than its content.
 
 Both are omitted when the document carries nothing to report.
 
-Register `numberingFormats` with the editor so the lists keep their numbering, and pass them to the exporter so a round-trip preserves it. The [ordered list numbering](/conversion/export/docx/ordered-list-numbering) page covers the full cycle.
+Register `numberingFormats` with the editor so the lists keep their numbering, and pass them to the exporter so a round-trip preserves it. The [list numbering and bullets](/conversion/export/docx/ordered-list-numbering) page covers the full cycle.
 
 ### Applying the page layout
 

--- a/src/content/conversion/import/docx/rest-api.mdx
+++ b/src/content/conversion/import/docx/rest-api.mdx
@@ -293,7 +293,7 @@ Two more fields describe the document as a whole rather than its content.
 | Field              | Type     | Description                                                                                                                                                     |
 | ------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `pageLayout`       | `Object` | Page size, orientation and margins read from the document's section properties. Values are in twips. See [Applying the page layout](#applying-the-page-layout). |
-| `numberingFormats` | `Array`  | The numbering definitions behind the document's ordered lists. Each list node carries a `numberingFormat` attribute naming its entry here.                      |
+| `numberingFormats` | `Array`  | The numbering definitions behind the document's ordered and bullet lists. Each list node carries a `numberingFormat` attribute naming its entry here.           |
 
 Both are omitted when the document carries nothing to report.
 

--- a/src/content/conversion/sidebar.ts
+++ b/src/content/conversion/sidebar.ts
@@ -144,7 +144,7 @@ export const sidebarConfig: SidebarConfig = {
                   href: '/conversion/export/docx/fonts',
                 },
                 {
-                  title: 'Ordered list numbering',
+                  title: 'List numbering and bullets',
                   href: '/conversion/export/docx/ordered-list-numbering',
                 },
                 {


### PR DESCRIPTION
### What the page gains

A numbering format whose levels use `baseStyle: 'bullet'` draws a glyph ladder instead of a counter, and a bullet list selects it through the same `numberingFormat` attribute an ordered list already used. The page picks up a Bullet ladders section, a `'bullet'` entry in the `baseStyle` table, the `setBulletListNumberingFormat` and `toggleBulletListWithFormat` commands, the `defaultBulletFormat` option and the `activeBulletNumberingFormat` storage field.

`NumberingLevelDefinition` gains three settings from Word's own list templates: `suffix` (`w:suff`), `isLegalNumbering` (`w:isLgl`) and `linkedStyle` (`w:pStyle`). The first two leave the known-limitations table, which gains picture bullets and names `w:lvlRestart` for the counter-restart entry.